### PR TITLE
Upgrade to new goreleaser-action, with non-deprecated falgs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,10 +39,10 @@ jobs:
         with:
           gpg_private_key: ${{ steps.secrets.outputs.token }}
 
-      - uses: goreleaser/goreleaser-action@7ec5c2b0c6cdda6e8bbb49444bc797dd33d74dd8 # v5.0.0
+      - uses: goreleaser/goreleaser-action@v6.0.0
         with:
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Signed-off-by: Dimitri John Ledkov <dimitri.ledkov@chainguard.dev>
