### PR TITLE
plumb through container config as `sandbox`

### DIFF
--- a/docs/resources/harness_container.md
+++ b/docs/resources/harness_container.md
@@ -23,7 +23,7 @@ A harness that runs steps in a sandbox container.
 ### Optional
 
 - `envs` (Map of String) Environment variables to set on the container.
-- `image` (String) The full image reference to use for the k3s container.
+- `image` (String) The full image reference to use for the container.
 - `mounts` (Attributes List) The list of mounts to create on the container. (see [below for nested schema](#nestedatt--mounts))
 - `networks` (Attributes Map) A map of existing networks to attach the container to. (see [below for nested schema](#nestedatt--networks))
 - `privileged` (Boolean)

--- a/docs/resources/harness_k3s.md
+++ b/docs/resources/harness_k3s.md
@@ -28,6 +28,7 @@ A harness that runs steps in a sandbox container networked to a running k3s clus
 - `image` (String) The full image reference to use for the k3s container.
 - `networks` (Attributes Map) A map of existing networks to attach the harness containers to. (see [below for nested schema](#nestedatt--networks))
 - `registries` (Attributes Map) A map of registries containing configuration for optional auth, tls, and mirror configuration. (see [below for nested schema](#nestedatt--registries))
+- `sandbox` (Attributes) A map of configuration for the sandbox container. (see [below for nested schema](#nestedatt--sandbox))
 
 ### Read-Only
 
@@ -85,3 +86,32 @@ Optional:
 - `ca_file` (String)
 - `cert_file` (String)
 - `key_file` (String)
+
+
+
+<a id="nestedatt--sandbox"></a>
+### Nested Schema for `sandbox`
+
+Optional:
+
+- `envs` (Map of String) Environment variables to set on the container.
+- `image` (String) The full image reference to use for the container.
+- `mounts` (Attributes List) The list of mounts to create on the container. (see [below for nested schema](#nestedatt--sandbox--mounts))
+- `networks` (Attributes Map) A map of existing networks to attach the container to. (see [below for nested schema](#nestedatt--sandbox--networks))
+- `privileged` (Boolean)
+
+<a id="nestedatt--sandbox--mounts"></a>
+### Nested Schema for `sandbox.mounts`
+
+Required:
+
+- `destination` (String) The absolute path on the container to mount the source directory.
+- `source` (String) The relative or absolute path on the host to the source directory to mount.
+
+
+<a id="nestedatt--sandbox--networks"></a>
+### Nested Schema for `sandbox.networks`
+
+Required:
+
+- `name` (String) The name of the existing network to attach the container to.

--- a/internal/harnesses/k3s/opts.go
+++ b/internal/harnesses/k3s/opts.go
@@ -3,6 +3,8 @@ package k3s
 import (
 	"fmt"
 
+	"github.com/chainguard-dev/terraform-provider-imagetest/internal/containers/provider"
+	"github.com/docker/docker/api/types/mount"
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
 )
@@ -16,6 +18,8 @@ type Opt struct {
 
 	Registries map[string]*RegistryOpt
 	Mirrors    map[string]*RegistryMirrorOpt
+
+	Sandbox provider.DockerRequest
 }
 
 type RegistryOpt struct {
@@ -119,6 +123,52 @@ func WithNetworks(networks ...string) Option {
 			opt.Networks = []string{}
 		}
 		opt.Networks = append(opt.Networks, networks...)
+
+		// also append to sandbox networks
+		if opt.Sandbox.Networks == nil {
+			opt.Sandbox.Networks = []string{}
+		}
+		opt.Sandbox.Networks = append(opt.Sandbox.Networks, networks...)
+		return nil
+	}
+}
+
+func WithSandboxImage(image string) Option {
+	return func(opt *Opt) error {
+		opt.Sandbox.Image = image
+		return nil
+	}
+}
+
+func WithSandboxMounts(mounts ...mount.Mount) Option {
+	return func(opt *Opt) error {
+		if opt.Sandbox.Mounts == nil {
+			opt.Sandbox.Mounts = []mount.Mount{}
+		}
+		opt.Sandbox.Mounts = append(opt.Sandbox.Mounts, mounts...)
+		return nil
+	}
+}
+
+func WithSandboxNetworks(networks ...string) Option {
+	return func(opt *Opt) error {
+		if opt.Sandbox.Networks == nil {
+			opt.Sandbox.Networks = []string{}
+		}
+		opt.Sandbox.Networks = append(opt.Sandbox.Networks, networks...)
+		return nil
+	}
+}
+
+func WithSandboxEnv(envs provider.Env) Option {
+	return func(opt *Opt) error {
+		if opt.Sandbox.Env == nil {
+			opt.Sandbox.Env = make(provider.Env)
+		}
+
+		for k, v := range envs {
+			opt.Sandbox.Env[k] = v
+		}
 		return nil
 	}
 }

--- a/internal/provider/harness_container_resource.go
+++ b/internal/provider/harness_container_resource.go
@@ -63,52 +63,9 @@ func (r *HarnessContainerResource) Schema(ctx context.Context, req resource.Sche
 	resp.Schema = schema.Schema{
 		MarkdownDescription: `A harness that runs steps in a sandbox container.`,
 
-		Attributes: addHarnessResourceSchemaAttributes(map[string]schema.Attribute{
-			"image": schema.StringAttribute{
-				Description: "The full image reference to use for the k3s container.",
-				Optional:    true,
-				Computed:    true,
-				Default:     stringdefault.StaticString("cgr.dev/chainguard/wolfi-base:latest"),
-			},
-			"privileged": schema.BoolAttribute{
-				Optional: true,
-				Computed: true,
-				Default:  booldefault.StaticBool(false),
-			},
-			"envs": schema.MapAttribute{
-				Description: "Environment variables to set on the container.",
-				Optional:    true,
-				ElementType: types.StringType,
-			},
-			"networks": schema.MapNestedAttribute{
-				Description: "A map of existing networks to attach the container to.",
-				Optional:    true,
-				NestedObject: schema.NestedAttributeObject{
-					Attributes: map[string]schema.Attribute{
-						"name": schema.StringAttribute{
-							Description: "The name of the existing network to attach the container to.",
-							Required:    true,
-						},
-					},
-				},
-			},
-			"mounts": schema.ListNestedAttribute{
-				Description: "The list of mounts to create on the container.",
-				Optional:    true,
-				NestedObject: schema.NestedAttributeObject{
-					Attributes: map[string]schema.Attribute{
-						"source": schema.StringAttribute{
-							Description: "The relative or absolute path on the host to the source directory to mount.",
-							Required:    true,
-						},
-						"destination": schema.StringAttribute{
-							Description: "The absolute path on the container to mount the source directory.",
-							Required:    true,
-						},
-					},
-				},
-			},
-		}),
+		Attributes: addHarnessResourceSchemaAttributes(
+			addContainerResourceSchemaAttributes(),
+		),
 	}
 }
 
@@ -254,4 +211,56 @@ func (r *HarnessContainerResource) Delete(ctx context.Context, req resource.Dele
 
 func (r *HarnessContainerResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}
+
+// addContainerResourceSchemaAttributes adds common container resource
+// attributes to the given map. this function is provided knowing how common it
+// is for other harnesses to require some sort of container configuration.
+func addContainerResourceSchemaAttributes() map[string]schema.Attribute {
+	return map[string]schema.Attribute{
+		"image": schema.StringAttribute{
+			Description: "The full image reference to use for the container.",
+			Optional:    true,
+			Computed:    true,
+			Default:     stringdefault.StaticString("cgr.dev/chainguard/wolfi-base:latest"),
+		},
+		"privileged": schema.BoolAttribute{
+			Optional: true,
+			Computed: true,
+			Default:  booldefault.StaticBool(false),
+		},
+		"envs": schema.MapAttribute{
+			Description: "Environment variables to set on the container.",
+			Optional:    true,
+			ElementType: types.StringType,
+		},
+		"networks": schema.MapNestedAttribute{
+			Description: "A map of existing networks to attach the container to.",
+			Optional:    true,
+			NestedObject: schema.NestedAttributeObject{
+				Attributes: map[string]schema.Attribute{
+					"name": schema.StringAttribute{
+						Description: "The name of the existing network to attach the container to.",
+						Required:    true,
+					},
+				},
+			},
+		},
+		"mounts": schema.ListNestedAttribute{
+			Description: "The list of mounts to create on the container.",
+			Optional:    true,
+			NestedObject: schema.NestedAttributeObject{
+				Attributes: map[string]schema.Attribute{
+					"source": schema.StringAttribute{
+						Description: "The relative or absolute path on the host to the source directory to mount.",
+						Required:    true,
+					},
+					"destination": schema.StringAttribute{
+						Description: "The absolute path on the container to mount the source directory.",
+						Required:    true,
+					},
+				},
+			},
+		},
+	}
 }


### PR DESCRIPTION
plumb through the re-usable bits of `harness_container` to other harnesses that also spin up containers.

this also hoists the re-usable bits of the `container` spec out into `addContainerResourceSchemaAttributes`