### PR TITLE
docs(readme.md): set correct design document link

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@
 
 A terraform provider for authoring and executing tests using terraform primitives. Designed to work in conjunction with the [Chainguard Images](https://github.com/chainguard-dev/images) project. I would strongly recommend against using it for anything else.
 
-See [examples](./examples) for usages, and [design](./DESIGN.md) for more information about the providers design.
+See [examples](./examples) for usages, and [design](./design.md) for more information about the providers design.


### PR DESCRIPTION
This PR set the correct design document file name in the readme file.