### PR TITLE
ensure warnings are properly plumbed

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -320,11 +320,11 @@ func (p *ImageTestProvider) Configure(ctx context.Context, req provider.Configur
 		}
 	}
 
-	if v := os.Getenv("IMAGETEST_SKIP_ALL"); v == "true" {
+	if v := os.Getenv("IMAGETEST_SKIP_ALL"); v != "" {
 		data.TestExecution.SkipAll = basetypes.NewBoolValue(true)
 	}
 
-	if v := os.Getenv("IMAGETEST_SKIP_TEARDOWN"); v == "true" {
+	if v := os.Getenv("IMAGETEST_SKIP_TEARDOWN"); v != "" {
 		data.TestExecution.SkipTeardown = basetypes.NewBoolValue(true)
 	}
 


### PR DESCRIPTION
add some code cleanup that accidentally changed some behavior in #198.

1. this sets the `IMAGETEST_SKIP_TEARDOWN` to have the same behavior as before (any value flags it)
2. ensures the terraform `warnings` are properly updated when harnesses are skipped