### PR TITLE
partially wrap docker client with concurrency safe DockerClient

### DIFF
--- a/internal/harnesses/container/container.go
+++ b/internal/harnesses/container/container.go
@@ -10,7 +10,6 @@ import (
 	"github.com/chainguard-dev/terraform-provider-imagetest/internal/log"
 	"github.com/chainguard-dev/terraform-provider-imagetest/internal/types"
 	"github.com/docker/docker/api/types/mount"
-	"github.com/docker/docker/client"
 	"github.com/google/go-containerregistry/pkg/name"
 	"k8s.io/apimachinery/pkg/api/resource"
 )
@@ -77,7 +76,7 @@ type ConfigMount struct {
 	Destination string
 }
 
-func New(name string, cli *client.Client, cfg Config) (types.Harness, error) {
+func New(name string, cli *provider.DockerClient, cfg Config) (types.Harness, error) {
 	// TODO: Support more providers
 
 	mounts := make([]mount.Mount, 0, len(cfg.Mounts))

--- a/internal/harnesses/k3s/k3s.go
+++ b/internal/harnesses/k3s/k3s.go
@@ -17,7 +17,6 @@ import (
 	"github.com/chainguard-dev/terraform-provider-imagetest/internal/log"
 	"github.com/chainguard-dev/terraform-provider-imagetest/internal/types"
 	"github.com/docker/docker/api/types/mount"
-	"github.com/docker/docker/client"
 )
 
 const (
@@ -39,7 +38,7 @@ type k3s struct {
 	sandbox provider.Provider
 }
 
-func New(id string, cli *client.Client, opts ...Option) (types.Harness, error) {
+func New(id string, cli *provider.DockerClient, opts ...Option) (types.Harness, error) {
 	opt := &Opt{
 		ImageRef:      name.MustParseReference(K3sImageTag),
 		Cni:           true,

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -3,7 +3,7 @@ package provider
 import (
 	"context"
 
-	"github.com/docker/docker/client"
+	cprovider "github.com/chainguard-dev/terraform-provider-imagetest/internal/containers/provider"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/provider"
 	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
@@ -197,13 +197,11 @@ func (p *ImageTestProvider) Configure(ctx context.Context, req provider.Configur
 	}
 	p.store.labels = labels
 
-	cli, err := client.NewClientWithOpts(
-		client.WithAPIVersionNegotiation(),
-		client.WithVersionFromEnv(),
-	)
+	cli, err := cprovider.NewDockerClient()
 	if err != nil {
 		resp.Diagnostics.AddError("failed to create docker client", err.Error())
 		return
+
 	}
 	p.store.cli = cli
 

--- a/internal/provider/store.go
+++ b/internal/provider/store.go
@@ -7,10 +7,10 @@ import (
 	"os"
 	"sync"
 
+	"github.com/chainguard-dev/terraform-provider-imagetest/internal/containers/provider"
 	"github.com/chainguard-dev/terraform-provider-imagetest/internal/inventory"
 	"github.com/chainguard-dev/terraform-provider-imagetest/internal/log"
 	"github.com/chainguard-dev/terraform-provider-imagetest/internal/types"
-	"github.com/docker/docker/client"
 	slogmulti "github.com/samber/slog-multi"
 )
 
@@ -28,7 +28,7 @@ type ProviderStore struct {
 
 	// cli is the Docker client. it is initialized once during the providers
 	// Configure() stage and reused for any resource that requires it.
-	cli *client.Client
+	cli *provider.DockerClient
 }
 
 func NewProviderStore() *ProviderStore {


### PR DESCRIPTION
comments are mostly inline, but this ultimately ensures we don't race while trying to create a network.

the container start/run's are not affected by this, because they operate on their own `DockerProvider` scoped resources