### PR TITLE
Dood to dind

### DIFF
--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -51,6 +51,7 @@ type Request struct {
 	Contents     []*Content
 	PortBindings nat.PortMap
 	ExtraHosts   []string
+	Volumes      map[string]struct{}
 }
 
 type ResourcesRequest struct {
@@ -137,6 +138,7 @@ func (d *Client) Start(ctx context.Context, req *Request) (*Response, error) {
 			Labels:       d.withDefaultLabels(req.Labels),
 			Healthcheck:  req.HealthCheck,
 			ExposedPorts: exposedPorts,
+			Volumes:      req.Volumes,
 		},
 		&container.HostConfig{
 			ExtraHosts: req.ExtraHosts,

--- a/internal/harness/docker/opts.go
+++ b/internal/harness/docker/opts.go
@@ -9,7 +9,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/name"
 )
 
-type Option func(*docker) error
+type Option func(*dind) error
 
 type VolumeConfig struct {
 	Name   string
@@ -34,21 +34,21 @@ type RegistryTlsConfig struct {
 }
 
 func WithName(name string) Option {
-	return func(opt *docker) error {
+	return func(opt *dind) error {
 		opt.Name = name
 		return nil
 	}
 }
 
 func WithImageRef(ref name.Reference) Option {
-	return func(opt *docker) error {
+	return func(opt *dind) error {
 		opt.ImageRef = ref
 		return nil
 	}
 }
 
 func WithMounts(mounts ...mount.Mount) Option {
-	return func(opt *docker) error {
+	return func(opt *dind) error {
 		if mounts != nil {
 			opt.Mounts = append(opt.Mounts, mounts...)
 		}
@@ -57,14 +57,14 @@ func WithMounts(mounts ...mount.Mount) Option {
 }
 
 func WithNetworks(networks ...client.NetworkAttachment) Option {
-	return func(opt *docker) error {
+	return func(opt *dind) error {
 		opt.Networks = append(opt.Networks, networks...)
 		return nil
 	}
 }
 
 func WithAuthFromStatic(registry, username, password, auth string) Option {
-	return func(opt *docker) error {
+	return func(opt *dind) error {
 		if opt.Registries == nil {
 			opt.Registries = make(map[string]*RegistryConfig)
 		}
@@ -83,7 +83,7 @@ func WithAuthFromStatic(registry, username, password, auth string) Option {
 }
 
 func WithAuthFromKeychain(registry string) Option {
-	return func(opt *docker) error {
+	return func(opt *dind) error {
 		if opt.Registries == nil {
 			opt.Registries = make(map[string]*RegistryConfig)
 		}
@@ -117,7 +117,7 @@ func WithAuthFromKeychain(registry string) Option {
 }
 
 func WithEnvs(env ...string) Option {
-	return func(opt *docker) error {
+	return func(opt *dind) error {
 		if opt.Envs == nil {
 			opt.Envs = make([]string, 0)
 		}
@@ -127,14 +127,14 @@ func WithEnvs(env ...string) Option {
 }
 
 func WithResources(req client.ResourcesRequest) Option {
-	return func(opt *docker) error {
+	return func(opt *dind) error {
 		opt.Resources = req
 		return nil
 	}
 }
 
 func WithVolumes(volumes ...VolumeConfig) Option {
-	return func(opt *docker) error {
+	return func(opt *dind) error {
 		if volumes == nil {
 			return nil
 		}


### PR DESCRIPTION
successor to #181.

this changes the docker harness to instead be a `dind` variant created dynamically with the bundler changes landed in #195.

the docker harness is now a single container thats running its own docker daemon in the background, which ultimately makes the harness "feel" a lot more like a native host docker system, without all the footguns of `dood`.

additionally, this brings the harness entirely within `imagetest`, meaning teardowns properly clean up any containers/networks/resources created within the harness