### PR TITLE
plumb through context cancellation to container execs

### DIFF
--- a/docs/resources/harness_k3s.md
+++ b/docs/resources/harness_k3s.md
@@ -29,6 +29,7 @@ A harness that runs steps in a sandbox container networked to a running k3s clus
 - `networks` (Attributes Map) A map of existing networks to attach the harness containers to. (see [below for nested schema](#nestedatt--networks))
 - `registries` (Attributes Map) A map of registries containing configuration for optional auth, tls, and mirror configuration. (see [below for nested schema](#nestedatt--registries))
 - `sandbox` (Attributes) A map of configuration for the sandbox container. (see [below for nested schema](#nestedatt--sandbox))
+- `timeouts` (Attributes) (see [below for nested schema](#nestedatt--timeouts))
 
 ### Read-Only
 
@@ -115,3 +116,12 @@ Required:
 Required:
 
 - `name` (String) The name of the existing network to attach the container to.
+
+
+
+<a id="nestedatt--timeouts"></a>
+### Nested Schema for `timeouts`
+
+Optional:
+
+- `create` (String) The maximum time to wait for the k3s harness to be created.

--- a/internal/provider/harness_k3s_resource_test.go
+++ b/internal/provider/harness_k3s_resource_test.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -86,6 +87,38 @@ EOM
       workdir = "/src"
     },
   ]
+}
+          `,
+			},
+		},
+	})
+}
+
+func TestAccHarnessK3sResourceTimeout(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create testing
+			{
+				ExpectNonEmptyPlan: true,
+				ExpectError:        regexp.MustCompile(".*timed out.*"),
+				Config: `
+data "imagetest_inventory" "this" {}
+
+resource "imagetest_harness_k3s" "test" {
+  name = "test"
+  inventory = data.imagetest_inventory.this
+  timeouts = {
+    create = "1s"
+  }
+}
+
+resource "imagetest_feature" "test" {
+  name = "Dummy"
+  description = "Should never get here"
+  harness = imagetest_harness_k3s.test
+  steps = []
 }
           `,
 			},


### PR DESCRIPTION
the way the docker provider works, the bulk of the exec action happens in the `stdcopy.StdCopy()` routine, which doesn't take a context, and doesn't respect context cancellations.

this wires up the appropriate routines/channels to listen for any context cancellations from the callers and immediately exit the `Exec()`. this means the callers (like k3s' startup probe) can be ignorant on timeouts. this simplifies commands like startup checks.

this is also a fix for the previous k3s startup checks, which could potentially start waiting before the apiserver was ready, resulting in an error. the new startup check slurps the error and simplify waits indefinitely for the pods to be ready, and gets cancelled by the parent if the timeout limit is hit