### PR TITLE
use an api check for k3s startup instead of system pod check

### DIFF
--- a/internal/harnesses/k3s/k3s.go
+++ b/internal/harnesses/k3s/k3s.go
@@ -177,10 +177,10 @@ func (h *k3s) Setup() types.StepFn {
 			if _, err := h.service.Exec(ctx, provider.ExecConfig{
 				Command: `
 while true; do
-  if k3s kubectl wait --for condition=ready pods --all -n kube-system; then
+  if k3s kubectl cluster-info; then
     break
   fi
-  sleep 2
+  sleep 0.5
 done
       `,
 			}); err != nil {

--- a/internal/provider/harness_k3s_resource_test.go
+++ b/internal/provider/harness_k3s_resource_test.go
@@ -110,7 +110,7 @@ resource "imagetest_harness_k3s" "test" {
   name = "test"
   inventory = data.imagetest_inventory.this
   timeouts = {
-    create = "5s"
+    create = "2s"
   }
 }
 


### PR DESCRIPTION
we don't actually need to wait for all the system pods to be ready to start using the cluster, so this just waits for the apiserver to be ready to receive requests.

completely unscientific wall clock time on my local machine:

before:

```
imagetest_harness_k3s.foo: Creating...
imagetest_harness_k3s.foo: Still creating... [10s elapsed]
imagetest_harness_k3s.foo: Still creating... [20s elapsed]
imagetest_harness_k3s.foo: Creation complete after 22s [id=foo-62upv]
```

after:

```
imagetest_harness_k3s.foo: Creating...
imagetest_harness_k3s.foo: Creation complete after 3s [id=foo-4ki9u]
```