### PR TITLE
chore: add targets to build and clean provider locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ website/vendor
 
 # Keep windows files with windows line endings
 *.winfile eol=crlf
+
+# Generated binary
+terraform-provider-imagetest

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,6 +1,0 @@
-default: testacc
-
-# Run acceptance tests
-.PHONY: testacc
-testacc:
-	TF_ACC=1 go test ./... -v $(TESTARGS) -timeout 120m

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+default: testacc
+
+# Run acceptance tests
+.PHONY: testacc
+testacc:
+	TF_ACC=1 go test ./... -v $(TESTARGS) -timeout 120m
+
+terraform-provider-imagetest:
+	CGO_ENABLED=0 go build -ldflags "-s -w -X main.version=devel -X main.commit=$(shell git rev-parse --short HEAD)" .
+
+.PHONY: clean
+clean:
+	rm terraform-provider-imagetest


### PR DESCRIPTION
Add a few changes to the Makefile:
* Include a local build target (`terraform-provider-imagetest`).
* Rename the Makefile from `GNUmakefile` to `Makefile`.
* Include a cleanup target (`clean`).
* Add `terraform-provider-imagetest` to `.gitignore` to prevent accidental commits of generated binaries.