### PR TITLE
support update/destroy lifecycles with state

### DIFF
--- a/internal/provider/feature_resource_test.go
+++ b/internal/provider/feature_resource_test.go
@@ -116,3 +116,65 @@ resource "imagetest_feature" "test" {
 		},
 	})
 }
+
+// TestAccFeatureResourceUpdate tests that this provider works with Update()
+// requests as well. This also hits the base_harness path, where all the
+// harness update logic is located.
+func TestAccFeatureResourceUpdate(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create testing
+			{
+				ExpectNonEmptyPlan: true,
+				Destroy:            false,
+				Config: `
+data "imagetest_inventory" "this" {}
+
+resource "imagetest_harness_container" "test" {
+  name = "test"
+  inventory = data.imagetest_inventory.this
+}
+
+resource "imagetest_feature" "test" {
+  name = "update"
+  description = "Test whether creates work"
+  harness = imagetest_harness_container.test
+  steps = [
+    {
+      name = "something"
+      cmd = "echo do something"
+    },
+  ]
+}
+`,
+			},
+			// Update testing
+			{
+				ExpectNonEmptyPlan: true,
+				Destroy:            false,
+				Config: `
+data "imagetest_inventory" "this" {}
+
+resource "imagetest_harness_container" "test" {
+  name = "test"
+  inventory = data.imagetest_inventory.this
+}
+
+resource "imagetest_feature" "test" {
+  name = "update"
+  description = "Test whether updates work"
+  harness = imagetest_harness_container.test
+  steps = [
+    {
+      name = "something"
+      cmd = "echo do another something"
+    },
+  ]
+}
+`,
+			},
+		},
+	})
+}


### PR DESCRIPTION
Previously, if we had any pre-existing state (ie anything but `inmem` backend was used), this provider wouldn't work because we weren't accounting for the `Update()` rpc's or the legs where state isn't nil. The provider would fail with pretty cryptic inventory errors.

This uses the refactoring done in #143 and #145 to support the `Update()` rpc, as well as handle the `Destroy()` rpc by short-circuiting the `ModifyPlan` when we're in a destroy.

We don't need this yet, but will if/when we move to opentofu and start using state.

Importantly, this doesn't actually change the logic if state exists, it simply makes the provider work. All the logic for a `Update()` is the same as it would be for a `Create()`, given our use case, "state" in this sense just means a state file, no existing state is preserved from one run to another.