### PR TITLE
feat: support entrypoint/command in harness and feature

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ default: testacc
 testacc:
 	TF_ACC=1 go test ./... -v $(TESTARGS) -timeout 120m
 
-terraform-provider-imagetest:
+terraform-provider-imagetest: testacc
 	CGO_ENABLED=0 go build -ldflags "-s -w -X main.version=devel -X main.commit=$(shell git rev-parse --short HEAD)" .
 
 .PHONY: clean

--- a/docs/resources/harness_container.md
+++ b/docs/resources/harness_container.md
@@ -22,11 +22,14 @@ A harness that runs steps in a sandbox container.
 
 ### Optional
 
+- `command` (List of String) An optional command for the harness
+- `entrypoint` (List of String) An optional entrypoint for the harness
 - `envs` (Map of String) Environment variables to set on the container.
 - `image` (String) The full image reference to use for the container.
 - `mounts` (Attributes List) The list of mounts to create on the container. (see [below for nested schema](#nestedatt--mounts))
 - `networks` (Attributes Map) A map of existing networks to attach the container to. (see [below for nested schema](#nestedatt--networks))
 - `privileged` (Boolean)
+- `workdir` (String) The default working directory for the harness container
 
 ### Read-Only
 

--- a/docs/resources/harness_k3s.md
+++ b/docs/resources/harness_k3s.md
@@ -95,11 +95,14 @@ Optional:
 
 Optional:
 
+- `command` (List of String) An optional command for the harness
+- `entrypoint` (List of String) An optional entrypoint for the harness
 - `envs` (Map of String) Environment variables to set on the container.
 - `image` (String) The full image reference to use for the container.
 - `mounts` (Attributes List) The list of mounts to create on the container. (see [below for nested schema](#nestedatt--sandbox--mounts))
 - `networks` (Attributes Map) A map of existing networks to attach the container to. (see [below for nested schema](#nestedatt--sandbox--networks))
 - `privileged` (Boolean)
+- `workdir` (String) The default working directory for the harness container
 
 <a id="nestedatt--sandbox--mounts"></a>
 ### Nested Schema for `sandbox.mounts`

--- a/internal/containers/provider/docker.go
+++ b/internal/containers/provider/docker.go
@@ -149,6 +149,7 @@ func (p *DockerProvider) Start(ctx context.Context) error {
 		Env:          p.req.Env.ToSlice(),
 		Entrypoint:   p.req.Entrypoint,
 		Cmd:          p.req.Cmd,
+		WorkingDir:   p.req.Workdir,
 		AttachStdout: true,
 		AttachStderr: true,
 		Labels:       p.labels,

--- a/internal/containers/provider/provider.go
+++ b/internal/containers/provider/provider.go
@@ -13,10 +13,10 @@ import (
 )
 
 type ExecConfig struct {
-	// The command to be executed in the provider
+	// The command to be executed in the provider.
 	Command string
 
-	// The working directory to be used to execute the command
+	// The working directory to be used to execute the command.
 	WorkingDir string
 }
 
@@ -29,6 +29,8 @@ type Provider interface {
 type ContainerRequest struct {
 	Ref        name.Reference
 	Entrypoint []string
+	Command    []string
+	Workdir    string
 	User       string // uid:gid
 	Env        Env
 	Cmd        []string

--- a/internal/harnesses/container/container.go
+++ b/internal/harnesses/container/container.go
@@ -91,7 +91,7 @@ func New(name string, cli *provider.DockerClient, cfg Config) (types.Harness, er
 		})
 	}
 
-	if cfg.Command == nil || len(cfg.Command) == 0 {
+	if len(cfg.Command) == 0 {
 		cfg.Command = []string{"tail -f /dev/null"}
 	}
 

--- a/internal/provider/harness_container_resource_test.go
+++ b/internal/provider/harness_container_resource_test.go
@@ -124,3 +124,118 @@ resource "imagetest_feature" "test" {
 		},
 	})
 }
+
+func TestAccHarnessContainerResourceProviderWithEntrypoint(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ExpectNonEmptyPlan: true,
+				Config: `
+data "imagetest_inventory" "this" {}
+
+resource "imagetest_harness_container" "test" {
+  name = "test"
+  inventory = data.imagetest_inventory.this
+  entrypoint = ["/bin/sh", "-c"]
+  command = ["tail -f /dev/null"]
+}
+
+resource "imagetest_feature" "test" {
+  name = "Simple container based test"
+  description = "Test that we can spin up a container and run some steps with a working directory"
+  harness = imagetest_harness_container.test
+  steps = [
+    {
+      workdir = "/tmp"
+      name = "Echo"
+      cmd = "echo test >> .testfile"
+    },
+    {
+      workdir = "/tmp"
+      name = "Cat"
+      cmd = "cat .testfile"
+    }
+  ]
+}
+        `,
+				Check: resource.ComposeAggregateTestCheckFunc(),
+			},
+		},
+	})
+}
+
+func TestAccHarnessContainerResourceProviderWithCommand(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ExpectNonEmptyPlan: true,
+				Config: `
+data "imagetest_inventory" "this" {}
+
+resource "imagetest_harness_container" "test" {
+  name = "test"
+  inventory = data.imagetest_inventory.this
+  entrypoint = ["/bin/sh", "-c", "tail -f /dev/null"]
+  command = [""]
+}
+
+resource "imagetest_feature" "test" {
+  name = "Simple container based test"
+  description = "Test that we can spin up a container and run some steps with a working directory"
+  harness = imagetest_harness_container.test
+  steps = [
+    {
+      workdir = "/tmp"
+      name = "Echo"
+      cmd = "echo test >> .testfile"
+    },
+    {
+      workdir = "/tmp"
+      name = "Cat"
+      cmd = "cat .testfile"
+    }
+  ]
+}
+        `,
+				Check: resource.ComposeAggregateTestCheckFunc(),
+			},
+		},
+	})
+}
+
+func TestAccHarnessContainerResourceProviderWithWorkdir(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ExpectNonEmptyPlan: true,
+				Config: `
+data "imagetest_inventory" "this" {}
+
+resource "imagetest_harness_container" "test" {
+  name = "test"
+  inventory = data.imagetest_inventory.this
+  workdir = "/tmp"
+}
+
+resource "imagetest_feature" "test" {
+  name = "Simple container based test"
+  description = "Test that we can spin up a container and run some steps with a working directory"
+  harness = imagetest_harness_container.test
+  steps = [
+    {
+      cmd = "[[ \"/tmp\" == $(pwd) ]]"
+    },
+  ]
+}
+        `,
+				Check: resource.ComposeAggregateTestCheckFunc(),
+			},
+		},
+	})
+}


### PR DESCRIPTION
Add support to specifying a custom entrypoint and command in both harness and feature.