### PR TITLE
fix(harness_k3s): add volume property in the right place

### DIFF
--- a/docs/resources/harness_k3s.md
+++ b/docs/resources/harness_k3s.md
@@ -100,7 +100,6 @@ Optional:
 - `mounts` (Attributes List) The list of mounts to create on the container. (see [below for nested schema](#nestedatt--sandbox--mounts))
 - `networks` (Attributes Map) A map of existing networks to attach the container to. (see [below for nested schema](#nestedatt--sandbox--networks))
 - `privileged` (Boolean)
-- `volumes` (Attributes List) The volumes this harness should mount. This is received as a mapping from imagetest_container_volume resources to destination folders. (see [below for nested schema](#nestedatt--sandbox--volumes))
 
 <a id="nestedatt--sandbox--mounts"></a>
 ### Nested Schema for `sandbox.mounts`
@@ -117,33 +116,6 @@ Required:
 Required:
 
 - `name` (String) The name of the existing network to attach the container to.
-
-
-<a id="nestedatt--sandbox--volumes"></a>
-### Nested Schema for `sandbox.volumes`
-
-Required:
-
-- `destination` (String)
-- `source` (Attributes) (see [below for nested schema](#nestedatt--sandbox--volumes--source))
-
-<a id="nestedatt--sandbox--volumes--source"></a>
-### Nested Schema for `sandbox.volumes.source`
-
-Required:
-
-- `id` (String)
-- `inventory` (Attributes) (see [below for nested schema](#nestedatt--sandbox--volumes--source--inventory))
-- `name` (String)
-
-<a id="nestedatt--sandbox--volumes--source--inventory"></a>
-### Nested Schema for `sandbox.volumes.source.name`
-
-Required:
-
-- `seed` (String)
-
-
 
 
 

--- a/internal/provider/harness_container_resource.go
+++ b/internal/provider/harness_container_resource.go
@@ -68,7 +68,38 @@ func (r *HarnessContainerResource) Schema(_ context.Context, _ resource.SchemaRe
 		MarkdownDescription: `A harness that runs steps in a sandbox container.`,
 
 		Attributes: addHarnessResourceSchemaAttributes(
-			addContainerResourceSchemaAttributes(map[string]schema.Attribute{}),
+			addContainerResourceSchemaAttributes(map[string]schema.Attribute{
+				"volumes": schema.ListNestedAttribute{
+					NestedObject: schema.NestedAttributeObject{
+						Attributes: map[string]schema.Attribute{
+							"source": schema.SingleNestedAttribute{
+								Attributes: map[string]schema.Attribute{
+									"id": schema.StringAttribute{
+										Required: true,
+									},
+									"name": schema.StringAttribute{
+										Required: true,
+									},
+									"inventory": schema.SingleNestedAttribute{
+										Required: true,
+										Attributes: map[string]schema.Attribute{
+											"seed": schema.StringAttribute{
+												Required: true,
+											},
+										},
+									},
+								},
+								Required: true,
+							},
+							"destination": schema.StringAttribute{
+								Required: true,
+							},
+						},
+					},
+					Description: "The volumes this harness should mount. This is received as a mapping from imagetest_container_volume resources to destination folders.",
+					Optional:    true,
+				},
+			}),
 		),
 	}
 }
@@ -283,36 +314,6 @@ func addContainerResourceSchemaAttributes(attrs map[string]schema.Attribute) map
 					},
 				},
 			},
-		},
-		"volumes": schema.ListNestedAttribute{
-			NestedObject: schema.NestedAttributeObject{
-				Attributes: map[string]schema.Attribute{
-					"source": schema.SingleNestedAttribute{
-						Attributes: map[string]schema.Attribute{
-							"id": schema.StringAttribute{
-								Required: true,
-							},
-							"name": schema.StringAttribute{
-								Required: true,
-							},
-							"inventory": schema.SingleNestedAttribute{
-								Required: true,
-								Attributes: map[string]schema.Attribute{
-									"seed": schema.StringAttribute{
-										Required: true,
-									},
-								},
-							},
-						},
-						Required: true,
-					},
-					"destination": schema.StringAttribute{
-						Required: true,
-					},
-				},
-			},
-			Description: "The volumes this harness should mount. This is received as a mapping from imagetest_container_volume resources to destination folders.",
-			Optional:    true,
 		},
 	}
 

--- a/internal/provider/harness_k3s_resource_test.go
+++ b/internal/provider/harness_k3s_resource_test.go
@@ -107,6 +107,37 @@ resource "imagetest_feature" "test" {
           `,
 			},
 		},
+		"sandbox config": {
+			// Create testing
+			{
+				ExpectNonEmptyPlan: true,
+				Config: `
+data "imagetest_inventory" "this" {}
+
+resource "imagetest_harness_k3s" "test" {
+  name = "test"
+  inventory = data.imagetest_inventory.this
+  sandbox = {
+    envs = {
+      "test": "value",
+    }
+  }
+}
+
+resource "imagetest_feature" "test" {
+  name = "Simple k3s based test"
+  description = "Test that we can spin up a k3s cluster and run some steps"
+  harness = imagetest_harness_k3s.test
+  steps = [
+    {
+      name = "Access cluster"
+      cmd = "kubectl get po -A"
+    },
+  ]
+}
+          `,
+			},
+		},
 	}
 
 	for name, tc := range testCases {


### PR DESCRIPTION
Move the volume property out of the generic method so it doesn't impact the k3s harness when the `sandbox` property is specified.