### PR TITLE
fix(harness_k3s): prevent volume leak on teardown

### DIFF
--- a/internal/containers/provider/docker.go
+++ b/internal/containers/provider/docker.go
@@ -25,7 +25,12 @@ const (
 	DockerDefaultNetworkName = "imagetest"
 )
 
-var ErrNetworkNotFound = errors.New("network not found")
+var (
+	ErrNetworkNotFound = errors.New("network not found")
+	DefaultLabels      = map[string]string{
+		"dev.chainguard.imagetest": "true",
+	}
+)
 
 type DockerProvider struct {
 	cli *DockerClient
@@ -76,12 +81,10 @@ func NewDockerClient() (*DockerClient, error) {
 // NewDocker creates a new DockerProvider with the given client.
 func NewDocker(name string, cli *DockerClient, req DockerRequest) *DockerProvider {
 	return &DockerProvider{
-		name: name,
-		req:  req,
-		cli:  cli,
-		labels: map[string]string{
-			"imagetest": "true",
-		},
+		name:   name,
+		req:    req,
+		cli:    cli,
+		labels: DefaultLabels,
 	}
 }
 

--- a/internal/harnesses/k3s/opts.go
+++ b/internal/harnesses/k3s/opts.go
@@ -20,7 +20,8 @@ type Opt struct {
 	Registries map[string]*RegistryOpt
 	Mirrors    map[string]*RegistryMirrorOpt
 
-	Sandbox provider.DockerRequest
+	Sandbox             provider.DockerRequest
+	ContainerVolumeName string
 }
 
 type RegistryOpt struct {
@@ -205,6 +206,13 @@ func WithTraefikDisabled(disabled bool) Option {
 func WithMetricsServerDisabled(disabled bool) Option {
 	return func(opt *Opt) error {
 		opt.MetricsServer = !disabled
+		return nil
+	}
+}
+
+func WithContainerVolumeName(volumeName string) Option {
+	return func(opt *Opt) error {
+		opt.ContainerVolumeName = volumeName
 		return nil
 	}
 }

--- a/internal/provider/harness_k3s_resource.go
+++ b/internal/provider/harness_k3s_resource.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/chainguard-dev/terraform-provider-imagetest/internal/containers/provider"
+
 	"github.com/docker/docker/api/types/volume"
 
 	"github.com/chainguard-dev/terraform-provider-imagetest/internal/harnesses/k3s"
@@ -334,7 +336,7 @@ func (r *HarnessK3sResource) Create(ctx context.Context, req resource.CreateRequ
 	configVolumeName := id + "-config"
 
 	_, err := r.store.cli.VolumeCreate(ctx, volume.CreateOptions{
-		Labels: map[string]string{"owner": "imagetest"},
+		Labels: provider.DefaultLabels,
 		Name:   configVolumeName,
 	})
 	if err != nil {

--- a/internal/provider/harness_k3s_resource.go
+++ b/internal/provider/harness_k3s_resource.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/docker/docker/api/types/volume"
+
 	"github.com/chainguard-dev/terraform-provider-imagetest/internal/harnesses/k3s"
 	"github.com/chainguard-dev/terraform-provider-imagetest/internal/log"
 	"github.com/docker/docker/api/types/mount"
@@ -328,14 +330,28 @@ func (r *HarnessK3sResource) Create(ctx context.Context, req resource.CreateRequ
 
 	kopts = append(kopts, k3s.WithNetworks(networks...))
 
-	harness, err := k3s.New(data.Id.ValueString(), r.store.cli, kopts...)
+	id := data.Id.ValueString()
+	configVolumeName := id + "-config"
+
+	_, err := r.store.cli.VolumeCreate(ctx, volume.CreateOptions{
+		Labels: map[string]string{"owner": "imagetest"},
+		Name:   configVolumeName,
+	})
+	if err != nil {
+		resp.Diagnostics.AddError("failed to create config volume for k3s harness", err.Error())
+		return
+	}
+
+	kopts = append(kopts, k3s.WithContainerVolumeName(configVolumeName))
+
+	harness, err := k3s.New(id, r.store.cli, kopts...)
 	if err != nil {
 		resp.Diagnostics.AddError("failed to initialize k3s harness", err.Error())
 		return
 	}
-	r.store.harnesses.Set(data.Id.ValueString(), harness)
+	r.store.harnesses.Set(id, harness)
 
-	log.Info(ctx, fmt.Sprintf("creating k3s harness [%s]", data.Id.ValueString()))
+	log.Info(ctx, fmt.Sprintf("creating k3s harness [%s]", id))
 
 	// Finally, create the harness
 	// TODO: Change this signature

--- a/internal/provider/harness_k3s_resource_test.go
+++ b/internal/provider/harness_k3s_resource_test.go
@@ -86,7 +86,7 @@ EOM
 			// Create testing
 			{
 				ExpectNonEmptyPlan: true,
-				ExpectError:        regexp.MustCompile(".*context\\s+deadline.*"),
+				ExpectError:        regexp.MustCompile(`.*context\s+deadline.*`),
 				Config: `
 data "imagetest_inventory" "this" {}
 

--- a/internal/provider/harness_k3s_resource_test.go
+++ b/internal/provider/harness_k3s_resource_test.go
@@ -8,10 +8,8 @@ import (
 )
 
 func TestAccHarnessK3sResource(t *testing.T) {
-	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		Steps: []resource.TestStep{
+	testCases := map[string][]resource.TestStep{
+		"happy path": {
 			// Create testing
 			{
 				ExpectNonEmptyPlan: true,
@@ -37,14 +35,7 @@ resource "imagetest_feature" "test" {
           `,
 			},
 		},
-	})
-}
-
-func TestAccHarnessK3sResourceWithWorkingDirectory(t *testing.T) {
-	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		Steps: []resource.TestStep{
+		"with working directory": {
 			// Create testing
 			{
 				ExpectNonEmptyPlan: true,
@@ -91,18 +82,11 @@ EOM
           `,
 			},
 		},
-	})
-}
-
-func TestAccHarnessK3sResourceTimeout(t *testing.T) {
-	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		Steps: []resource.TestStep{
+		"timeout": {
 			// Create testing
 			{
 				ExpectNonEmptyPlan: true,
-				ExpectError:        regexp.MustCompile(".*context deadline.*"),
+				ExpectError:        regexp.MustCompile(".*context\\s+deadline.*"),
 				Config: `
 data "imagetest_inventory" "this" {}
 
@@ -123,5 +107,15 @@ resource "imagetest_feature" "test" {
           `,
 			},
 		},
-	})
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			resource.Test(t, resource.TestCase{
+				PreCheck:                 func() { testAccPreCheck(t) },
+				ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+				Steps:                    tc,
+			})
+		})
+	}
 }


### PR DESCRIPTION
The current implementation of the k3s harness has a tendency to leak config volumes at the end of each run. This change detaches the creation of the volume from the creation of the container and includes a clean up step that deletes the config volume created by the harness itself, preventing that specific leak.