### PR TITLE
chore(make): add targets for common tasks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ default: testacc
 testacc:
 	TF_ACC=1 go test ./... -v $(TESTARGS) -timeout 120m
 
-terraform-provider-imagetest:
+terraform-provider-imagetest: goimports lint testacc
 	CGO_ENABLED=0 go build -ldflags "-s -w -X main.version=devel -X main.commit=$(shell git rev-parse --short HEAD)" .
 
 .PHONY: clean
@@ -15,3 +15,11 @@ clean:
 .PHONY: go-generate
 go-generate:
 	go generate -v ./...
+
+.PHONY: goimports
+goimports:
+	find . -name \*.go -not -path .github -not -path .git -exec goimports -w {} \;
+
+.PHONY: lint
+lint:
+	golangci-lint run


### PR DESCRIPTION
Add some targets for common tasks in the imagetest provider, such as linting and `goimports`ing.