### PR TITLE
plumb through combined stdout/stderr to diagnostics

### DIFF
--- a/internal/features/features.go
+++ b/internal/features/features.go
@@ -131,7 +131,7 @@ func (f *Feature) Test(ctx context.Context) error {
 	afters := func() {
 		for _, after := range f.afters {
 			if err := after.Fn(ctx); err != nil {
-				collectError(fmt.Errorf("after step '%s' failed: %v", after.Name, err))
+				collectError(fmt.Errorf("after step '%s' failed:\n%v", after.Name, err))
 				// Don't continue if we error
 				break
 			}
@@ -140,7 +140,7 @@ func (f *Feature) Test(ctx context.Context) error {
 
 	for _, before := range f.befores {
 		if err := before.Fn(ctx); err != nil {
-			collectError(fmt.Errorf("before step '%s' failed: %v", before.Name, err))
+			collectError(fmt.Errorf("before step '%s' failed:\n%v", before.Name, err))
 			afters()
 			return collectedError
 		}
@@ -148,7 +148,7 @@ func (f *Feature) Test(ctx context.Context) error {
 
 	for _, assessment := range f.assessments {
 		if err := assessment.Fn(ctx); err != nil {
-			collectError(fmt.Errorf("assessment step '%s' failed: %v", assessment.Name, err))
+			collectError(fmt.Errorf("assessment step '%s' failed:\n%v", assessment.Name, err))
 			afters()
 			return collectedError
 		}

--- a/internal/features/features_test.go
+++ b/internal/features/features_test.go
@@ -70,7 +70,7 @@ func TestFeature(t *testing.T) {
 				}
 			},
 			wantout: "after ",
-			wanterr: "before step 'Before Step' failed: before step error",
+			wanterr: "before step 'Before Step' failed:\nbefore step error",
 		},
 		{
 			name: "ShortCircuitAssessmentFailure",
@@ -100,7 +100,7 @@ func TestFeature(t *testing.T) {
 				}
 			},
 			wantout: "assessment after ",
-			wanterr: "assessment step 'Assessment Step' failed: assessment step error; after step 'After Step 2' failed: after step error",
+			wanterr: "assessment step 'Assessment Step' failed:\nassessment step error; after step 'After Step 2' failed:\nafter step error",
 		},
 		{
 			name: "Retry",
@@ -124,7 +124,7 @@ func TestFeature(t *testing.T) {
 			},
 			wantout: "foo foo foo ",
 			// This will always fail, so just grep on the error message
-			wanterr: "assessment step 'Assessment Step' failed: timed out waiting for the condition",
+			wanterr: "assessment step 'Assessment Step' failed:\ntimed out waiting for the condition",
 		},
 	}
 

--- a/internal/harness/harness.go
+++ b/internal/harness/harness.go
@@ -25,6 +25,19 @@ func DefaultEntrypoint() []string {
 	return []string{"/bin/sh", "-c"}
 }
 
+type RunError struct {
+	ExitCode int
+	Cmd      string
+	// CombinedOutput is intentional since when something goes wrong, it usually
+	// makes more sense to see the interweaved stdout/stderr since thats how they
+	// appear in a shell.
+	CombinedOutput string
+}
+
+func (e *RunError) Error() string {
+	return fmt.Sprintf("%s\n%s\nexit status %d", e.Cmd, e.CombinedOutput, e.ExitCode)
+}
+
 func DefaultCmd() []string {
 	return []string{"tail -f /dev/null"}
 }


### PR DESCRIPTION
previous:

```
╷
│ Error: failed to test feature: foo
│
│   with imagetest_feature.foo,
│   on main.tf line 24, in resource "imagetest_feature" "foo":
│   24: resource "imagetest_feature" "foo" {
│
│ assessment step 'Sample' failed: running step: command exited with non-zero exit code: 3
│
│ No resources found
│ * URL rejected: Port number was not a decimal number between 0 and 65535
│ * closing connection #-1
│ curl: (3) URL rejected: Port number was not a decimal number between 0 and 65535
│ : No resources found
│ * URL rejected: Port number was not a decimal number between 0 and 65535
│ * closing connection #-1
│ curl: (3) URL rejected: Port number was not a decimal number between 0 and 65535
│
╵
```

new:

```
╷
│ Error: failed to test feature: foo
│
│   with imagetest_feature.foo,
│   on main.tf line 24, in resource "imagetest_feature" "foo":
│   24: resource "imagetest_feature" "foo" {
│
│ assessment step 'Sample' failed:
│ Error executing command (exit code 3)
│
│ Command:
│       apk add curl jq
│
│       kubectl get po -A
│
│       curl -v --fail http://notarealzfhost:81234
│
│ Output:
│       fetch https://packages.wolfi.dev/os/aarch64/APKINDEX.tar.gz
│       (1/3) Installing curl (8.9.1-r3)
│       (2/3) Installing oniguruma (6.9.9-r3)
│       (3/3) Installing jq (1.7.1-r2)
│       OK: 118 MiB in 32 packages
│       No resources found
│       * URL rejected: Port number was not a decimal number between 0 and 65535
│       * closing connection #-1
│       curl: (3) URL rejected: Port number was not a decimal number between 0 and 65535
│
```

This also plumbs through stdout/stderr better to `TF_LOG=info` surfaced log lines