### PR TITLE
label containers created with imagetest provider

### DIFF
--- a/internal/containers/provider/docker.go
+++ b/internal/containers/provider/docker.go
@@ -67,6 +67,9 @@ func (p *DockerProvider) Start(ctx context.Context) error {
 		Cmd:          p.req.Cmd,
 		AttachStdout: true,
 		AttachStderr: true,
+		Labels: map[string]string{
+			"imagetest": "true",
+		},
 	}, &container.HostConfig{
 		NetworkMode: container.NetworkMode(mode.ID),
 		Mounts:      p.req.Mounts,


### PR DESCRIPTION
even with proper context cancellation plumbing, it's far too easy to end up in a state with dangling containers.

this is a intermediary workaround that at least labels the containers, so they can be easily cleaned up by the user using something like:

```bash
docker rm -f $(docker ps -aq --filter "label=imagetest=true")
```