### PR TITLE
Add some more resources to clusterrole

### DIFF
--- a/internal/harnesses/remote/k8s.go
+++ b/internal/harnesses/remote/k8s.go
@@ -189,7 +189,7 @@ func (h *k8s) createRbacResources(ctx context.Context, namespaceName string, com
 			{
 				Verbs:     []string{"get", "create", "list", "delete", "watch"},
 				APIGroups: []string{""},
-				Resources: []string{"pods", "configmaps", "secrets", "serviceaccounts", "services", "namespaces"},
+				Resources: []string{"pods", "configmaps", "secrets", "serviceaccounts", "services", "namespaces", "persistentvolumeclaims", "events"},
 			},
 			{
 				Verbs:     []string{"get", "create", "list", "delete", "watch"},
@@ -205,6 +205,10 @@ func (h *k8s) createRbacResources(ctx context.Context, namespaceName string, com
 				Verbs:     []string{"get", "create", "list", "delete", "watch"},
 				APIGroups: []string{"storage"},
 				Resources: []string{"jobs", "cronjobs"},
+			}, {
+				Verbs:     []string{"get", "create", "list", "delete", "watch"},
+				APIGroups: []string{"networking.k8s.io"},
+				Resources: []string{"ingresses"},
 			},
 		},
 	}, metav1.CreateOptions{})


### PR DESCRIPTION
I was trying out the remote harness and tried to convert an existing k3s harness test to the remote one just to learn more about how it worked. It needed some extra cluster permissions to get the test running, this PR includes those additional roles in case they're needed elsewhere. 