### PR TITLE
use structs for processing resources

### DIFF
--- a/docs/resources/harness_docker.md
+++ b/docs/resources/harness_docker.md
@@ -104,6 +104,7 @@ Optional:
 
 Optional:
 
+- `limit` (String) Unused.
 - `request` (String) Quantity of CPUs requested for the harness container
 
 

--- a/docs/resources/harness_k3s.md
+++ b/docs/resources/harness_k3s.md
@@ -104,7 +104,8 @@ Optional:
 
 Optional:
 
-- `request` (String) Quantity of CPUs requested for the harness container
+- `limit` (String) Limit of memory the harness container can consume
+- `request` (String) Amount of memory requested for the harness container
 
 
 <a id="nestedatt--resources--memory"></a>
@@ -113,7 +114,7 @@ Optional:
 Optional:
 
 - `limit` (String) Limit of memory the harness container can consume
-- `request` (String) Amount of memory requested for the harness container
+- `request` (String) Amount of memory requested for the harness container. The default is the bare minimum required by k3s. Anything lower should be used with caution.
 
 
 

--- a/internal/containers/provider/docker.go
+++ b/internal/containers/provider/docker.go
@@ -179,7 +179,6 @@ func (p *DockerProvider) Start(ctx context.Context) error {
 		Resources: container.Resources{
 			MemoryReservation: p.req.Resources.MemoryRequest.Value(),
 			Memory:            p.req.Resources.MemoryLimit.Value(),
-
 			// mirroring what's done in Docker CLI: https://github.com/docker/cli/blob/0ad1d55b02910f4b40462c0d01aac2934eb0f061/cli/command/container/update.go#L117
 			NanoCPUs: p.req.Resources.CpuRequest.Value(),
 		},

--- a/internal/provider/harness_docker_resource_test.go
+++ b/internal/provider/harness_docker_resource_test.go
@@ -220,7 +220,19 @@ resource "imagetest_harness_docker" "test" {
   inventory = data.imagetest_inventory.this
 
   resources = {
-    memory = { request = "2Gi" }
+    cpu = {
+      request = "1"
+    }
+    memory = {
+      request = "524288000" # 500Mi
+    }
+  }
+
+  provisioner "local-exec" {
+    command = <<EOF
+docker inspect ${self.id} | jq '.[0].HostConfig.NanoCpus' | grep 1
+docker inspect ${self.id} | jq '.[0].HostConfig.MemoryReservation' | grep 524288000
+      EOF
   }
 }
 

--- a/internal/provider/harness_k3s_resource_test.go
+++ b/internal/provider/harness_k3s_resource_test.go
@@ -155,10 +155,21 @@ resource "imagetest_harness_k3s" "test" {
   }
 
   resources = {
-    memory = {
-      request = "256Mi"
-      limit = "1Gi"
+    cpu = {
+      request = "1"
     }
+    memory = {
+      request = "524288000" # 500Mi
+      limit   = "524288001"
+    }
+  }
+
+  provisioner "local-exec" {
+    command = <<EOF
+docker inspect ${self.id} | jq '.[0].HostConfig.NanoCpus' | grep 1
+docker inspect ${self.id} | jq '.[0].HostConfig.MemoryReservation' | grep 524288000
+docker inspect ${self.id} | jq '.[0].HostConfig.Memory' | grep 524288001
+      EOF
   }
 }
 


### PR DESCRIPTION
trial an approach of using a typed struct instead of `types.Object`.

at first glance this seems more ergonomic, but I feel like I remember there being a reason why we don't already do this.