### PR TITLE
plumb "sandbox.image" through as a valid provider config

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -111,6 +111,7 @@ Optional:
 
 - `networks` (Attributes Map) A map of existing networks to attach the harness containers to. (see [below for nested schema](#nestedatt--harnesses--k3s--networks))
 - `registries` (Attributes Map) A map of registries containing configuration for optional auth, tls, and mirror configuration. (see [below for nested schema](#nestedatt--harnesses--k3s--registries))
+- `sandbox` (Attributes) A map of configuration for the sandbox container. (see [below for nested schema](#nestedatt--harnesses--k3s--sandbox))
 
 <a id="nestedatt--harnesses--k3s--networks"></a>
 ### Nested Schema for `harnesses.k3s.networks`
@@ -156,6 +157,14 @@ Optional:
 - `cert_file` (String)
 - `key_file` (String)
 
+
+
+<a id="nestedatt--harnesses--k3s--sandbox"></a>
+### Nested Schema for `harnesses.k3s.sandbox`
+
+Optional:
+
+- `image` (String) The full image reference to use for the container.
 
 
 

--- a/examples/filtering/main.tf
+++ b/examples/filtering/main.tf
@@ -1,6 +1,6 @@
 terraform {
   required_providers {
-    imagetest = { source = "registry.terraform.io/chainguard-dev/imagetest" }
+    imagetest = { source = "chainguard-dev/imagetest" }
   }
   backend "inmem" {}
 }
@@ -19,6 +19,7 @@ data "imagetest_inventory" "this" {}
 resource "imagetest_harness_k3s" "foo" {
   name      = "foo"
   inventory = data.imagetest_inventory.this
+  image     = "gcr.io/wolf-chainguard/images/k3s-test"
 }
 
 resource "imagetest_feature" "foo" {
@@ -28,7 +29,7 @@ resource "imagetest_feature" "foo" {
   steps = [
     {
       name = "Sample"
-      cmd  = "kubectl get po -A"
+      cmd  = "sleep inf"
     }
   ]
 

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -43,8 +43,13 @@ type ProviderHarnessContainerModel struct {
 }
 
 type ProviderHarnessK3sModel struct {
-	Networks   map[string]ContainerResourceModelNetwork `tfsdk:"networks"`
-	Registries map[string]RegistryResourceModel         `tfsdk:"registries"`
+	Networks   map[string]ContainerResourceModelNetwork      `tfsdk:"networks"`
+	Registries map[string]RegistryResourceModel              `tfsdk:"registries"`
+	Sandbox    *ProviderHarnessContainerSandboxResourceModel `tfsdk:"sandbox"`
+}
+
+type ProviderHarnessContainerSandboxResourceModel struct {
+	Image types.String `tfsdk:"image"`
 }
 
 type ProviderHarnessDockerModel struct {
@@ -181,6 +186,16 @@ func (p *ImageTestProvider) Schema(ctx context.Context, req provider.SchemaReque
 												},
 											},
 										},
+									},
+								},
+							},
+							"sandbox": schema.SingleNestedAttribute{
+								Description: "A map of configuration for the sandbox container.",
+								Optional:    true,
+								Attributes: map[string]schema.Attribute{
+									"image": schema.StringAttribute{
+										Description: "The full image reference to use for the container.",
+										Optional:    true,
 									},
 								},
 							},


### PR DESCRIPTION
I don't love the datamodel here and the re-use, but it feels like the least evil given the difference between `provider.schema` and `resource.schema` 🤦 