### PR TITLE
modify startup scripts to call kubectl directly

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -84,7 +84,17 @@ jobs:
   images-test:
     name: Run imagetest against images
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        # Pick small, reliable image tests that hit the various harnesses. Run
+        # these in shards because we're using undersized runners compared to
+        # upstream and will easily hit disk pressure.
+        images:
+          - calico
+          - cilium
+          - jre
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
@@ -123,40 +133,4 @@ jobs:
           direct {}
           EOF
 
-          # # Run a presubmit scoped global imagetest provider override that
-          # # configures the k3s harnesses for the presubmit scoped local registry.
-          # # This _could_ be in the `main.tf` with some conditionals, but since
-          # # this is striclty for presubmit we take this approach to keep things
-          # # simpler.
-          # cat >> main_override.tf <<EOF
-          # provider "imagetest" {
-          #   log = {
-          #     file = {
-          #       directory = "imagetest-logs"
-          #     }
-          #   }
-          #   harnesses = {
-          #     k3s = {
-          #       networks = {
-          #         // wire in k3d's default network where the registry lives
-          #         "k3d-default" = { name = "k3d-k3s-default" }
-          #       }
-          #       registries = {
-          #         # Mirror the var.target_repository host registry to the local registry.
-          #         # This ensures the images that are pushed from the host registry are
-          #         # mirrored to the internal hostname:port registry.
-          #         "registry.local:5000" = {
-          #           mirror = { endpoints = ["http://registry.local:5000"] }
-          #         }
-          #       }
-          #     }
-          #   }
-          # }
-          # EOF
-
-          targets=""
-          for image in calico cert-manager spire istio jre; do
-            targets+=' -target='module."${image}"''
-          done
-
-          terraform apply ${targets} -auto-approve --parallelism=$(nproc)
+          terraform apply -target='module.${{ matrix.images }}' -auto-approve --parallelism=$(nproc)

--- a/internal/harness/k3s/k3s.go
+++ b/internal/harness/k3s/k3s.go
@@ -162,7 +162,7 @@ func (h *k3s) Create(ctx context.Context) error {
 				},
 			},
 			HealthCheck: &container.HealthConfig{
-				Test:          []string{"CMD", "/bin/sh", "-c", "k3s kubectl get --raw='/healthz'"},
+				Test:          []string{"CMD", "/bin/sh", "-c", "kubectl get --raw='/healthz'"},
 				Interval:      1 * time.Second,
 				Timeout:       5 * time.Second,
 				Retries:       5,
@@ -184,7 +184,7 @@ func (h *k3s) Create(ctx context.Context) error {
 		// Modify the kubeconfig to use the containers external hostname, this
 		// makes it accessible from the host and any network attached container
 		if err := resp.Run(ctx, harness.Command{
-			Args: fmt.Sprintf("KUBECONFIG=/etc/rancher/k3s/k3s.yaml k3s kubectl config set-cluster default --server https://%[1]s:6443 > /dev/null", resp.Name),
+			Args: fmt.Sprintf("KUBECONFIG=/etc/rancher/k3s/k3s.yaml kubectl config set-cluster default --server https://%[1]s:6443 > /dev/null", resp.Name),
 		}); err != nil {
 			return fmt.Errorf("setting cluster name: %w", err)
 		}
@@ -192,7 +192,7 @@ func (h *k3s) Create(ctx context.Context) error {
 		if h.HostKubeconfigPath != "" {
 			var kr bytes.Buffer
 			if err := resp.Run(ctx, harness.Command{
-				Args:   "KUBECONFIG=/etc/rancher/k3s/k3s.yaml k3s kubectl config view --raw > /dev/null",
+				Args:   "KUBECONFIG=/etc/rancher/k3s/k3s.yaml kubectl config view --raw > /dev/null",
 				Stdout: &kr,
 			}); err != nil {
 				return fmt.Errorf("writing kubeconfig to host: %w", err)

--- a/internal/provider/testdata/pterraform/local-k8s/main.tf
+++ b/internal/provider/testdata/pterraform/local-k8s/main.tf
@@ -6,11 +6,9 @@ port=$(shuf -i 1024-65535 -n 1)
 docker run --name ${self.id} -l 'dev.chainguard.imagetest=true' -d --privileged -p $port:$port cgr.dev/chainguard/k3s:latest server --disable traefik --disable metrics-server --https-listen-port $port --write-kubeconfig-mode 0644 --tls-san ${self.id} --https-listen-port $port
 
 # Wait for the k3s cluster to be ready
-until docker exec ${self.id} sh -c "k3s kubectl get --raw='/healthz'"; do
+until docker exec ${self.id} sh -c "kubectl get --raw='/healthz'"; do
   sleep 1
 done
-
-# docker exec ${self.id} k3s kubectl config set-cluster default --server https://localhost:$port > /dev/null
 
 docker exec ${self.id} cat /etc/rancher/k3s/k3s.yaml > foo.yaml
 EOF


### PR DESCRIPTION
[this](https://github.com/wolfi-dev/os/pull/26136) PR modified the image to be more like upstream, which means it also broke support for calling `kubectl` via `k3s kubectl`. within the image, `kubectl` is now directly invoked 🤦 

also rolling in #157 to this PR for better proof that this fix works as intended