### PR TITLE
plumb through k3s harness config options

### DIFF
--- a/internal/harnesses/k3s/opts.go
+++ b/internal/harnesses/k3s/opts.go
@@ -187,3 +187,24 @@ func WithSandboxResources(req provider.ContainerResourcesRequest) Option {
 		return nil
 	}
 }
+
+func WithCniDisabled(disabled bool) Option {
+	return func(opt *Opt) error {
+		opt.Cni = !disabled
+		return nil
+	}
+}
+
+func WithTraefikDisabled(disabled bool) Option {
+	return func(opt *Opt) error {
+		opt.Traefik = !disabled
+		return nil
+	}
+}
+
+func WithMetricsServerDisabled(disabled bool) Option {
+	return func(opt *Opt) error {
+		opt.MetricsServer = !disabled
+		return nil
+	}
+}

--- a/internal/provider/harness_k3s_resource.go
+++ b/internal/provider/harness_k3s_resource.go
@@ -230,6 +230,9 @@ func (r *HarnessK3sResource) Create(ctx context.Context, req resource.CreateRequ
 
 	kopts := []k3s.Option{
 		k3s.WithImage(data.Image.ValueString()),
+		k3s.WithCniDisabled(data.DisableCni.ValueBool()),
+		k3s.WithTraefikDisabled(data.DisableTraefik.ValueBool()),
+		k3s.WithMetricsServerDisabled(data.DisableMetricsServer.ValueBool()),
 	}
 
 	if !data.Sandbox.IsNull() {


### PR DESCRIPTION
these options were handled in the config struct, but not actually plumbed through from terraform 😓 