### PR TITLE
use a slightly more robust health check

### DIFF
--- a/internal/harness/k3s/k3s.go
+++ b/internal/harness/k3s/k3s.go
@@ -162,7 +162,7 @@ func (h *k3s) Create(ctx context.Context) error {
 				},
 			},
 			HealthCheck: &container.HealthConfig{
-				Test:          []string{"CMD", "/bin/sh", "-c", "kubectl get --raw='/healthz'"},
+				Test:          []string{"CMD", "/bin/sh", "-c", "kubectl get --raw='/readyz' && kubectl get sa default -n default"},
 				Interval:      1 * time.Second,
 				Timeout:       5 * time.Second,
 				Retries:       5,


### PR DESCRIPTION
use `/readyz` instead of the deprecated `/healthz` for validating the api server. and then use a primitive check on the `default` service account to indicate the cluster is ready for scheduling.

this isn't perfect, but its simple enough to fit within docker's healthcheck, and will protect against the most common race flakes we're seeing where scheduling is happening before the default service account is ready