### PR TITLE
ensure we're testing all the things

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,7 +78,7 @@ jobs:
       - run: go mod download
       - env:
           TF_ACC: "1"
-        run: go test -v -cover ./internal/provider/
+        run: go test -v -cover ./...
         timeout-minutes: 10
 
   images-test:


### PR DESCRIPTION
I believe this is leftover from boilerplate land, but we've since expanded far beyond just `./internal/provider`