### PR TITLE
feat: add support for working directory per step

### DIFF
--- a/docs/resources/feature.md
+++ b/docs/resources/feature.md
@@ -57,11 +57,12 @@ Required:
 
 Required:
 
-- `cmd` (String)
+- `cmd` (String) The command or set of commands that should be run at this step
 
 Optional:
 
-- `name` (String)
+- `name` (String) An identifying name for this step
+- `workdir` (String) An optional working directory for the step to run in
 
 
 <a id="nestedatt--before"></a>
@@ -69,11 +70,12 @@ Optional:
 
 Required:
 
-- `cmd` (String)
+- `cmd` (String) The command or set of commands that should be run at this step
 
 Optional:
 
-- `name` (String)
+- `name` (String) An identifying name for this step
+- `workdir` (String) An optional working directory for the step to run in
 
 
 <a id="nestedatt--steps"></a>
@@ -81,11 +83,12 @@ Optional:
 
 Required:
 
-- `cmd` (String)
+- `cmd` (String) The command or set of commands that should be run at this step
 
 Optional:
 
-- `name` (String)
+- `name` (String) An identifying name for this step
+- `workdir` (String) An optional working directory for the step to run in
 
 
 <a id="nestedatt--timeouts"></a>

--- a/internal/containers/provider/docker.go
+++ b/internal/containers/provider/docker.go
@@ -151,12 +151,15 @@ func (p *DockerProvider) Teardown(ctx context.Context) error {
 }
 
 // Exec implements Provider.
-func (p *DockerProvider) Exec(ctx context.Context, command string) (io.Reader, error) {
-	resp, err := p.cli.ContainerExecCreate(ctx, p.id, types.ExecConfig{
-		Cmd:          []string{"/bin/sh", "-c", command},
+func (p *DockerProvider) Exec(ctx context.Context, config ExecConfig) (io.Reader, error) {
+	execConfig := types.ExecConfig{
+		Cmd:          []string{"/bin/sh", "-c", config.Command},
+		WorkingDir:   config.WorkingDir,
 		AttachStderr: true,
 		AttachStdout: true,
-	})
+	}
+
+	resp, err := p.cli.ContainerExecCreate(ctx, p.id, execConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/containers/provider/provider.go
+++ b/internal/containers/provider/provider.go
@@ -9,10 +9,18 @@ import (
 	"path/filepath"
 )
 
+type ExecConfig struct {
+	// The command to be executed in the provider
+	Command string
+
+	// The working directory to be used to execute the command
+	WorkingDir string
+}
+
 type Provider interface {
 	Start(ctx context.Context) error
 	Teardown(ctx context.Context) error
-	Exec(ctx context.Context, command string) (io.Reader, error)
+	Exec(ctx context.Context, config ExecConfig) (io.Reader, error)
 }
 
 type ContainerRequest struct {

--- a/internal/harnesses/container/container.go
+++ b/internal/harnesses/container/container.go
@@ -38,10 +38,13 @@ func (h *container) Destroy(ctx context.Context) error {
 }
 
 // StepFn implements types.Harness.
-func (h *container) StepFn(command string) types.StepFn {
+func (h *container) StepFn(config types.StepConfig) types.StepFn {
 	return func(ctx context.Context) (context.Context, error) {
-		log.Info(ctx, "stepping in container", "command", command)
-		r, err := h.provider.Exec(ctx, command)
+		log.Info(ctx, "stepping in container", "command", config.Command)
+		r, err := h.provider.Exec(ctx, provider.ExecConfig{
+			Command:    config.Command,
+			WorkingDir: config.WorkingDir,
+		})
 		if err != nil {
 			return ctx, fmt.Errorf("failed to execute command: %w", err)
 		}
@@ -50,7 +53,7 @@ func (h *container) StepFn(command string) types.StepFn {
 		if err != nil {
 			return ctx, err
 		}
-		log.Info(ctx, "finished stepping in container", "command", command, "out", string(out))
+		log.Info(ctx, "finished stepping in container", "command", config.Command, "out", string(out))
 
 		return ctx, nil
 	}

--- a/internal/harnesses/host/host.go
+++ b/internal/harnesses/host/host.go
@@ -28,9 +28,9 @@ func NewHost() types.Harness {
 }
 
 // StepFn implements types.Harn.
-func (h *host) StepFn(command string) types.StepFn {
+func (h *host) StepFn(config types.StepConfig) types.StepFn {
 	return func(ctx context.Context) (context.Context, error) {
-		if _, err := h.exec(ctx, []string{"sh", "-c", command}); err != nil {
+		if _, err := h.exec(ctx, []string{"sh", "-c", config.Command}); err != nil {
 			return ctx, fmt.Errorf("running step on host: %w", err)
 		}
 		return ctx, nil

--- a/internal/provider/harness_container_resource.go
+++ b/internal/provider/harness_container_resource.go
@@ -140,7 +140,7 @@ func (r *HarnessContainerResource) Create(ctx context.Context, req resource.Crea
 		Env:        map[string]string{},
 	}
 
-	mounts := []ContainerResourceMountModel{}
+	mounts := make([]ContainerResourceMountModel, 0)
 	if data.Mounts != nil {
 		mounts = data.Mounts
 	}

--- a/internal/provider/harness_k3s_resource_test.go
+++ b/internal/provider/harness_k3s_resource_test.go
@@ -38,3 +38,57 @@ resource "imagetest_feature" "test" {
 		},
 	})
 }
+
+func TestAccHarnessK3sResourceWithWorkingDirectory(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create testing
+			{
+				ExpectNonEmptyPlan: true,
+				Config: `
+data "imagetest_inventory" "this" {}
+
+resource "imagetest_harness_k3s" "test" {
+  name = "test"
+  inventory = data.imagetest_inventory.this
+}
+
+resource "imagetest_feature" "test" {
+  name = "Simple k3s based test"
+  description = "Test that we can spin up a k3s cluster and run some steps"
+  harness = imagetest_harness_k3s.test
+  steps = [
+    {
+      name = "Create /src dir"
+      cmd  = "mkdir -p /src"
+    },
+    {
+      name    = "Create simple test file"
+      cmd     = <<EOM
+cat <<EOF > testcm.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-config-map
+data:
+  config.yaml: |
+    test-key1: test-value1
+    test-key2: test-value2
+EOF
+EOM
+      workdir = "/src"
+    },
+    {
+      name    = "Access cluster"
+      cmd     = "kubectl apply -f testcm.yaml"
+      workdir = "/src"
+    },
+  ]
+}
+          `,
+			},
+		},
+	})
+}

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -9,6 +9,14 @@ type Environment interface {
 	Test(context.Context, Feature) error
 }
 
+type StepConfig struct {
+	// the command that the step should run
+	Command string
+
+	// the working directory where the step should run
+	WorkingDir string
+}
+
 type Harness interface {
 	// Setup returns the Step that creates the harness and signals the caller is
 	// using the harness.
@@ -25,7 +33,7 @@ type Harness interface {
 	Done() error
 
 	// StepFn returns a StepFn that executes the given command in the harness.
-	StepFn(command string) StepFn
+	StepFn(config StepConfig) StepFn
 }
 
 type Feature interface {


### PR DESCRIPTION
Add support to specify a working directory per step of the test. This plumbs the working directory through to the container runtime for the exec operation.