### PR TITLE
fix(harness_docker): remove unused TLS field from schema

### DIFF
--- a/docs/resources/harness_docker.md
+++ b/docs/resources/harness_docker.md
@@ -68,7 +68,6 @@ Required:
 Optional:
 
 - `auth` (Attributes) (see [below for nested schema](#nestedatt--registries--auth))
-- `tls` (Attributes) (see [below for nested schema](#nestedatt--registries--tls))
 
 <a id="nestedatt--registries--auth"></a>
 ### Nested Schema for `registries.auth`
@@ -78,16 +77,6 @@ Optional:
 - `auth` (String)
 - `password` (String, Sensitive)
 - `username` (String)
-
-
-<a id="nestedatt--registries--tls"></a>
-### Nested Schema for `registries.tls`
-
-Optional:
-
-- `ca_file` (String)
-- `cert_file` (String)
-- `key_file` (String)
 
 
 

--- a/internal/provider/harness.go
+++ b/internal/provider/harness.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/chainguard-dev/terraform-provider-imagetest/internal/containers/provider"
 	"github.com/chainguard-dev/terraform-provider-imagetest/internal/inventory"
@@ -13,6 +14,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	kresource "k8s.io/apimachinery/pkg/api/resource"
+)
+
+const (
+	defaultHarnessCreateTimeout = 5 * time.Minute
 )
 
 // HarnessResource provides common methods for all HarnessResource

--- a/internal/provider/harness_container_resource.go
+++ b/internal/provider/harness_container_resource.go
@@ -95,7 +95,7 @@ func (r *HarnessContainerResource) Create(ctx context.Context, req resource.Crea
 		return
 	}
 
-	timeout, diags := data.Timeouts.Create(ctx, defaultHarnessK3sCreateTimeout)
+	timeout, diags := data.Timeouts.Create(ctx, defaultHarnessCreateTimeout)
 	resp.Diagnostics.Append(diags...)
 
 	ctx, cancel := context.WithTimeout(ctx, timeout)

--- a/internal/provider/harness_docker_resource.go
+++ b/internal/provider/harness_docker_resource.go
@@ -100,7 +100,7 @@ func (r *HarnessDockerResource) Create(ctx context.Context, req resource.CreateR
 		return
 	}
 
-	timeout, diags := data.Timeouts.Create(ctx, defaultHarnessK3sCreateTimeout)
+	timeout, diags := data.Timeouts.Create(ctx, defaultHarnessCreateTimeout)
 	resp.Diagnostics.Append(diags...)
 
 	ctx, cancel := context.WithTimeout(ctx, timeout)
@@ -336,20 +336,6 @@ func addDockerResourceSchemaAttributes() map[string]schema.Attribute {
 								Sensitive: true,
 							},
 							"auth": schema.StringAttribute{
-								Optional: true,
-							},
-						},
-					},
-					"tls": schema.SingleNestedAttribute{
-						Optional: true,
-						Attributes: map[string]schema.Attribute{
-							"cert_file": schema.StringAttribute{
-								Optional: true,
-							},
-							"key_file": schema.StringAttribute{
-								Optional: true,
-							},
-							"ca_file": schema.StringAttribute{
 								Optional: true,
 							},
 						},

--- a/internal/provider/harness_docker_resource_test.go
+++ b/internal/provider/harness_docker_resource_test.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -67,6 +68,46 @@ resource "imagetest_feature" "test" {
     {
       name = "Echo"
       cmd = "echo $foo $bar $baz | diff - <(echo foo bar baz) > /dev/null"
+    },
+  ]
+}
+        `,
+				Check: resource.ComposeAggregateTestCheckFunc(),
+			},
+		},
+		"with auth config in the harness": {
+			{
+				ExpectNonEmptyPlan: true,
+				ExpectError:        regexp.MustCompile(`repository\sdoes\snot\sexist\sor\smay\srequire\s'docker\slogin'`),
+				Config: `
+data "imagetest_inventory" "this" {}
+
+resource "imagetest_harness_docker" "test" {
+  name = "test"
+  inventory = data.imagetest_inventory.this
+  envs = {
+    bar = "bar"
+    baz = "baz"
+  }
+
+  registries = {
+    "registry.local": {
+      auth = {
+        username = "testuser"
+        password = "testpass"
+      }
+    }
+  }
+}
+
+resource "imagetest_feature" "test" {
+  name = "Simple Docker based test"
+  description = "Test that we can spin up a container and run some steps with environment variables"
+  harness = imagetest_harness_docker.test
+  steps = [
+    {
+      name = "docker run"
+      cmd = "docker run --rm registry.local/test-image"
     },
   ]
 }
@@ -166,7 +207,7 @@ resource "imagetest_feature" "test" {
   harness = imagetest_harness_docker.test
   steps = [
     {
-      name = "Echo"
+      name = "docker run"
       cmd = "docker run --rm hello-world"
     },
   ]
@@ -200,7 +241,7 @@ resource "imagetest_feature" "test" {
   harness = imagetest_harness_docker.test
   steps = [
     {
-      name = "Echo"
+      name = "docker run"
       cmd = "docker run --rm hello-world"
     },
   ]
@@ -243,7 +284,7 @@ resource "imagetest_feature" "test" {
 
   steps = [
     {
-      name = "Echo"
+      name = "docker run"
       cmd = "docker run --rm hello-world"
     },
   ]
@@ -277,7 +318,7 @@ resource "imagetest_feature" "test" {
 
   steps = [
     {
-      name = "Echo"
+      name = "docker run"
       cmd = "docker run --rm hello-world"
     },
   ]

--- a/internal/provider/harness_docker_resource_test.go
+++ b/internal/provider/harness_docker_resource_test.go
@@ -78,7 +78,7 @@ resource "imagetest_feature" "test" {
 		"with auth config in the harness": {
 			{
 				ExpectNonEmptyPlan: true,
-				ExpectError:        regexp.MustCompile(`repository\sdoes\snot\sexist\sor\smay\srequire\s'docker\slogin'`),
+				ExpectError:        regexp.MustCompile(`Error\sresponse\sfrom\sdaemon`),
 				Config: `
 data "imagetest_inventory" "this" {}
 

--- a/internal/provider/harness_k3s_resource.go
+++ b/internal/provider/harness_k3s_resource.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"time"
 
 	"github.com/chainguard-dev/terraform-provider-imagetest/internal/containers/provider"
 	"github.com/chainguard-dev/terraform-provider-imagetest/internal/harnesses/k3s"
@@ -22,10 +21,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
-)
-
-const (
-	defaultHarnessK3sCreateTimeout = 5 * time.Minute
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.
@@ -114,7 +109,7 @@ func (r *HarnessK3sResource) Create(ctx context.Context, req resource.CreateRequ
 		return
 	}
 
-	timeout, diags := data.Timeouts.Create(ctx, defaultHarnessK3sCreateTimeout)
+	timeout, diags := data.Timeouts.Create(ctx, defaultHarnessCreateTimeout)
 	resp.Diagnostics.Append(diags...)
 
 	ctx, cancel := context.WithTimeout(ctx, timeout)


### PR DESCRIPTION
Remove the unused TLS field from the harness definition schema so it doesn't error out when specifying the auth directly on the harness object.

Extra: some refactorings around name and usage of timeouts.