### PR TITLE
plumb through an IMAGETEST_SKIP_HARNESS runtime env for skipping harness teardowns

### DIFF
--- a/internal/provider/feature_resource.go
+++ b/internal/provider/feature_resource.go
@@ -264,6 +264,11 @@ func (r *FeatureResource) Create(ctx context.Context, req resource.CreateRequest
 			}
 
 			// Destroy the harness...
+			if r.store.SkipTeardown() {
+				resp.Diagnostics.AddWarning(fmt.Sprintf("skipping harness [%s] teardown because IMAGETEST_SKIP_TEARDOWN is set", data.Harness.Id.ValueString()), "harness must be removed manually")
+				return
+			}
+
 			if err := harness.Destroy(ctx); err != nil {
 				resp.Diagnostics.AddError("failed to destroy harness", err.Error())
 				return

--- a/internal/provider/store.go
+++ b/internal/provider/store.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha256"
 	"log/slog"
 	"math/big"
+	"os"
 	"sync"
 
 	"github.com/chainguard-dev/terraform-provider-imagetest/internal/inventory"
@@ -64,6 +65,13 @@ func (s *ProviderStore) Encode(components ...string) (string, error) {
 func (s *ProviderStore) Inventory(data InventoryDataSourceModel) inventory.Inventory {
 	// TODO: More backends?
 	return inventory.NewFile(data.Seed.ValueString())
+}
+
+// SkipTeardown returns true if the IMAGETEST_SKIP_TEARDOWN environment
+// variable is declared.
+func (s *ProviderStore) SkipTeardown() bool {
+	v := os.Getenv("IMAGETEST_SKIP_TEARDOWN")
+	return v != ""
 }
 
 func newSmap[K comparable, V any]() *smap[K, V] {


### PR DESCRIPTION
example usage:

```
IMAGETEST_SKIP_TEARDOWN=1 TF_LOG=info terraform apply

...

2024-02-02T12:07:23.381-0500 [WARN]  provider.terraform-provider-imagetest: Response contains warning diagnostic: diagnostic_detail="harness must be removed manually" tf_proto_version=6.4 tf_provider_addr=registry.terraform.io/chainguard-dev/terraform-provider-imagetest tf_resource_type=imagetest_feature @caller=/Users/wolf/go/pkg/mod/github.com/hashicorp/terraform-plugin-go@v0.21.0/tfprotov6/internal/diag/diagnostics.go:64 @module=sdk.proto diagnostic_severity=WARNING tf_req_id=a8071888-a832-09ac-88b6-c1103e52616e tf_rpc=ApplyResourceChange diagnostic_summary="skipping harness [foo-4r4nf] teardown because IMAGETEST_SKIP_TEARDOWN is set" timestamp=2024-02-02T12:07:23.379-0500
╷
│ Warning: skipping harness [foo-4r4nf] teardown because IMAGETEST_SKIP_TEARDOWN is set
│
│   with imagetest_feature.foo,
│   on main.tf line 28, in resource "imagetest_feature" "foo":
│   28: resource "imagetest_feature" "foo" {
│
│ harness must be removed manually
╵
```