### PR TITLE
chore(imagetest): reuse `entrypoint` and `cmd` across imagetest

### DIFF
--- a/internal/containers/provider/docker.go
+++ b/internal/containers/provider/docker.go
@@ -10,6 +10,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/chainguard-dev/terraform-provider-imagetest/internal/harnesses/base"
+
 	"github.com/chainguard-dev/terraform-provider-imagetest/internal/log"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
@@ -272,7 +274,7 @@ func (p *DockerProvider) Teardown(ctx context.Context) error {
 // Exec implements Provider.
 func (p *DockerProvider) Exec(ctx context.Context, config ExecConfig) (io.Reader, error) {
 	execConfig := types.ExecConfig{
-		Cmd:          []string{"/bin/sh", "-c", config.Command},
+		Cmd:          append(base.DefaultEntrypoint(), config.Command),
 		WorkingDir:   config.WorkingDir,
 		AttachStderr: true,
 		AttachStdout: true,

--- a/internal/harnesses/base/base.go
+++ b/internal/harnesses/base/base.go
@@ -71,3 +71,17 @@ func (h *Base) Done() error {
 	}
 	return nil
 }
+
+// DefaultEntrypoint returns the default entrypoint command used for multiple harnesses. This is currently used like this
+// in several places, so we might as well make it reusable.
+// Not safe to be made into a variable since slices are mutable and therefore cannot be made constant in Go.
+func DefaultEntrypoint() []string {
+	return []string{"/bin/sh", "-c"}
+}
+
+// DefaultCmd returns the default command used for multiple harnesses. This is currently used like this
+// in several places, so we might as well make it reusable.
+// Not safe to be made into a variable since slices are mutable and therefore cannot be made constant in Go.
+func DefaultCmd() []string {
+	return []string{"tail -f /dev/null"}
+}

--- a/internal/harnesses/container/container.go
+++ b/internal/harnesses/container/container.go
@@ -101,8 +101,8 @@ func New(name string, cli *provider.DockerClient, cfg Config) (types.Harness, er
 	p := provider.NewDocker(name, cli, provider.DockerRequest{
 		ContainerRequest: provider.ContainerRequest{
 			Ref:        cfg.Ref,
-			Entrypoint: []string{"/bin/sh", "-c"},
-			Cmd:        []string{"tail -f /dev/null"},
+			Entrypoint: base.DefaultEntrypoint(),
+			Cmd:        base.DefaultCmd(),
 			Env:        cfg.Env,
 			Networks:   cfg.Networks,
 			Resources: provider.ContainerResourcesRequest{

--- a/internal/harnesses/docker/docker.go
+++ b/internal/harnesses/docker/docker.go
@@ -64,8 +64,8 @@ func New(id string, cli *provider.DockerClient, opts ...Option) (types.Harness, 
 	container := provider.NewDocker(id, cli, provider.DockerRequest{
 		ContainerRequest: provider.ContainerRequest{
 			Ref:        options.ImageRef,
-			Entrypoint: []string{"/bin/sh", "-c"},
-			Cmd:        []string{"tail -f /dev/null"},
+			Entrypoint: base.DefaultEntrypoint(),
+			Cmd:        base.DefaultCmd(),
 			Networks:   options.Networks,
 			Env:        options.Envs,
 		},

--- a/internal/harnesses/k3s/k3s.go
+++ b/internal/harnesses/k3s/k3s.go
@@ -54,8 +54,8 @@ func New(id string, cli *provider.DockerClient, opts ...Option) (types.Harness, 
 		Sandbox: provider.DockerRequest{
 			ContainerRequest: provider.ContainerRequest{
 				Ref:        name.MustParseReference(KubectlImageTag),
-				Entrypoint: []string{"/bin/sh", "-c"},
-				Cmd:        []string{"tail -f /dev/null"},
+				Entrypoint: base.DefaultEntrypoint(),
+				Cmd:        base.DefaultCmd(),
 				Env: map[string]string{
 					"KUBECONFIG": "/k3s-config/k3s.yaml",
 				},


### PR DESCRIPTION
Create methods that allow reusing the `entrypoint` slice and the `cmd` string.