### PR TITLE
use kubectl image as default for k3s sandbox image

### DIFF
--- a/internal/provider/harness_container_resource.go
+++ b/internal/provider/harness_container_resource.go
@@ -64,7 +64,7 @@ func (r *HarnessContainerResource) Schema(ctx context.Context, req resource.Sche
 		MarkdownDescription: `A harness that runs steps in a sandbox container.`,
 
 		Attributes: addHarnessResourceSchemaAttributes(
-			addContainerResourceSchemaAttributes(),
+			addContainerResourceSchemaAttributes(map[string]schema.Attribute{}),
 		),
 	}
 }
@@ -216,8 +216,8 @@ func (r *HarnessContainerResource) ImportState(ctx context.Context, req resource
 // addContainerResourceSchemaAttributes adds common container resource
 // attributes to the given map. this function is provided knowing how common it
 // is for other harnesses to require some sort of container configuration.
-func addContainerResourceSchemaAttributes() map[string]schema.Attribute {
-	return map[string]schema.Attribute{
+func addContainerResourceSchemaAttributes(attrs map[string]schema.Attribute) map[string]schema.Attribute {
+	defaults := map[string]schema.Attribute{
 		"image": schema.StringAttribute{
 			Description: "The full image reference to use for the container.",
 			Optional:    true,
@@ -263,4 +263,10 @@ func addContainerResourceSchemaAttributes() map[string]schema.Attribute {
 			},
 		},
 	}
+
+	for k, v := range attrs {
+		defaults[k] = v
+	}
+
+	return defaults
 }

--- a/internal/provider/harness_k3s_resource.go
+++ b/internal/provider/harness_k3s_resource.go
@@ -174,7 +174,17 @@ func (r *HarnessK3sResource) Schema(ctx context.Context, req resource.SchemaRequ
 			"sandbox": schema.SingleNestedAttribute{
 				Description: "A map of configuration for the sandbox container.",
 				Optional:    true,
-				Attributes:  addContainerResourceSchemaAttributes(),
+				Attributes: addContainerResourceSchemaAttributes(
+					map[string]schema.Attribute{
+						// Override the default image to use one with kubectl instead
+						"image": schema.StringAttribute{
+							Description: "The full image reference to use for the container.",
+							Optional:    true,
+							Computed:    true,
+							Default:     stringdefault.StaticString("cgr.dev/chainguard/kubectl:latest-dev"),
+						},
+					},
+				),
 			},
 		}),
 	}


### PR DESCRIPTION
the plugin-framework doesn't really have a great way to check if something is defaulted, so just override the `image` key with a new default.

this is more verbose, but needs less conditional logic to handle so I think it's overall cleaner