### PR TITLE
chore: add target to run go-generate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,3 +11,7 @@ terraform-provider-imagetest:
 .PHONY: clean
 clean:
 	rm terraform-provider-imagetest
+
+.PHONY: go-generate
+go-generate:
+	go generate -v ./...


### PR DESCRIPTION
Add a new target `go-generate` to script running `go generate -v ./...`