### PR TITLE
plumb through command logging

### DIFF
--- a/internal/features/features.go
+++ b/internal/features/features.go
@@ -131,7 +131,7 @@ func (f *Feature) Test(ctx context.Context) error {
 	afters := func() {
 		for _, after := range f.afters {
 			if err := after.Fn(ctx); err != nil {
-				collectError(err)
+				collectError(fmt.Errorf("after step '%s' failed: %v", after.Name, err))
 				// Don't continue if we error
 				break
 			}
@@ -140,7 +140,7 @@ func (f *Feature) Test(ctx context.Context) error {
 
 	for _, before := range f.befores {
 		if err := before.Fn(ctx); err != nil {
-			collectError(err)
+			collectError(fmt.Errorf("before step '%s' failed: %v", before.Name, err))
 			afters()
 			return collectedError
 		}
@@ -148,7 +148,7 @@ func (f *Feature) Test(ctx context.Context) error {
 
 	for _, assessment := range f.assessments {
 		if err := assessment.Fn(ctx); err != nil {
-			collectError(err)
+			collectError(fmt.Errorf("assessment step '%s' failed: %v", assessment.Name, err))
 			afters()
 			return collectedError
 		}

--- a/internal/features/features_test.go
+++ b/internal/features/features_test.go
@@ -70,7 +70,7 @@ func TestFeature(t *testing.T) {
 				}
 			},
 			wantout: "after ",
-			wanterr: "before step error",
+			wanterr: "before step 'Before Step' failed: before step error",
 		},
 		{
 			name: "ShortCircuitAssessmentFailure",
@@ -94,10 +94,13 @@ func TestFeature(t *testing.T) {
 					{Name: "After Step 2", Fn: func(ctx context.Context) error {
 						return errors.New("after step error")
 					}},
+					{Name: "After Step 3", Fn: func(ctx context.Context) error {
+						return errors.New("ignored")
+					}},
 				}
 			},
 			wantout: "assessment after ",
-			wanterr: "assessment step error; after step error",
+			wanterr: "assessment step 'Assessment Step' failed: assessment step error; after step 'After Step 2' failed: after step error",
 		},
 		{
 			name: "Retry",
@@ -121,7 +124,7 @@ func TestFeature(t *testing.T) {
 			},
 			wantout: "foo foo foo ",
 			// This will always fail, so just grep on the error message
-			wanterr: "timed out waiting for the condition",
+			wanterr: "assessment step 'Assessment Step' failed: timed out waiting for the condition",
 		},
 	}
 

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -25,6 +25,11 @@ func Error(ctx context.Context, msg string, args ...any) {
 	log(ctx, clog.FromContext(ctx), slog.LevelError, msg, args...)
 }
 
+func With(ctx context.Context, args ...any) context.Context {
+	logger := clog.FromContext(ctx).With(args...)
+	return clog.WithLogger(ctx, logger)
+}
+
 func log(ctx context.Context, l *clog.Logger, level slog.Level, msg string, args ...any) {
 	if !l.Enabled(ctx, level) {
 		return

--- a/internal/provider/store.go
+++ b/internal/provider/store.go
@@ -73,43 +73,41 @@ func (s *ProviderStore) Inventory(data InventoryDataSourceModel) inventory.Inven
 
 // Logger initializes the context logger for the given inventory.
 func (s *ProviderStore) Logger(ctx context.Context, inv InventoryDataSourceModel, withs ...any) (context.Context, error) {
-	if s.providerResourceData.Log == nil {
-		return ctx, nil
-	}
-
-	if lf := s.providerResourceData.Log.File; lf != nil {
-		ihash, err := s.Encode(inv.Seed.ValueString())
-		if err != nil {
-			return ctx, fmt.Errorf("failed to encode inventory hash: %w", err)
-		}
-		logpath := fmt.Sprintf("%s.log", ihash)
-
-		if dir := lf.Directory.ValueString(); dir != "" {
-			if err := os.MkdirAll(dir, os.ModePerm); err != nil {
-				return ctx, fmt.Errorf("failed to create log directory: %w", err)
+	if s.providerResourceData.Log != nil {
+		if lf := s.providerResourceData.Log.File; lf != nil {
+			ihash, err := s.Encode(inv.Seed.ValueString())
+			if err != nil {
+				return ctx, fmt.Errorf("failed to encode inventory hash: %w", err)
 			}
-			logpath = path.Join(dir, logpath)
+			logpath := fmt.Sprintf("%s.log", ihash)
+
+			if dir := lf.Directory.ValueString(); dir != "" {
+				if err := os.MkdirAll(dir, os.ModePerm); err != nil {
+					return ctx, fmt.Errorf("failed to create log directory: %w", err)
+				}
+				logpath = path.Join(dir, logpath)
+			}
+
+			f, err := os.OpenFile(logpath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+			if err != nil {
+				return ctx, fmt.Errorf("failed to create logfile: %w", err)
+			}
+
+			var fhandler slog.Handler
+			switch lf.Format.ValueString() {
+			case "text":
+				fhandler = slog.NewTextHandler(f, &slog.HandlerOptions{})
+			default:
+				fhandler = slog.NewJSONHandler(f, &slog.HandlerOptions{})
+			}
+
+			logger := clog.New(slogmulti.Fanout(
+				&ilog.TFHandler{},
+				fhandler,
+			)).With("inventory", ihash)
+
+			ctx = clog.WithLogger(ctx, logger)
 		}
-
-		f, err := os.OpenFile(logpath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
-		if err != nil {
-			return ctx, fmt.Errorf("failed to create logfile: %w", err)
-		}
-
-		var fhandler slog.Handler
-		switch lf.Format.ValueString() {
-		case "text":
-			fhandler = slog.NewTextHandler(f, &slog.HandlerOptions{})
-		default:
-			fhandler = slog.NewJSONHandler(f, &slog.HandlerOptions{})
-		}
-
-		logger := clog.New(slogmulti.Fanout(
-			&ilog.TFHandler{},
-			fhandler,
-		)).With("inventory", ihash)
-
-		ctx = clog.WithLogger(ctx, logger)
 	}
 
 	logger := clog.FromContext(ctx).With(withs...)


### PR DESCRIPTION
plumbs through some better step logging to both the resulting diagnostics (the feature name and step error), as well as log stdout/stderr for each step command.

also fixes an existing bug where the logger was not being properly propagated through the context