### PR TITLE
feat(harness_k3s): add an alias for `kubectl`

### DIFF
--- a/internal/harnesses/k3s/k3s.go
+++ b/internal/harnesses/k3s/k3s.go
@@ -58,6 +58,14 @@ func New(id string, cli *provider.DockerClient, opts ...Option) (types.Harness, 
 				Cmd:        base.DefaultCmd(),
 				Env: map[string]string{
 					"KUBECONFIG": "/k3s-config/k3s.yaml",
+					"ENV":        "/root/.ashrc",
+				},
+				Files: []provider.File{
+					{
+						Contents: bytes.NewBufferString("alias k=kubectl"),
+						Target:   "/root/.ashrc",
+						Mode:     644,
+					},
 				},
 				User: "0:0",
 				// Default to something small just for "scheduling" purposes, the bulk of


### PR DESCRIPTION
Include an `.ashrc` file in the sandbox for the k3s harness that enables the alias `k` for `kubectl`.