### PR TITLE
change harness failures to a warning

### DIFF
--- a/internal/provider/feature_resource.go
+++ b/internal/provider/feature_resource.go
@@ -304,7 +304,7 @@ func (r *FeatureResource) Create(ctx context.Context, req resource.CreateRequest
 			}
 
 			if err := harness.Destroy(ctx); err != nil {
-				resp.Diagnostics.AddError("failed to destroy harness", err.Error())
+				resp.Diagnostics.AddWarning("failed to destroy harness", err.Error())
 				return
 			}
 		}


### PR DESCRIPTION
the consequences of a harness failing to destroy have no bearing on the success of the feature/test, and are almost always flakes, so rather than throw red signals on flakes, simply warn