### PR TITLE
feat(harness_docker): implement auth support

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -66,6 +66,7 @@ Optional:
 - `host_socket_path` (String) The Docker host socket path.
 - `mounts` (Attributes List) The list of mounts to create on the container. (see [below for nested schema](#nestedatt--harnesses--docker--mounts))
 - `networks` (Attributes Map) A map of existing networks to attach the container to. (see [below for nested schema](#nestedatt--harnesses--docker--networks))
+- `registries` (Attributes Map) A map of registries containing configuration for optional auth, tls, and mirror configuration. (see [below for nested schema](#nestedatt--harnesses--docker--registries))
 
 <a id="nestedatt--harnesses--docker--mounts"></a>
 ### Nested Schema for `harnesses.docker.mounts`
@@ -82,6 +83,24 @@ Required:
 Required:
 
 - `name` (String) The name of the existing network to attach the container to.
+
+
+<a id="nestedatt--harnesses--docker--registries"></a>
+### Nested Schema for `harnesses.docker.registries`
+
+Optional:
+
+- `auth` (Attributes) (see [below for nested schema](#nestedatt--harnesses--docker--registries--auth))
+
+<a id="nestedatt--harnesses--docker--registries--auth"></a>
+### Nested Schema for `harnesses.docker.registries.auth`
+
+Optional:
+
+- `auth` (String)
+- `password` (String, Sensitive)
+- `username` (String)
+
 
 
 

--- a/docs/resources/harness_docker.md
+++ b/docs/resources/harness_docker.md
@@ -27,6 +27,7 @@ A harness that runs steps in a sandbox container with access to a Docker daemon.
 - `mounts` (Attributes List) The list of mounts to create on the container. (see [below for nested schema](#nestedatt--mounts))
 - `networks` (Attributes Map) A map of existing networks to attach the container to. (see [below for nested schema](#nestedatt--networks))
 - `privileged` (Boolean)
+- `registries` (Attributes Map) A map of registries containing configuration for optional auth, tls, and mirror configuration. (see [below for nested schema](#nestedatt--registries))
 - `volumes` (Attributes List) The volumes this harness should mount. This is received as a mapping from imagetest_container_volume resources to destination folders. (see [below for nested schema](#nestedatt--volumes))
 
 ### Read-Only
@@ -57,6 +58,35 @@ Required:
 Required:
 
 - `name` (String) The name of the existing network to attach the container to.
+
+
+<a id="nestedatt--registries"></a>
+### Nested Schema for `registries`
+
+Optional:
+
+- `auth` (Attributes) (see [below for nested schema](#nestedatt--registries--auth))
+- `tls` (Attributes) (see [below for nested schema](#nestedatt--registries--tls))
+
+<a id="nestedatt--registries--auth"></a>
+### Nested Schema for `registries.auth`
+
+Optional:
+
+- `auth` (String)
+- `password` (String, Sensitive)
+- `username` (String)
+
+
+<a id="nestedatt--registries--tls"></a>
+### Nested Schema for `registries.tls`
+
+Optional:
+
+- `ca_file` (String)
+- `cert_file` (String)
+- `key_file` (String)
+
 
 
 <a id="nestedatt--volumes"></a>

--- a/internal/harnesses/base/base_opts.go
+++ b/internal/harnesses/base/base_opts.go
@@ -1,0 +1,13 @@
+package base
+
+type RegistryAuthOpt struct {
+	Username string
+	Password string
+	Auth     string
+}
+
+type RegistryTlsOpt struct {
+	CertFile string
+	KeyFile  string
+	CaFile   string
+}

--- a/internal/harnesses/k3s/opts.go
+++ b/internal/harnesses/k3s/opts.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/chainguard-dev/terraform-provider-imagetest/internal/containers/provider"
+	"github.com/chainguard-dev/terraform-provider-imagetest/internal/harnesses/base"
 	"github.com/docker/docker/api/types/mount"
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
@@ -26,20 +27,8 @@ type Opt struct {
 }
 
 type RegistryOpt struct {
-	Auth *RegistryAuthOpt
-	Tls  *RegistryTlsOpt
-}
-
-type RegistryAuthOpt struct {
-	Username string
-	Password string
-	Auth     string
-}
-
-type RegistryTlsOpt struct {
-	CertFile string
-	KeyFile  string
-	CaFile   string
+	Auth *base.RegistryAuthOpt
+	Tls  *base.RegistryTlsOpt
 }
 
 type RegistryMirrorOpt struct {
@@ -71,7 +60,7 @@ func WithAuthFromStatic(registry, username, password, auth string) Option {
 			opt.Registries[registry] = &RegistryOpt{}
 		}
 
-		opt.Registries[registry].Auth = &RegistryAuthOpt{
+		opt.Registries[registry].Auth = &base.RegistryAuthOpt{
 			Username: username,
 			Password: password,
 			Auth:     auth,
@@ -105,7 +94,7 @@ func WithAuthFromKeychain(registry string) Option {
 			return fmt.Errorf("getting authorization for registry %s: %w", r.String(), err)
 		}
 
-		opt.Registries[registry].Auth = &RegistryAuthOpt{
+		opt.Registries[registry].Auth = &base.RegistryAuthOpt{
 			Username: acfg.Username,
 			Password: acfg.Password,
 			Auth:     acfg.Auth,

--- a/internal/provider/harness.go
+++ b/internal/provider/harness.go
@@ -32,6 +32,18 @@ type FeatureHarnessVolumeMountModel struct {
 	Destination string                       `tfsdk:"destination"`
 }
 
+type RegistryResourceAuthModel struct {
+	Username types.String `tfsdk:"username"`
+	Password types.String `tfsdk:"password"`
+	Auth     types.String `tfsdk:"auth"`
+}
+
+type RegistryResourceTlsModel struct {
+	CertFile types.String `tfsdk:"cert_file"`
+	KeyFile  types.String `tfsdk:"key_file"`
+	CaFile   types.String `tfsdk:"ca_file"`
+}
+
 func (r *HarnessResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
 	// Prevent panic if the provider has not been configured.
 	if req.ProviderData == nil {

--- a/internal/provider/harness_k3s_resource.go
+++ b/internal/provider/harness_k3s_resource.go
@@ -68,18 +68,6 @@ type RegistryResourceModel struct {
 	Mirror *RegistryResourceMirrorModel `tfsdk:"mirror"`
 }
 
-type RegistryResourceAuthModel struct {
-	Username types.String `tfsdk:"username"`
-	Password types.String `tfsdk:"password"`
-	Auth     types.String `tfsdk:"auth"`
-}
-
-type RegistryResourceTlsModel struct {
-	CertFile types.String `tfsdk:"cert_file"`
-	KeyFile  types.String `tfsdk:"key_file"`
-	CaFile   types.String `tfsdk:"ca_file"`
-}
-
 type RegistryResourceMirrorModel struct {
 	Endpoints types.List `tfsdk:"endpoints"`
 }

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -52,6 +52,7 @@ type ProviderHarnessDockerModel struct {
 	Networks       map[string]ContainerResourceModelNetwork `tfsdk:"networks"`
 	Envs           types.Map                                `tfsdk:"envs"`
 	Mounts         []ContainerResourceMountModel            `tfsdk:"mounts"`
+	Registries     map[string]DockerRegistryResourceModel   `tfsdk:"registries"`
 }
 
 type ProviderLoggerModel struct {
@@ -222,6 +223,29 @@ func (p *ImageTestProvider) Schema(ctx context.Context, req provider.SchemaReque
 										"destination": schema.StringAttribute{
 											Description: "The absolute path on the container to mount the source directory to.",
 											Required:    true,
+										},
+									},
+								},
+							},
+							"registries": schema.MapNestedAttribute{
+								Description: "A map of registries containing configuration for optional auth, tls, and mirror configuration.",
+								Optional:    true,
+								NestedObject: schema.NestedAttributeObject{
+									Attributes: map[string]schema.Attribute{
+										"auth": schema.SingleNestedAttribute{
+											Optional: true,
+											Attributes: map[string]schema.Attribute{
+												"username": schema.StringAttribute{
+													Optional: true,
+												},
+												"password": schema.StringAttribute{
+													Optional:  true,
+													Sensitive: true,
+												},
+												"auth": schema.StringAttribute{
+													Optional: true,
+												},
+											},
 										},
 									},
 								},


### PR DESCRIPTION
Add auth support to the Docker harness, in a similar way to how the k3s harness currently implements it. This implementation can read credentials from the underlying environment or from variables supplied directly to the provider and/or resource.