### PR TITLE
register a secret in the harness cluster

### DIFF
--- a/internal/provider/harness_k3s_resource_test.go
+++ b/internal/provider/harness_k3s_resource_test.go
@@ -245,6 +245,15 @@ resource "imagetest_harness_k3s" "test" {
   name = "test"
   inventory = data.imagetest_inventory.this
 
+  registries = {
+    "foo" = {
+      auth = {
+        username = "testuser"
+        password = "testpass"
+      }
+    }
+  }
+
   hooks = {
     post_start = [
       "echo 'post' > /tmp/hi",
@@ -254,6 +263,7 @@ resource "imagetest_harness_k3s" "test" {
   provisioner "local-exec" {
     command = <<EOF
 docker exec ${self.id} sh -c "cat /tmp/hi"
+docker exec ${self.id} sh -c "kubectl get secret -n kube-system imagetest-registry-auth -o json"
       EOF
   }
 }


### PR DESCRIPTION
currently the `k3s` harness wires in all the necessary auth at the `containerd` level.

this means the cluster can transparently pull private images without the need for cluster namespace/sa scoped secrets in the traditional sense.

this has been working great, but is limited in that only `containerd` can leverage the creds when pulling the image(s). since not all applications can leverage this store, this PR also uses those same creds but stores them as a secret scoped to the cluster.

the secret created is by default benign: `imagetest-registry-auth/kube-system`. everything will still use the default containerd creds to pull images. but creating this secret allows for things like `post_hooks` to copy the secret around to the various applications that may need to leverage these pull creds.

the best example for this is something like crossplane, which hijacks the method of using `kubernetes.io/dockerconfigjson` type secrets to handle application level credentials.