### PR TITLE
expose k3s to the host and rejigger sandbox connection

### DIFF
--- a/internal/docker/network.go
+++ b/internal/docker/network.go
@@ -27,7 +27,7 @@ type NetworkAttachment struct {
 	ID   string
 }
 
-func (d *docker) CreateNetwork(ctx context.Context, req *NetworkRequest) (*NetworkAttachment, error) {
+func (d *Client) CreateNetwork(ctx context.Context, req *NetworkRequest) (*NetworkAttachment, error) {
 	if req.Name == "" {
 		req.Name = uuid.New().String()
 	}
@@ -77,7 +77,7 @@ func (d *docker) CreateNetwork(ctx context.Context, req *NetworkRequest) (*Netwo
 	}, nil
 }
 
-func (d *docker) RemoveNetwork(ctx context.Context, nw *NetworkAttachment) error {
+func (d *Client) RemoveNetwork(ctx context.Context, nw *NetworkAttachment) error {
 	return d.cli.NetworkRemove(ctx, nw.ID)
 }
 

--- a/internal/docker/opts.go
+++ b/internal/docker/opts.go
@@ -4,17 +4,17 @@ import (
 	"github.com/docker/docker/client"
 )
 
-type Option func(*docker) error
+type Option func(*Client) error
 
 func WithClient(cli *client.Client) Option {
-	return func(d *docker) error {
+	return func(d *Client) error {
 		d.cli = cli
 		return nil
 	}
 }
 
 func WithClientOpts(opts ...client.Opt) Option {
-	return func(d *docker) error {
+	return func(d *Client) error {
 		if opts == nil {
 			return nil
 		}

--- a/internal/docker/volume.go
+++ b/internal/docker/volume.go
@@ -15,7 +15,7 @@ type VolumeRequest struct {
 	Labels map[string]string
 }
 
-func (d *docker) CreateVolume(ctx context.Context, req *VolumeRequest) (mount.Mount, error) {
+func (d *Client) CreateVolume(ctx context.Context, req *VolumeRequest) (mount.Mount, error) {
 	if req.Labels == nil {
 		req.Labels = make(map[string]string)
 	}
@@ -38,6 +38,6 @@ func (d *docker) CreateVolume(ctx context.Context, req *VolumeRequest) (mount.Mo
 	}, nil
 }
 
-func (d *docker) RemoveVolume(ctx context.Context, v mount.Mount) error {
+func (d *Client) RemoveVolume(ctx context.Context, v mount.Mount) error {
 	return d.cli.VolumeRemove(ctx, v.Source, true)
 }

--- a/internal/harness/k3s/options.go
+++ b/internal/harness/k3s/options.go
@@ -15,18 +15,19 @@ import (
 type Option func(*k3s) error
 
 type serviceConfig struct {
-	Name          string
-	Ref           name.Reference
-	Traefik       bool
-	Cni           bool
-	MetricsServer bool
-	NetworkPolicy bool
-	KubeletConfig string
-	Snapshotter   Snapshotter
-	Registries    map[string]*RegistryConfig
-	Mirrors       map[string]*MirrorConfig
-	Resources     docker.ResourcesRequest
-	Networks      []docker.NetworkAttachment // A list of existing networks names (or network aliases) to attach the harness containers to.
+	Name            string
+	Ref             name.Reference
+	Traefik         bool
+	Cni             bool
+	MetricsServer   bool
+	NetworkPolicy   bool
+	HttpsListenPort int
+	KubeletConfig   string
+	Snapshotter     Snapshotter
+	Registries      map[string]*RegistryConfig
+	Mirrors         map[string]*MirrorConfig
+	Resources       docker.ResourcesRequest
+	Networks        []docker.NetworkAttachment // A list of existing networks names (or network aliases) to attach the harness containers to.
 }
 
 type RegistryConfig struct {
@@ -215,20 +216,6 @@ func WithKubeletConfig(kubeletConfig string) Option {
 	}
 }
 
-func WithHostPort(port int) Option {
-	return func(o *k3s) error {
-		o.HostPort = port
-		return nil
-	}
-}
-
-func WithHostKubeconfigPath(path string) Option {
-	return func(o *k3s) error {
-		o.HostKubeconfigPath = path
-		return nil
-	}
-}
-
 func WithNetworks(networks ...docker.NetworkAttachment) Option {
 	return func(opt *k3s) error {
 		if opt.Service.Networks == nil {
@@ -258,16 +245,6 @@ func WithSandboxMounts(mounts ...mount.Mount) Option {
 			opt.Sandbox.Mounts = []mount.Mount{}
 		}
 		opt.Sandbox.Mounts = append(opt.Sandbox.Mounts, mounts...)
-		return nil
-	}
-}
-
-func WithSandboxNetworks(networks ...docker.NetworkAttachment) Option {
-	return func(opt *k3s) error {
-		if opt.Sandbox.Networks == nil {
-			opt.Sandbox.Networks = make([]docker.NetworkAttachment, 0)
-		}
-		opt.Sandbox.Networks = append(opt.Sandbox.Networks, networks...)
 		return nil
 	}
 }


### PR DESCRIPTION
this PR is another prep PR for running the test sandboxes within the actual harness cluster.

it:

- exposes the k3s cluster apiserver to the host
- stops using a volume mount for the sandbox container's kubeconfig

in future PRs the apiserver will be used by the provider to do more interesting things, this mostly sets the stage in a migration friendly way.

this also sneaks in an `Audit` policy config to the k3s harness, which for now is harmless, but in the future will be used by the provider to discover the events that happen on the harness