### PR TITLE
load creds for provider repo by default

### DIFF
--- a/internal/provider/harness_docker_resource.go
+++ b/internal/provider/harness_docker_resource.go
@@ -195,6 +195,16 @@ func (r *HarnessDockerResource) harness(ctx context.Context, data *HarnessDocker
 		}
 	}
 
+	// always ensure the provider scoped repository plumbs credentials through
+	if r.store.providerResourceData.Repo.ValueString() != "" {
+		ref, err := name.ParseReference(r.store.providerResourceData.Repo.ValueString())
+		if err != nil {
+			return nil, []diag.Diagnostic{diag.NewErrorDiagnostic("invalid repository reference", fmt.Sprintf("invalid repository reference: %s", err))}
+		}
+
+		opts = append(opts, docker.WithAuthFromKeychain(ref.Context().RegistryStr()))
+	}
+
 	b, err := r.bundler(data)
 	if err != nil {
 		return nil, []diag.Diagnostic{diag.NewErrorDiagnostic("failed to create bundler", err.Error())}


### PR DESCRIPTION
since `repo` became a provider scoped resource, we now have a consistent `Repo` that we can use to always plumb through some set of default credentials to the harness, without requiring the use of defining custom provider scoped overrides.

for all but the most advanced cases, this means users no longer need to specify harness scoped credentials.