### PR TITLE
decouple mount/layer models

### DIFF
--- a/docs/resources/harness_docker.md
+++ b/docs/resources/harness_docker.md
@@ -53,12 +53,8 @@ Required:
 
 Required:
 
-- `destination` (String) The absolute path on the container to root the source directory in.
 - `source` (String) The relative or absolute path on the host to the source directory to create a layer from.
-
-Optional:
-
-- `read_only` (Boolean, Deprecated) Whether the mount should be read-only.
+- `target` (String) The absolute path on the container to root the source directory in.
 
 
 <a id="nestedatt--mounts"></a>

--- a/docs/resources/harness_k3s.md
+++ b/docs/resources/harness_k3s.md
@@ -149,12 +149,8 @@ Optional:
 
 Required:
 
-- `destination` (String) The absolute path on the container to mount the source directory.
 - `source` (String) The relative or absolute path on the host to the source directory to mount.
-
-Optional:
-
-- `read_only` (Boolean, Deprecated) Whether the mount should be read-only.
+- `target` (String) The absolute path on the container to mount the source directory.
 
 
 <a id="nestedatt--sandbox--mounts"></a>

--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -51,6 +51,7 @@ type Request struct {
 	Contents     []*Content
 	PortBindings nat.PortMap
 	ExtraHosts   []string
+	AutoRemove   bool
 	Logger       io.Writer
 }
 
