### PR TITLE
k3s: add support for port-forwarding with IMAGETEST_PORT_FORWARDS

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -24,4 +24,4 @@ linters:
     - unconvert
     - unparam
     - unused
-    - vet
+    - govet

--- a/internal/containers/provider/docker.go
+++ b/internal/containers/provider/docker.go
@@ -23,6 +23,7 @@ import (
 	"github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/pkg/stdcopy"
+	"github.com/docker/go-connections/nat"
 	"github.com/google/go-containerregistry/pkg/authn"
 )
 
@@ -51,6 +52,10 @@ type DockerRequest struct {
 	// ManagedVolumes is the list of volumes that should be torn down when the
 	// provider finishes execution
 	ManagedVolumes []mount.Mount
+	// PortBindings is the list of port bindings to apply to the container
+	// when it is created. The key is the port to bind to on the host, and the
+	// value is the port to bind to on the container.
+	PortBindings map[nat.Port][]nat.PortBinding
 }
 
 type DockerNetworkRequest struct {
@@ -180,6 +185,7 @@ func (p *DockerProvider) Start(ctx context.Context) error {
 			// mirroring what's done in Docker CLI: https://github.com/docker/cli/blob/0ad1d55b02910f4b40462c0d01aac2934eb0f061/cli/command/container/update.go#L117
 			NanoCPUs: p.req.Resources.CpuRequest.Value(),
 		},
+		PortBindings: p.req.PortBindings,
 	}
 
 	if err := p.pull(ctx); err != nil {

--- a/internal/containers/provider/docker.go
+++ b/internal/containers/provider/docker.go
@@ -53,9 +53,11 @@ type DockerRequest struct {
 	// provider finishes execution
 	ManagedVolumes []mount.Mount
 	// PortBindings is the list of port bindings to apply to the container
-	// when it is created. The key is the port to bind to on the host, and the
-	// value is the port to bind to on the container.
-	PortBindings map[nat.Port][]nat.PortBinding
+	// when it is created. It is a collection of PortBinding indexed by Port.
+	PortBindings nat.PortMap
+	// ExposedPorts is the list of ports that should be exposed by the container
+	// when it is created. It is a collection of structs indexed by Port.
+	ExposedPorts nat.PortSet
 }
 
 type DockerNetworkRequest struct {
@@ -169,6 +171,7 @@ func (p *DockerProvider) Start(ctx context.Context) error {
 		AttachStdout: true,
 		AttachStderr: true,
 		Labels:       p.labels,
+		ExposedPorts: p.req.ExposedPorts,
 	}
 
 	hostConfig := &container.HostConfig{

--- a/internal/harnesses/k3s/k3s.go
+++ b/internal/harnesses/k3s/k3s.go
@@ -96,26 +96,26 @@ func New(id string, cli *provider.DockerClient, opts ...Option) (types.Harness, 
 		},
 	})
 
-    if len(harnessOptions.PortMappings) > 0 {
-            portMappings := make([]string, 0)
-	    for _, mapping := range harnessOptions.PortMappings {
-		    // If no `:` provided, assume the target port will be same as the local port
-		    if !strings.Contains(mapping, ":") {
-			    mapping = mapping + ":" + mapping
-		    }
-		
-		    portMappings = append(portMappings, mapping)
-	    }
-	
-	    exposedPorts, portBindings, err := nat.ParsePortSpecs(portMappings)
-	    if err != nil {
-	        // error handling here
-	    }
+	if len(harnessOptions.PortMappings) > 0 {
+		portMappings := make([]string, 0)
+		for _, mapping := range harnessOptions.PortMappings {
+			// If no `:` provided, assume the target port will be same as the local port
+			if !strings.Contains(mapping, ":") {
+				mapping = mapping + ":" + mapping
+			}
 
-	    harnessOptions.Sandbox.PortBindings = portBindings
-	    harnessOptions.Sandbox.ExposedPorts = exposedPorts
+			portMappings = append(portMappings, mapping)
+		}
+
+		exposedPorts, portBindings, err := nat.ParsePortSpecs(portMappings)
+		if err != nil {
+			return nil, fmt.Errorf("parsing port specs: %w", err)
+		}
+
+		harnessOptions.Sandbox.PortBindings = portBindings
+		harnessOptions.Sandbox.ExposedPorts = exposedPorts
 	}
-    }
+
 	k3s := &k3s{
 		Base: base.New(),
 		id:   id,

--- a/internal/harnesses/k3s/opts.go
+++ b/internal/harnesses/k3s/opts.go
@@ -26,6 +26,8 @@ type Opt struct {
 	Sandbox             provider.DockerRequest
 	ContainerVolumeName string
 	Snapshotter         K3sContainerSnapshotter
+
+	PortMappings []string
 }
 
 // Hooks are the hooks that can be run at various stages of the k3s lifecycle.
@@ -240,6 +242,13 @@ func WithContainerVolumeName(volumeName string) Option {
 func WithHooks(hooks Hooks) Option {
 	return func(opt *Opt) error {
 		opt.Hooks = hooks
+		return nil
+	}
+}
+
+func WithPortMappings(mappings []string) Option {
+	return func(opt *Opt) error {
+		opt.PortMappings = append(opt.PortMappings, mappings...)
 		return nil
 	}
 }

--- a/internal/provider/harness_k3s_resource.go
+++ b/internal/provider/harness_k3s_resource.go
@@ -278,6 +278,7 @@ func (r *HarnessK3sResource) Create(ctx context.Context, req resource.CreateRequ
 	}
 
 	kopts = append(kopts, k3s.WithContainerVolumeName(configVolumeName))
+	kopts = append(kopts, k3s.WithPortMappings(r.store.PortForwards()))
 
 	harness, err := k3s.New(id, r.store.cli, kopts...)
 	if err != nil {

--- a/internal/provider/store.go
+++ b/internal/provider/store.go
@@ -8,6 +8,7 @@ import (
 	"math/big"
 	"os"
 	"path"
+	"strings"
 	"sync"
 
 	"github.com/chainguard-dev/clog"
@@ -116,6 +117,12 @@ func (s *ProviderStore) Logger(ctx context.Context, inv InventoryDataSourceModel
 func (s *ProviderStore) SkipTeardown() bool {
 	v := os.Getenv("IMAGETEST_SKIP_TEARDOWN")
 	return v != ""
+}
+
+// PortForwards returns the IMAGETEST_PORT_FORWARDS environment variable.
+func (s *ProviderStore) PortForwards() []string {
+	v := os.Getenv("IMAGETEST_PORT_FORWARDS")
+	return strings.Split(v, ",")
 }
 
 func (s *ProviderStore) EnableDebugLogging() bool {

--- a/internal/provider/store.go
+++ b/internal/provider/store.go
@@ -121,7 +121,10 @@ func (s *ProviderStore) SkipTeardown() bool {
 
 // PortForwards returns the IMAGETEST_PORT_FORWARDS environment variable.
 func (s *ProviderStore) PortForwards() []string {
-	v := os.Getenv("IMAGETEST_PORT_FORWARDS")
+	v, ok := os.LookupEnv("IMAGETEST_PORT_FORWARDS")
+	if !ok || "" == v {
+	    return nil
+	}
 	return strings.Split(v, ",")
 }
 

--- a/internal/provider/store.go
+++ b/internal/provider/store.go
@@ -123,7 +123,7 @@ func (s *ProviderStore) SkipTeardown() bool {
 func (s *ProviderStore) PortForwards() []string {
 	v, ok := os.LookupEnv("IMAGETEST_PORT_FORWARDS")
 	if !ok || "" == v {
-	    return nil
+		return nil
 	}
 	return strings.Split(v, ",")
 }


### PR DESCRIPTION
This PR introduces the capability to specify multiple port mappings for the k3s harness running as containers. This allows users to define local-to-remote port forwarding in the format using the brand-new introduced `$IMAGETEST_PORT_FORWARDS` environment variable with format of `LOCAL_PORT:DEST_PORT`, enabling access to ports running inside the Docker container from the local environment.

If `:` not provided, the target port will be same as the local port.

**Example:**
```
export IMAGETEST_PORT_FORWARDS="8065,9090:57650"
```