### PR TITLE
add some different defaults when running on workstations

### DIFF
--- a/internal/harnesses/k3s/k3s.go
+++ b/internal/harnesses/k3s/k3s.go
@@ -43,6 +43,7 @@ func New(id string, cli *provider.DockerClient, opts ...Option) (types.Harness, 
 		ImageRef:      name.MustParseReference(K3sImageTag),
 		Cni:           true,
 		MetricsServer: false,
+		Snapshotter:   "overlayfs",
 		Traefik:       false,
 		// Default to the bare minimum k3s needs to run properly
 		// https://docs.k3s.io/installation/requirements#hardware
@@ -308,7 +309,8 @@ disable:
 {{- if not .Cni }}
 flannel-backend: none
 {{- end }}
-`, h.id)
+snapshotter: "%[2]s"
+`, h.id, h.opt.Snapshotter)
 
 	tmpl, err := template.New("config").Parse(cfgtmpl)
 	if err != nil {

--- a/internal/harnesses/k3s/opts.go
+++ b/internal/harnesses/k3s/opts.go
@@ -22,6 +22,7 @@ type Opt struct {
 
 	Sandbox             provider.DockerRequest
 	ContainerVolumeName string
+	Snapshotter         K3sContainerSnapshotter
 }
 
 type RegistryOpt struct {
@@ -44,6 +45,13 @@ type RegistryTlsOpt struct {
 type RegistryMirrorOpt struct {
 	Endpoints []string
 }
+
+type K3sContainerSnapshotter string
+
+const (
+	K3sContainerSnapshotterNative    K3sContainerSnapshotter = "native"
+	K3sContainerSnapshotterOverlayfs K3sContainerSnapshotter = "overlayfs"
+)
 
 type Option func(*Opt) error
 
@@ -131,6 +139,13 @@ func WithNetworks(networks ...string) Option {
 			opt.Sandbox.Networks = []string{}
 		}
 		opt.Sandbox.Networks = append(opt.Sandbox.Networks, networks...)
+		return nil
+	}
+}
+
+func WithContainerSnapshotter(snapshotter K3sContainerSnapshotter) Option {
+	return func(opt *Opt) error {
+		opt.Snapshotter = snapshotter
 		return nil
 	}
 }

--- a/internal/provider/harness_k3s_resource.go
+++ b/internal/provider/harness_k3s_resource.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"os"
 	"path/filepath"
 	"time"
 
@@ -236,6 +237,8 @@ func (r *HarnessK3sResource) Create(ctx context.Context, req resource.CreateRequ
 		k3s.WithMetricsServerDisabled(data.DisableMetricsServer.ValueBool()),
 	}
 
+	kopts = append(kopts, r.workstationOpts()...)
+
 	if !data.Image.IsNull() {
 		ref, err := name.ParseReference(data.Image.ValueString())
 		if err != nil {
@@ -407,4 +410,15 @@ func (r *HarnessK3sResource) Delete(ctx context.Context, req resource.DeleteRequ
 
 func (r *HarnessK3sResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}
+
+// workstationOpts holds any workstation specific k3s configuration.
+func (r *HarnessK3sResource) workstationOpts() []k3s.Option {
+	opts := []k3s.Option{}
+
+	if os.Getenv("WORKSTATION") != "" {
+		opts = append(opts, k3s.WithContainerSnapshotter(k3s.K3sContainerSnapshotterNative))
+	}
+
+	return opts
 }


### PR DESCRIPTION
plumbs through a way of adding workstation specific configuration for the k3s harness.

start by adding default `--snapshotter` options