### PR TITLE
feat: add CPU knobs to k3s and Docker harnesses

### DIFF
--- a/docs/resources/harness_docker.md
+++ b/docs/resources/harness_docker.md
@@ -96,7 +96,16 @@ Optional:
 
 Optional:
 
+- `cpu` (Attributes) (see [below for nested schema](#nestedatt--resources--cpu))
 - `memory` (Attributes) (see [below for nested schema](#nestedatt--resources--memory))
+
+<a id="nestedatt--resources--cpu"></a>
+### Nested Schema for `resources.cpu`
+
+Optional:
+
+- `request` (String) Quantity of CPUs requested for the harness container
+
 
 <a id="nestedatt--resources--memory"></a>
 ### Nested Schema for `resources.memory`

--- a/docs/resources/harness_k3s.md
+++ b/docs/resources/harness_k3s.md
@@ -96,7 +96,16 @@ Optional:
 
 Optional:
 
+- `cpu` (Attributes) (see [below for nested schema](#nestedatt--resources--cpu))
 - `memory` (Attributes) (see [below for nested schema](#nestedatt--resources--memory))
+
+<a id="nestedatt--resources--cpu"></a>
+### Nested Schema for `resources.cpu`
+
+Optional:
+
+- `request` (String) Quantity of CPUs requested for the harness container
+
 
 <a id="nestedatt--resources--memory"></a>
 ### Nested Schema for `resources.memory`

--- a/internal/containers/provider/docker.go
+++ b/internal/containers/provider/docker.go
@@ -179,6 +179,9 @@ func (p *DockerProvider) Start(ctx context.Context) error {
 		Resources: container.Resources{
 			MemoryReservation: p.req.Resources.MemoryRequest.Value(),
 			Memory:            p.req.Resources.MemoryLimit.Value(),
+
+			// mirroring what's done in Docker CLI: https://github.com/docker/cli/blob/0ad1d55b02910f4b40462c0d01aac2934eb0f061/cli/command/container/update.go#L117
+			NanoCPUs: p.req.Resources.CpuRequest.Value(),
 		},
 	}
 


### PR DESCRIPTION
Add CPU knobs to allow tweaking of resources at the harness level for both k3s and Docker harnesses.