@@ -92,6 +93,7 @@ func New(opts ...Option) (*Client, error) {
 }
 
 func (d *Client) Run(ctx context.Context, req *Request) (string, error) {
+	req.AutoRemove = true
 	cid, err := d.start(ctx, req)
 	if err != nil {
 		return "", fmt.Errorf("starting container: %w", err)
@@ -262,6 +264,7 @@ func (d *Client) start(ctx context.Context, req *Request) (string, error) {
 			},
 			Mounts:       req.Mounts,
 			PortBindings: req.PortBindings,
+			AutoRemove:   req.AutoRemove,
 		},
 		&network.NetworkingConfig{
 			EndpointsConfig: endpointSettings,

--- a/internal/provider/harness_base_resource.go
+++ b/internal/provider/harness_base_resource.go
@@ -96,6 +96,11 @@ type ContainerMountModel struct {
 	ReadOnly    types.Bool   `tfsdk:"read_only"`
 }
 
+type ContainerLayerModel struct {
+	Source types.String `tfsdk:"source"`
+	Target types.String `tfsdk:"target"`
+}
+
 type ContainerNetworkModel struct {
 	Name types.String `tfsdk:"name"`
 }

--- a/internal/provider/harness_docker_resource.go
+++ b/internal/provider/harness_docker_resource.go
@@ -46,7 +46,7 @@ type HarnessDockerResourceModel struct {
 	Privileged   types.Bool                             `tfsdk:"privileged"`
 	Envs         *HarnessContainerEnvs                  `tfsdk:"envs"`
 	Mounts       []ContainerMountModel                  `tfsdk:"mounts"`
-	Layers       []ContainerMountModel                  `tfsdk:"layers"`
+	Layers       []ContainerLayerModel                  `tfsdk:"layers"`
 	Packages     []string                               `tfsdk:"packages"`
 	Repositories []string                               `tfsdk:"repositories"`
 	Keyrings     []string                               `tfsdk:"keyrings"`
@@ -204,7 +204,7 @@ func (r *HarnessDockerResource) harness(ctx context.Context, data *HarnessDocker
 	for _, sl := range data.Layers {
 		layers = append(layers, bundler.NewFSLayer(
 			os.DirFS(sl.Source.ValueString()),
-			sl.Destination.ValueString(),
+			sl.Target.ValueString(),
 		))
 	}
 
@@ -350,16 +350,9 @@ func (r *HarnessDockerResource) Schema(ctx context.Context, _ resource.SchemaReq
 								Description: "The relative or absolute path on the host to the source directory to create a layer from.",
 								Required:    true,
 							},
-							"destination": schema.StringAttribute{
+							"target": schema.StringAttribute{
 								Description: "The absolute path on the container to root the source directory in.",
 								Required:    true,
-							},
-							"read_only": schema.BoolAttribute{
-								Description:        "Whether the mount should be read-only.",
-								DeprecationMessage: "This is invalid for layers and will be removed in a future release.",
-								Optional:           true,
-								Computed:           true,
-								Default:            booldefault.StaticBool(false),
 							},
 						},
 					},

--- a/internal/provider/harness_docker_resource_test.go
+++ b/internal/provider/harness_docker_resource_test.go
@@ -341,7 +341,7 @@ resource "imagetest_harness_docker" "test" {
   inventory = data.imagetest_inventory.this
 
   # this is called via go test, so path.module is relative to the test directory
-  layers = [{ source = path.module, destination = "/src/bar/" }]
+  layers = [{ source = path.module, target = "/src/bar/" }]
 
   packages = ["crane"]
 }

--- a/internal/provider/harness_k3s_resource.go
+++ b/internal/provider/harness_k3s_resource.go
@@ -67,7 +67,7 @@ type HarnessK3sSandboxResourceModel struct {
 	Privileged   types.Bool                       `tfsdk:"privileged"`
 	Envs         map[string]string                `tfsdk:"envs"`
 	Mounts       []ContainerMountModel            `tfsdk:"mounts"`
-	Layers       []ContainerMountModel            `tfsdk:"layers"`
+	Layers       []ContainerLayerModel            `tfsdk:"layers"`
 	Networks     map[string]ContainerNetworkModel `tfsdk:"networks"`
 	Packages     []string                         `tfsdk:"packages"`
 	Repositories []string                         `tfsdk:"repositories"`
@@ -167,7 +167,7 @@ func (r *HarnessK3sResource) harness(ctx context.Context, data *HarnessK3sResour
 		for _, l := range sandbox.Layers {
 			ls = append(ls, bundler.NewFSLayer(
 				os.DirFS(l.Source.ValueString()),
-				l.Destination.ValueString(),
+				l.Target.ValueString(),
 			))
 		}
 
@@ -353,16 +353,9 @@ func (r *HarnessK3sResource) Schema(ctx context.Context, _ resource.SchemaReques
 							Description: "The relative or absolute path on the host to the source directory to mount.",
 							Required:    true,
 						},
-						"destination": schema.StringAttribute{
+						"target": schema.StringAttribute{
 							Description: "The absolute path on the container to mount the source directory.",
 							Required:    true,
-						},
-						"read_only": schema.BoolAttribute{
-							Description:        "Whether the mount should be read-only.",
-							DeprecationMessage: "This is invalid for layers and will be removed in a future release.",
-							Optional:           true,
-							Computed:           true,
-							Default:            booldefault.StaticBool(false),
 						},
 					},
 				},

--- a/internal/provider/harness_k3s_resource_test.go
+++ b/internal/provider/harness_k3s_resource_test.go
@@ -125,7 +125,7 @@ resource "imagetest_harness_k3s" "test" {
       "test": "cgr.dev/chainguard/wolfi-base:latest",
     }
     packages = ["crane"]
-    layers = [{ source = path.module, destination = "/src/bar/" }]
+    layers = [{ source = path.module, target = "/src/bar/" }]
   }
 }
 
@@ -163,7 +163,7 @@ resource "imagetest_harness_k3s" "test" {
   inventory = data.imagetest_inventory.this
   sandbox = {
     image = "cgr.dev/chainguard/wolfi-base:latest"
-    layers = [{ source = path.module, destination = "/src/bar/" }]
+    layers = [{ source = path.module, target = "/src/bar/" }]
   }
 }
 


### PR DESCRIPTION
tying the `mount` to the `layers` model was just laziness.

this decouples the two, and properly removes the `read_only` attribute from the `layers` model as that doesn't make sense (its a cow fs)