### PR TITLE
Harden Sandbox Entrypoint

### DIFF
--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -53,6 +53,7 @@ type Request struct {
 	ExtraHosts   []string
 	AutoRemove   bool
 	Logger       io.Writer
+	Init         bool
 }
 
 type ResourcesRequest struct {
@@ -265,6 +266,7 @@ func (d *Client) start(ctx context.Context, req *Request) (string, error) {
 			Mounts:       req.Mounts,
 			PortBindings: req.PortBindings,
 			AutoRemove:   req.AutoRemove,
+			Init:         &req.Init,
 		},
 		&network.NetworkingConfig{
 			EndpointsConfig: endpointSettings,

--- a/internal/docker/docker_test.go
+++ b/internal/docker/docker_test.go
@@ -88,8 +88,8 @@ func TestDocker(t *testing.T) {
 	require.Equal(t, "test1", string(data))
 
 	// Fail to get a file that doesn't exist from the container
-	_, err = resp.GetFile(ctx, "/doesnt/exist/tmp/test")
-	require.ErrorContains(t, err, "requested file")
+	_, err = resp.GetFile(ctx, "/really/doesnt/exist/tmp/test")
+	require.ErrorContains(t, err, "not find the file")
 
 	// Fail to get a relative file from the container
 	_, err = resp.GetFile(ctx, "test")

--- a/internal/harness/k3s/k3s.go
+++ b/internal/harness/k3s/k3s.go
@@ -82,6 +82,7 @@ func New(opts ...Option) (*k3s, error) {
 			ExtraHosts: []string{
 				"host.docker.internal:host-gateway",
 			},
+			Init: true,
 		},
 		stack: harness.NewStack(),
 	}

--- a/internal/harness/k3s/k3s_test.go
+++ b/internal/harness/k3s/k3s_test.go
@@ -3,6 +3,7 @@ package k3s
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/chainguard-dev/terraform-provider-imagetest/internal/harness"
 	"github.com/stretchr/testify/require"
@@ -34,6 +35,38 @@ func TestK3s(t *testing.T) {
 	})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "exit code 1")
+
+	// Destroy the harness
+	err = h.Destroy(ctx)
+	require.NoError(t, err)
+}
+
+func TestK3sSandboxInit(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+
+	ctx := context.Background()
+
+	h, err := New()
+	require.NoError(t, err)
+
+	// Create the harness
+	err = h.Create(ctx)
+	require.NoError(t, err)
+
+	// Sleep for a while to let coredns stand up.
+	time.Sleep(20 * time.Second)
+
+	// We have to run this in another goroutine because we do not want to block
+	// our test!
+	go func() {
+		err := h.Run(ctx, harness.Command{
+			Args: "kubectl port-forward -n kube-system deploy/coredns 80:80",
+		})
+		require.NoError(t, err)
+	}()
+	time.Sleep(5 * time.Second)
 
 	// Destroy the harness
 	err = h.Destroy(ctx)


### PR DESCRIPTION
This PR adds an Init field to the docker.Request struct that is passed
through to the call to ContainerCreate.  This will instruct Docker to
use tini as PID 1.  It also modifies the k3s harness to use set the new
field.