### PR TITLE
fix(debug): fix the provider address so it becomes debuggable

### DIFF
--- a/main.go
+++ b/main.go
@@ -35,8 +35,7 @@ func main() {
 	flag.Parse()
 
 	opts := providerserver.ServeOpts{
-		// TODO: Update this string with the published name of your provider.
-		Address: "registry.terraform.io/chainguard-dev/terraform-provider-imagetest",
+		Address: "registry.terraform.io/chainguard-dev/imagetest",
 		Debug:   debug,
 	}
 


### PR DESCRIPTION
The current provider address is incorrect, which makes it impossible to debug the provider using `-debug`.