### PR TITLE
use magicdns for harnesses using docker

### DIFF
--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -50,6 +50,7 @@ type Request struct {
 	HealthCheck  *container.HealthConfig
 	Contents     []*Content
 	PortBindings nat.PortMap
+	ExtraHosts   []string
 }
 
 type ResourcesRequest struct {
@@ -138,6 +139,7 @@ func (d *Client) Start(ctx context.Context, req *Request) (*Response, error) {
 			ExposedPorts: exposedPorts,
 		},
 		&container.HostConfig{
+			ExtraHosts: req.ExtraHosts,
 			Privileged: req.Privileged,
 			RestartPolicy: container.RestartPolicy{
 				// Never restart

--- a/internal/harness/docker/docker.go
+++ b/internal/harness/docker/docker.go
@@ -105,6 +105,9 @@ func (h *docker) Create(ctx context.Context) error {
 		Contents: []*client.Content{
 			client.NewContentFromString(string(dockerconfigjson), "/root/.docker/config.json"),
 		},
+		ExtraHosts: []string{
+			"host.docker.internal:host-gateway",
+		},
 	})
 	if err != nil {
 		return fmt.Errorf("starting container: %w", err)

--- a/internal/harness/k3s/k3s.go
+++ b/internal/harness/k3s/k3s.go
@@ -70,6 +70,9 @@ func New(opts ...Option) (*k3s, error) {
 				"KUBECONFIG=/k3s-config/k3s.yaml",
 			},
 			Networks: make([]docker.NetworkAttachment, 0),
+			ExtraHosts: []string{
+				"host.docker.internal:host-gateway",
+			},
 		},
 		stack: harness.NewStack(),
 	}
@@ -198,6 +201,9 @@ rules:
 		},
 		Contents:  contents,
 		Resources: h.Service.Resources,
+		ExtraHosts: []string{
+			"host.docker.internal:host-gateway",
+		},
 	})
 	if err != nil {
 		return nil, fmt.Errorf("starting k3s service: %w", err)


### PR DESCRIPTION
hardcode the equivalent of an: `--add-host=host.docker.internal:host-gateway` to containers that `imagetest` spins up.

this means we can pretty much ~always assume we can access containers the same way we would from the host within containers without needing all the network configuration that such a pita for the user to configure. in layman's terms, this means no more need for specifying `networks` when dealing with local registries 

as far as I can tell, there's no downside to this on daemons > 20.04, which is over a year old at this point.

https://docs.docker.com/desktop/networking/#i-want-to-connect-from-a-container-to-a-service-on-the-host