### PR TITLE
use a single docker client for all resources

### DIFF
--- a/internal/containers/provider/docker.go
+++ b/internal/containers/provider/docker.go
@@ -43,15 +43,8 @@ type DockerNetworkRequest struct {
 	Name string
 }
 
-func NewDocker(name string, req DockerRequest) (*DockerProvider, error) {
-	cli, err := client.NewClientWithOpts(
-		client.WithAPIVersionNegotiation(),
-		client.WithVersionFromEnv(),
-	)
-	if err != nil {
-		return nil, err
-	}
-
+// NewDocker creates a new DockerProvider with the given client.
+func NewDocker(name string, cli *client.Client, req DockerRequest) (*DockerProvider, error) {
 	return &DockerProvider{
 		name: name,
 		req:  req,

--- a/internal/harnesses/container/container.go
+++ b/internal/harnesses/container/container.go
@@ -10,6 +10,7 @@ import (
 	"github.com/chainguard-dev/terraform-provider-imagetest/internal/log"
 	"github.com/chainguard-dev/terraform-provider-imagetest/internal/types"
 	"github.com/docker/docker/api/types/mount"
+	"github.com/docker/docker/client"
 	"github.com/google/go-containerregistry/pkg/name"
 	"k8s.io/apimachinery/pkg/api/resource"
 )
@@ -76,7 +77,7 @@ type ConfigMount struct {
 	Destination string
 }
 
-func New(_ context.Context, name string, cfg Config) (types.Harness, error) {
+func New(name string, cli *client.Client, cfg Config) (types.Harness, error) {
 	// TODO: Support more providers
 
 	mounts := make([]mount.Mount, 0, len(cfg.Mounts))
@@ -88,7 +89,7 @@ func New(_ context.Context, name string, cfg Config) (types.Harness, error) {
 		})
 	}
 
-	p, err := provider.NewDocker(name, provider.DockerRequest{
+	p, err := provider.NewDocker(name, cli, provider.DockerRequest{
 		ContainerRequest: provider.ContainerRequest{
 			Ref:        cfg.Ref,
 			Entrypoint: []string{"/bin/sh", "-c"},

--- a/internal/harnesses/k3s/k3s.go
+++ b/internal/harnesses/k3s/k3s.go
@@ -17,6 +17,7 @@ import (
 	"github.com/chainguard-dev/terraform-provider-imagetest/internal/log"
 	"github.com/chainguard-dev/terraform-provider-imagetest/internal/types"
 	"github.com/docker/docker/api/types/mount"
+	"github.com/docker/docker/client"
 )
 
 const (
@@ -38,7 +39,7 @@ type k3s struct {
 	sandbox provider.Provider
 }
 
-func New(id string, opts ...Option) (types.Harness, error) {
+func New(id string, cli *client.Client, opts ...Option) (types.Harness, error) {
 	opt := &Opt{
 		ImageRef:      name.MustParseReference(K3sImageTag),
 		Cni:           true,
@@ -98,7 +99,7 @@ func New(id string, opts ...Option) (types.Harness, error) {
 		return nil, fmt.Errorf("creating k3s registries config: %w", err)
 	}
 
-	service, err := provider.NewDocker(id, provider.DockerRequest{
+	service, err := provider.NewDocker(id, cli, provider.DockerRequest{
 		ContainerRequest: provider.ContainerRequest{
 			Ref:        opt.ImageRef,
 			Cmd:        []string{"server"},
@@ -138,7 +139,7 @@ func New(id string, opts ...Option) (types.Harness, error) {
 		return nil, err
 	}
 
-	sandbox, err := provider.NewDocker(k3s.id+"-sandbox", opt.Sandbox)
+	sandbox, err := provider.NewDocker(k3s.id+"-sandbox", cli, opt.Sandbox)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/provider/harness_container_resource.go
+++ b/internal/provider/harness_container_resource.go
@@ -158,7 +158,7 @@ func (r *HarnessContainerResource) Create(ctx context.Context, req resource.Crea
 		cfg.Env[k] = v
 	}
 
-	harness, err := container.New(ctx, data.Id.ValueString(), cfg)
+	harness, err := container.New(data.Id.ValueString(), r.store.cli, cfg)
 	if err != nil {
 		resp.Diagnostics.AddError("invalid provider data", "...")
 		return

--- a/internal/provider/harness_k3s_resource.go
+++ b/internal/provider/harness_k3s_resource.go
@@ -328,7 +328,7 @@ func (r *HarnessK3sResource) Create(ctx context.Context, req resource.CreateRequ
 
 	kopts = append(kopts, k3s.WithNetworks(networks...))
 
-	harness, err := k3s.New(data.Id.ValueString(), kopts...)
+	harness, err := k3s.New(data.Id.ValueString(), r.store.cli, kopts...)
 	if err != nil {
 		resp.Diagnostics.AddError("failed to initialize k3s harness", err.Error())
 		return

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 
+	"github.com/docker/docker/client"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/provider"
 	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
@@ -195,6 +196,16 @@ func (p *ImageTestProvider) Configure(ctx context.Context, req provider.Configur
 		return
 	}
 	p.store.labels = labels
+
+	cli, err := client.NewClientWithOpts(
+		client.WithAPIVersionNegotiation(),
+		client.WithVersionFromEnv(),
+	)
+	if err != nil {
+		resp.Diagnostics.AddError("failed to create docker client", err.Error())
+		return
+	}
+	p.store.cli = cli
 
 	// Store any "global" provider configuration in the store
 	p.store.providerResourceData = data

--- a/internal/provider/store.go
+++ b/internal/provider/store.go
@@ -10,6 +10,7 @@ import (
 	"github.com/chainguard-dev/terraform-provider-imagetest/internal/inventory"
 	"github.com/chainguard-dev/terraform-provider-imagetest/internal/log"
 	"github.com/chainguard-dev/terraform-provider-imagetest/internal/types"
+	"github.com/docker/docker/client"
 	slogmulti "github.com/samber/slog-multi"
 )
 
@@ -24,6 +25,10 @@ type ProviderStore struct {
 	// TODO: there's probably a way to do this without passing around the whole
 	// model
 	providerResourceData ImageTestProviderModel
+
+	// cli is the Docker client. it is initialized once during the providers
+	// Configure() stage and reused for any resource that requires it.
+	cli *client.Client
 }
 
 func NewProviderStore() *ProviderStore {


### PR DESCRIPTION
while the client itself is concurrency safe, the way it was being used (new client per resource) was not.

this hoists the docker client into the provider level, and plumbs it through to all the dependent resources.