### PR TITLE
Oom score adj

### DIFF
--- a/internal/containers/provider/docker.go
+++ b/internal/containers/provider/docker.go
@@ -77,6 +77,9 @@ func (p *DockerProvider) Start(ctx context.Context) error {
 		RestartPolicy: container.RestartPolicy{
 			Name: "no",
 		},
+		// Hide from the OOM killer. This is a default value that's adopted by
+		// similar kubernetes in docker tools (k3d, kind, etc...).
+		OomScoreAdj: -999,
 	}, nil, nil, p.name)
 	if err != nil {
 		return fmt.Errorf("creating container: %w", err)

--- a/internal/containers/provider/docker.go
+++ b/internal/containers/provider/docker.go
@@ -77,8 +77,9 @@ func (p *DockerProvider) Start(ctx context.Context) error {
 		RestartPolicy: container.RestartPolicy{
 			Name: "no",
 		},
-		// Hide from the OOM killer. This is a default value that's adopted by
-		// similar kubernetes in docker tools (k3d, kind, etc...).
+		// Use a low OOM score to prevent the kernel's OOM killer from needlessly
+		// killing this container. This value is adopted from other kubernetes in
+		// docker tools such as kind and k3d.
 		OomScoreAdj: -999,
 	}, nil, nil, p.name)
 	if err != nil {


### PR DESCRIPTION
This adjusts the `oom_score_adj` for **all** containers, and is adopted from `kind`.

In the future a better approach might be to hard cap the containers to a certain memory limit and toggle `--oom-kill-disable`, but this approach seems like a decent stopgap until we have more usage data about how much each cluster needs.