### PR TITLE
feat(imagetest): enable Docker socket on non-default location

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -18,6 +18,7 @@ description: |-
 ### Optional
 
 - `harnesses` (Attributes) (see [below for nested schema](#nestedatt--harnesses))
+- `host` (String) The Docker host (or socket path) to connect to
 - `labels` (Map of String)
 - `log` (Attributes) (see [below for nested schema](#nestedatt--log))
 
@@ -63,7 +64,6 @@ Required:
 Optional:
 
 - `envs` (Map of String) Environment variables to set on the container.
-- `host_socket_path` (String) The Docker host socket path.
 - `mounts` (Attributes List) The list of mounts to create on the container. (see [below for nested schema](#nestedatt--harnesses--docker--mounts))
 - `networks` (Attributes Map) A map of existing networks to attach the container to. (see [below for nested schema](#nestedatt--harnesses--docker--networks))
 - `registries` (Attributes Map) A map of registries containing configuration for optional auth, tls, and mirror configuration. (see [below for nested schema](#nestedatt--harnesses--docker--registries))

--- a/internal/containers/provider/docker.go
+++ b/internal/containers/provider/docker.go
@@ -70,12 +70,20 @@ type DockerClient struct {
 	mu sync.Mutex
 }
 
-func NewDockerClient() (*DockerClient, error) {
-	cli, err := client.NewClientWithOpts(
-		client.FromEnv,
+func NewDockerClient(host string) (*DockerClient, error) {
+	// default options
+	var opts = []client.Opt{
+		client.FromEnv, // load config from env
 		client.WithAPIVersionNegotiation(),
 		client.WithVersionFromEnv(),
-	)
+	}
+
+	// add custom host path, if specified
+	if "" != host {
+		opts = append(opts, client.WithHost(host))
+	}
+
+	cli, err := client.NewClientWithOpts(opts...)
 	if err != nil {
 		return nil, fmt.Errorf("creating docker client: %w", err)
 	}

--- a/internal/provider/harness_docker_resource.go
+++ b/internal/provider/harness_docker_resource.go
@@ -109,12 +109,6 @@ func (r *HarnessDockerResource) Create(ctx context.Context, req resource.CreateR
 	}
 	opts = append(opts, docker.WithImageRef(ref))
 
-	if r.store.providerResourceData.Harnesses != nil &&
-		r.store.providerResourceData.Harnesses.Docker != nil &&
-		r.store.providerResourceData.Harnesses.Docker.HostSocketPath != nil {
-		opts = append(opts, docker.WithHostSocketPath(*r.store.providerResourceData.Harnesses.Docker.HostSocketPath))
-	}
-
 	mounts := make([]ContainerResourceMountModel, 0)
 	if data.Mounts != nil {
 		mounts = data.Mounts
@@ -150,6 +144,12 @@ func (r *HarnessDockerResource) Create(ctx context.Context, req resource.CreateR
 				return
 			}
 			opts = append(opts, docker.WithContainerResources(resourceRequests))
+		}
+	}
+
+	if !r.store.providerResourceData.Host.IsNull() {
+		if hostSocketPath := r.store.providerResourceData.Host.ValueString(); hostSocketPath != "" {
+			opts = append(opts, docker.WithHostSocketPath(hostSocketPath))
 		}
 	}
 

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -49,11 +49,10 @@ type ProviderHarnessK3sModel struct {
 }
 
 type ProviderHarnessDockerModel struct {
-	HostSocketPath *string                                  `tfsdk:"host_socket_path"`
-	Networks       map[string]ContainerResourceModelNetwork `tfsdk:"networks"`
-	Envs           types.Map                                `tfsdk:"envs"`
-	Mounts         []ContainerResourceMountModel            `tfsdk:"mounts"`
-	Registries     map[string]DockerRegistryResourceModel   `tfsdk:"registries"`
+	Networks   map[string]ContainerResourceModelNetwork `tfsdk:"networks"`
+	Envs       types.Map                                `tfsdk:"envs"`
+	Mounts     []ContainerResourceMountModel            `tfsdk:"mounts"`
+	Registries map[string]DockerRegistryResourceModel   `tfsdk:"registries"`
 }
 
 type ProviderLoggerModel struct {
@@ -194,11 +193,6 @@ func (p *ImageTestProvider) Schema(ctx context.Context, req provider.SchemaReque
 					"docker": schema.SingleNestedAttribute{
 						Optional: true,
 						Attributes: map[string]schema.Attribute{
-							"host_socket_path": schema.StringAttribute{
-								Required:    false,
-								Optional:    true,
-								Description: "The Docker host socket path.",
-							},
 							"envs": schema.MapAttribute{
 								Description: "Environment variables to set on the container.",
 								Optional:    true,

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -25,6 +25,7 @@ type ImageTestProvider struct {
 
 // ImageTestProviderModel describes the provider data model.
 type ImageTestProviderModel struct {
+	Host      types.String                   `tfsdk:"host"`
 	Log       *ProviderLoggerModel           `tfsdk:"log"`
 	Harnesses *ImageTestProviderHarnessModel `tfsdk:"harnesses"`
 	Labels    types.Map                      `tfsdk:"labels"`
@@ -69,6 +70,10 @@ func (p *ImageTestProvider) Metadata(ctx context.Context, req provider.MetadataR
 func (p *ImageTestProvider) Schema(ctx context.Context, req provider.SchemaRequest, resp *provider.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
+			"host": schema.StringAttribute{
+				Optional:    true,
+				Description: "The Docker host (or socket path) to connect to",
+			},
 			"labels": schema.MapAttribute{
 				ElementType: types.StringType,
 				Optional:    true,
@@ -271,7 +276,12 @@ func (p *ImageTestProvider) Configure(ctx context.Context, req provider.Configur
 	}
 	p.store.labels = labels
 
-	cli, err := cprovider.NewDockerClient()
+	host := ""
+	if !data.Host.IsNull() {
+		host = data.Host.ValueString()
+	}
+
+	cli, err := cprovider.NewDockerClient(host)
 	if err != nil {
 		resp.Diagnostics.AddError("failed to create docker client", err.Error())
 		return


### PR DESCRIPTION
This change enables the usage of imagetest even if the Docker socket is not in the default location. Right now this is achievable by means of setting the `DOCKER_HOST` environment variable; this change also enables the usage of a Docker socket on a non-default location via provider configuration.