### PR TITLE
add entrypoint binary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,12 +5,29 @@ on:
       - 'v*'
 
 jobs:
+  entrypoint:
+    permissions:
+      contents: write # To publish the release.
+
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - run: git fetch --prune --unshallow
+      - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
+        with:
+          go-version-file: 'go.mod'
+          cache: false
+      - run: go test -v -cover ./cmd/entrypoint
+      - uses: ko-build/setup-ko@d982fec422852203cfb2053a8ec6ad302280d04d # v0.8
+      - run: ko build ./cmd/entrypoint
+
   goreleaser:
     permissions:
       contents: write # To publish the release.
       id-token: write # To federate for the GPG key.
 
     runs-on: ubuntu-latest
+    needs: entrypoint
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - run: git fetch --prune --unshallow

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,6 +52,18 @@ jobs:
           git diff --compact-summary --exit-code || \
             (echo; echo "Unexpected difference in directories after code generation. Run 'go generate ./...' command and commit."; exit 1)
 
+  entrypoint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
+        with:
+          go-version-file: "go.mod"
+          cache: true
+      - run: go test -v -cover ./cmd/entrypoint
+      - uses: ko-build/setup-ko@d982fec422852203cfb2053a8ec6ad302280d04d # v0.8
+      - run: ko build --push=false ./cmd/entrypoint
+
   # Run acceptance tests in a matrix with Terraform CLI versions
   test:
     name: Terraform Provider Acceptance Tests

--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,0 +1,5 @@
+defafultBaseImage: cgr.dev/chainguard/busybox:latest
+
+defaultPlatforms:
+- linux/arm64
+- linux/amd64

--- a/cmd/entrypoint/kodata/entrypoint-wrapper.sh
+++ b/cmd/entrypoint/kodata/entrypoint-wrapper.sh
@@ -1,0 +1,122 @@
+#!/bin/sh
+set -eu
+
+# Print usage and exit with error
+usage() {
+  echo "Usage: $0 <test-script-path>"
+  echo "Environment variables:"
+  echo "  IMAGETEST_DRIVER: Type of test environment (docker_in_docker, k3s_in_docker)"
+  exit 1
+}
+
+# Validate that a test script exists and is executable.
+# This function is used by all drivers to ensure consistent validation.
+# Arguments:
+#   $1: Path to the test script
+validate_test_script() {
+  script_path="$1"
+
+  if [ ! -f "$script_path" ]; then
+    echo "Error: Test script '$script_path' does not exist"
+    exit 1
+  fi
+
+  if [ ! -x "$script_path" ]; then
+    echo "Warning: Test script '$script_path' is not executable, attempting to set execute permission"
+    if ! chmod +x "$script_path"; then
+      echo "Error: Failed to make test script executable"
+      exit 1
+    fi
+    echo "Successfully made test script executable"
+  fi
+}
+
+# Initialize and manage a Docker-in-Docker environment.
+# This function handles the Docker daemon startup and monitoring.
+# Arguments:
+#   $1: Path to the test script (already validated)
+init_docker_in_docker() {
+  test_script="$1"
+  timeout=30
+  log_dir="/var/log/docker"
+
+  # Set up logging directory
+  mkdir -p "$log_dir"
+
+  # Start Docker daemon in background, capturing logs
+  /usr/bin/dockerd-entrypoint.sh dockerd >"$log_dir/dockerd.log" 2>&1 &
+
+  # Wait for Docker to be ready
+  echo "Waiting for Docker daemon to be ready..."
+  while [ "$timeout" -gt 0 ]; do
+    if docker version >/dev/null 2>&1; then
+      echo "Docker daemon is ready"
+      break
+    fi
+    timeout=$((timeout - 1))
+    echo "Waiting... ($timeout seconds remaining)"
+    sleep 1
+  done
+
+  if [ "$timeout" -le 0 ]; then
+    echo "Error: Docker daemon failed to start"
+    exit 1
+  fi
+
+  # Execute test script with strict shell options
+  set -eux
+  exec /bin/sh -c ". $test_script"
+}
+
+# Initialize and manage a K3s-in-Docker environment.
+# Arguments:
+#   $1: Path to the test script (already validated)
+init_k3s_in_docker() {
+  test_script="$1"
+
+  # Ensure required environment variables are set
+  if [ -z "${POD_NAME-}" ] || [ -z "${POD_NAMESPACE-}" ]; then
+    echo "Error: POD_NAME and POD_NAMESPACE environment variables must be set"
+    exit 1
+  fi
+
+  echo "Waiting for pod ${POD_NAME} to be ready..."
+  if ! kubectl wait --for=condition=Ready=true pod/${POD_NAME} -n "${POD_NAMESPACE}" --timeout=60s; then
+    echo "Error: Pod ${POD_NAME} failed to become ready"
+    exit 1
+  fi
+
+  # Execute test script with strict shell options
+  set -eux
+  exec /bin/sh -c ". $test_script"
+}
+
+# Validate command-line arguments
+if [ $# -ne 1 ]; then
+  usage
+fi
+
+test_script="$1"
+
+# Make sure IMAGETEST_DRIVER is set
+if [ -z "${IMAGETEST_DRIVER-}" ]; then
+  echo "Error: IMAGETEST_DRIVER environment variable not set"
+  usage
+fi
+
+# Validate the test script first, regardless of driver
+validate_test_script "$test_script"
+
+# Initialize the appropriate driver
+case "$IMAGETEST_DRIVER" in
+docker_in_docker)
+  init_docker_in_docker "$test_script"
+  ;;
+k3s_in_docker)
+  init_k3s_in_docker "$test_script"
+  ;;
+*)
+  echo "Error: Unknown driver '$IMAGETEST_DRIVER'"
+  usage
+  ;;
+esac

--- a/cmd/entrypoint/main.go
+++ b/cmd/entrypoint/main.go
@@ -1,0 +1,381 @@
+// entrypoint is **heavily** inspired by prow's entrypoint package:
+// https://github.com/kubernetes-sigs/prow/tree/main/pkg/entrypoint
+//
+// The major differences are the absence of marker files, and a refreshed
+// context/clog implementation. As imagetest doesn't use prow's markers, we
+// strictly rely on the exit codes and containers that run to completion.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"os"
+	"os/exec"
+	"os/signal"
+	"path/filepath"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/chainguard-dev/clog"
+	"github.com/chainguard-dev/terraform-provider-imagetest/internal/entrypoint"
+)
+
+const (
+	DefaultTimeout = 60 * time.Minute
+	GracePeriod    = 15 * time.Second
+
+	DefaultHealthCheckSocket = "/tmp/imagetest.health.sock"
+)
+
+type opts struct {
+	ProcessLogPath string
+	CommandTimeout time.Duration
+	GracePeriod    time.Duration
+	WaitForProbe   bool
+
+	healthStatus *healthStatus
+	args         []string
+}
+
+func parseFlags() *opts {
+	opts := &opts{
+		healthStatus: newHealthStatus(),
+	}
+
+	flag.StringVar(&opts.ProcessLogPath, "process-log-path", "", "Path to the log file for the process")
+	flag.DurationVar(&opts.CommandTimeout, "timeout", DefaultTimeout, "How long to allow the process to run before cancelling it")
+	flag.DurationVar(&opts.GracePeriod, "grace-period", GracePeriod, "How long to wait for the process to exit gracefully after sending a SIGINT before sending a SIGKILL")
+	flag.BoolVar(&opts.WaitForProbe, "wait-for-probe", true, "Wait for the entrypoint to be probed before starting the wrapped process")
+
+	flag.Parse()
+
+	opts.args = flag.Args()
+
+	return opts
+}
+
+func main() {
+	opts := parseFlags()
+
+	log := clog.New(slog.Default().Handler())
+	ctx := clog.WithLogger(context.Background(), log)
+
+	ctx, stop := signal.NotifyContext(ctx, syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	if len(os.Args) == 2 && os.Args[1] == "healthcheck" {
+		// Run the binary as a health check
+		conn, err := net.Dial("unix", DefaultHealthCheckSocket)
+		if err != nil {
+			clog.ErrorContextf(ctx, "failed to connect to health socket: %v", err)
+			os.Exit(entrypoint.InternalErrorCode)
+		}
+		defer conn.Close()
+
+		var status healthStatus
+		if err := json.NewDecoder(conn).Decode(&status); err != nil {
+			clog.ErrorContextf(ctx, "failed to decode health status: %v", err)
+			os.Exit(entrypoint.InternalErrorCode)
+		}
+
+		switch status.State {
+		case healthRunning:
+			clog.InfoContext(ctx, "health check passed")
+			os.Exit(0)
+		case healthPaused:
+			clog.InfoContext(ctx, "health check paused")
+			os.Exit(entrypoint.ProcessPausedErrorCode)
+		case healthFailed:
+			clog.InfoContext(ctx, "health check failed")
+			os.Exit(entrypoint.InternalErrorCode)
+		}
+
+		os.Exit(0)
+	}
+
+	// Run the binary as an entrypoint
+	code := opts.Run(ctx)
+	os.Exit(code)
+}
+
+func (o *opts) Run(ctx context.Context) int {
+	code, err := o.executeProcess(ctx)
+	if err != nil {
+		clog.ErrorContextf(ctx, "Error executing wrapped process: %v", err)
+		o.healthStatus.update(healthFailed, err.Error())
+		return code
+	}
+
+	return code
+}
+
+func (o *opts) executeProcess(ctx context.Context) (int, error) {
+	ctx, cancel := context.WithTimeout(ctx, o.CommandTimeout)
+	defer cancel()
+
+	healthCleanup, err := o.healthStatus.startSocket()
+	if err != nil {
+		return entrypoint.InternalErrorCode, fmt.Errorf("failed to start health socket: %w", err)
+	}
+	defer healthCleanup()
+
+	w := io.Writer(os.Stdout)
+	if o.ProcessLogPath != "" {
+		if err := os.MkdirAll(filepath.Dir(o.ProcessLogPath), 0755); err != nil {
+			return entrypoint.InternalErrorCode, fmt.Errorf("failed to create process log directory: %w", err)
+		}
+
+		plf, err := os.Create(o.ProcessLogPath)
+		if err != nil {
+			return entrypoint.InternalErrorCode, fmt.Errorf("failed to create process log file: %w", err)
+		}
+		defer plf.Close()
+		w = io.MultiWriter(w, plf)
+	}
+
+	if len(o.args) == 0 {
+		return entrypoint.InternalErrorCode, fmt.Errorf("no command provided")
+	}
+	cmdName, cmdArgs := o.args[0], o.args[1:]
+
+	cmd := exec.Command(cmdName, cmdArgs...)
+	cmd.Stdout = w
+	cmd.Stderr = w
+	cmd.Env = append(os.Environ(), "IMAGETEST=true")
+
+	// Block until we are probed
+	if o.WaitForProbe {
+		clog.InfoContext(ctx, "waiting for probe before starting wrapped process")
+
+		select {
+		case <-ctx.Done():
+			clog.InfoContext(ctx, "context cancelled before probe received")
+			return entrypoint.InternalErrorCode, ctx.Err()
+		case <-o.healthStatus.probed:
+			clog.InfoContext(ctx, "probed, starting wrapped process")
+		}
+	}
+
+	if err := cmd.Start(); err != nil {
+		return entrypoint.InternalErrorCode, fmt.Errorf("failed to start the process: %w", err)
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- cmd.Wait()
+	}()
+
+	var waitErr error
+	select {
+	case waitErr = <-done:
+		// Child finished before timeout
+	case <-ctx.Done():
+		// Process timed out or cancelled
+		clog.InfoContext(ctx, "process timed out")
+		waitErr = errors.New("process timed out or cancelled")
+		gracefullyTerminate(ctx, cmd, o.GracePeriod)
+
+		<-done
+	}
+
+	// extract the exit code from the error
+	if waitErr != nil {
+		var exitErr *exec.ExitError
+
+		if errors.As(waitErr, &exitErr) {
+			if os.Getenv("IMAGETEST_PAUSE_ON_ERROR") != "" {
+				o.healthStatus.update(healthPaused, fmt.Sprintf("exit code %d", exitErr.ExitCode()))
+				if err := pause(ctx, exitErr.ExitCode()); err != nil {
+					return entrypoint.InternalErrorCode, err
+				}
+
+				// after a successful pause, just exit with the originally captured exit code
+				return exitErr.ExitCode(), nil
+			}
+
+			// wrapped process exiting with an error, just surface it
+			return exitErr.ExitCode(), exitErr
+		}
+
+		// we got an error while force killing
+		return entrypoint.InternalErrorCode, waitErr
+	}
+
+	return 0, nil
+}
+
+// gracefullyTerminate sends a SIGINT, waits for gracePeriod, then sends a SIGKILL.
+func gracefullyTerminate(ctx context.Context, cmd *exec.Cmd, gracePeriod time.Duration) {
+	if cmd.Process == nil {
+		return
+	}
+
+	if err := cmd.Process.Signal(syscall.SIGINT); err != nil {
+		clog.ErrorContextf(ctx, "failed to send SIGINT to process: %v", err)
+		return
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- cmd.Wait()
+	}()
+
+	select {
+	case <-done:
+		clog.InfoContext(ctx, "process exited gracefully after SIGINT")
+		return
+	case <-time.After(gracePeriod):
+		clog.InfoContext(ctx, "process did not exit gracefully after SIGINT, sending SIGKILL")
+		if err := cmd.Process.Signal(syscall.SIGKILL); err != nil {
+			clog.ErrorContextf(ctx, "failed to send SIGKILL to process: %v", err)
+			return
+		}
+	}
+}
+
+func pause(parentCtx context.Context, exitCode int) error {
+	fifoPath := "/tmp/imagetest.unpause"
+	clog.InfoContext(parentCtx, "wrapped process failed, attempting to pause for debugging", "fifo_path", fifoPath, "exit_code", exitCode)
+
+	// create a new context to avoid exiting early if the parent context is cancelled
+	pauseCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	pauseCtx, stop := signal.NotifyContext(pauseCtx, syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	if err := os.Remove(fifoPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("failed to remove debug fifo: %w", err)
+	}
+
+	if err := syscall.Mkfifo(fifoPath, 0622); err != nil {
+		return fmt.Errorf("failed to create debug fifo: %w", err)
+	}
+	defer os.Remove(fifoPath)
+
+	unpaused := make(chan struct{})
+	errChan := make(chan error, 1)
+
+	go func() {
+		// open the FIFO in blocking mode
+		fd, err := syscall.Open(fifoPath, syscall.O_RDONLY, 0)
+		if err != nil {
+			errChan <- fmt.Errorf("failed to open FIFO: %w", err)
+			return
+		}
+		defer syscall.Close(fd)
+
+		// block until we read a single byte from somewhere (presumably the user)
+		buf := make([]byte, 1)
+		_, err = syscall.Read(fd, buf)
+		if err != nil {
+			errChan <- fmt.Errorf("failed to read from FIFO: %w", err)
+			return
+		}
+
+		close(unpaused)
+	}()
+
+	clog.InfoContextf(parentCtx, "successfully paused, to resume, run: echo > %s", fifoPath)
+
+	for {
+		select {
+		case <-pauseCtx.Done():
+			return fmt.Errorf("debugging interrupted: %w", pauseCtx.Err())
+		case err := <-errChan:
+			return fmt.Errorf("FIFO error: %w", err)
+		case <-unpaused:
+			clog.InfoContext(parentCtx, "resuming execution")
+			return nil
+		}
+	}
+}
+
+type healthState string
+
+const (
+	healthStarting healthState = "starting"
+	healthRunning  healthState = "running"
+	healthPaused   healthState = "paused"
+	healthFailed   healthState = "failed"
+)
+
+type healthStatus struct {
+	State   healthState `json:"state"`
+	Time    time.Time   `json:"time"`
+	Message string      `json:"message"`
+	mu      sync.RWMutex
+
+	probed     chan struct{}
+	probedOnce sync.Once
+}
+
+func newHealthStatus() *healthStatus {
+	return &healthStatus{
+		State:      healthStarting,
+		Time:       time.Now(),
+		Message:    "starting",
+		mu:         sync.RWMutex{},
+		probed:     make(chan struct{}),
+		probedOnce: sync.Once{},
+	}
+}
+
+func (h *healthStatus) update(state healthState, message string) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.State = state
+	h.Message = message
+	// This ends up being an approximation, but we don't need to be super precise
+	h.Time = time.Now()
+}
+
+func (h *healthStatus) startSocket() (func(), error) {
+	if err := os.Remove(DefaultHealthCheckSocket); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return nil, fmt.Errorf("failed to remove health socket: %w", err)
+	}
+
+	listener, err := net.Listen("unix", DefaultHealthCheckSocket)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create health socket: %w", err)
+	}
+
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			defer conn.Close()
+
+			// Take out a lock, since this is on the same goroutine it blocks, but we
+			// only ever expect this to be called by runtimes during health checks
+			h.mu.RLock()
+			if err := json.NewEncoder(conn).Encode(h); err != nil {
+				return
+			}
+			h.mu.RUnlock()
+
+			h.markProbed()
+		}
+	}()
+
+	return func() {
+		listener.Close()
+		os.Remove(DefaultHealthCheckSocket)
+	}, nil
+}
+
+func (h *healthStatus) markProbed() {
+	h.probedOnce.Do(func() {
+		h.update(healthRunning, "marking as probed")
+		close(h.probed)
+	})
+}

--- a/cmd/entrypoint/main_test.go
+++ b/cmd/entrypoint/main_test.go
@@ -1,0 +1,134 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/chainguard-dev/terraform-provider-imagetest/internal/entrypoint"
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestRun(t *testing.T) {
+	tests := []struct {
+		name          string
+		args          []string
+		expectedCode  int
+		expectedLog   string
+		expectedError string
+		overrideOpts  func(*opts)
+	}{
+		{
+			name:         "successful command",
+			args:         []string{"echo", "hello world"},
+			expectedCode: 0,
+			overrideOpts: func(o *opts) {
+				o.WaitForProbe = false
+			},
+		},
+		{
+			name:         "failed process uses process exit code",
+			args:         []string{"/bin/sh", "-c", "exit 42"},
+			expectedCode: 42,
+			overrideOpts: func(o *opts) {
+				o.WaitForProbe = false
+			},
+		},
+		{
+			name: "command times out",
+			args: []string{"sleep", "10"},
+			overrideOpts: func(o *opts) {
+				o.WaitForProbe = false
+				o.CommandTimeout = 1 * time.Second
+				o.GracePeriod = 1 * time.Second
+			},
+			expectedCode:  entrypoint.InternalErrorCode,
+			expectedError: "process timed out or cancelled",
+		},
+		{
+			name: "command forks logs to file",
+			args: []string{"echo", "hello world"},
+			overrideOpts: func(o *opts) {
+				o.WaitForProbe = false
+			},
+			expectedLog: "hello world\n",
+		},
+		{
+			name: "internal failure uses internal error code",
+			args: []string{"invalid"},
+			overrideOpts: func(o *opts) {
+				o.WaitForProbe = false
+			},
+			expectedCode: entrypoint.InternalErrorCode,
+		},
+		{
+			name: "process blocks until probed",
+			args: []string{"echo", "hello world"},
+			overrideOpts: func(o *opts) {
+				o.GracePeriod = 1 * time.Second
+			},
+			expectedCode: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Save original args
+			oldArgs := os.Args
+			defer func() {
+				os.Args = oldArgs
+				flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+			}()
+
+			// Set up new args for this test
+			os.Args = append([]string{"cmd"}, tt.args...)
+
+			opts := parseFlags()
+			opts.args = tt.args
+			opts.ProcessLogPath = filepath.Join(t.TempDir(), "process.log")
+
+			if tt.overrideOpts != nil {
+				tt.overrideOpts(opts)
+			}
+
+			if opts.WaitForProbe {
+				go func() {
+					// janky way to probe
+					time.Sleep(3 * time.Second)
+					opts.healthStatus.markProbed()
+				}()
+			}
+
+			code, err := opts.executeProcess(context.Background())
+
+			// Validate the result
+			if err != nil && tt.expectedCode == 0 {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if code != tt.expectedCode {
+				t.Errorf("expected code %d, got %d", tt.expectedCode, code)
+			}
+
+			if err != nil && tt.expectedError != "" {
+				if diff := cmp.Diff(tt.expectedError, err.Error()); diff != "" {
+					t.Errorf("unexpected error (-want +got):\n%s", diff)
+				}
+			}
+
+			if tt.expectedLog != "" {
+				content, err := os.ReadFile(opts.ProcessLogPath)
+				if err != nil {
+					t.Fatalf("failed to read process log: %v", err)
+				}
+
+				if diff := cmp.Diff(tt.expectedLog, string(content)); diff != "" {
+					t.Errorf("unexpected log content (-want +got):\n%s", diff)
+				}
+			}
+		})
+	}
+}

--- a/internal/entrypoint/entrypoint.go
+++ b/internal/entrypoint/entrypoint.go
@@ -1,0 +1,26 @@
+package entrypoint
+
+var ImageRef = "ghcr.io/chainguard-dev/terraform-provider-imagetest:latest"
+
+const (
+	BinaryPath            = "/ko-app/entrypoint"
+	WrapperPath           = "/var/run/ko/entrypoint-wrapper.sh"
+	DefaultProcessLogPath = "/tmp/imagetest.log"
+
+	// Return code if entrypoint fails.
+	InternalErrorCode = 1000
+
+	// Healthcheck return code if wrapped command fails and we're paused.
+	ProcessPausedErrorCode = 927
+)
+
+var DefaultEntrypoint = []string{
+	BinaryPath,
+	"--process-log-path", DefaultProcessLogPath,
+	WrapperPath,
+}
+
+var DefaultHealthCheckCommand = []string{
+	BinaryPath,
+	"healthcheck",
+}


### PR DESCRIPTION
Initial work for the `entrypoint` binary, a small little tool to be the entrypoint for future imagetest containers built using `tests_resource`. Each test container will use this entrypoint alongside a user defined `cmd`, for example:

```hcl
resource "imagetest_tests" "foo" {
  ...

  tests = [
    {
      name    = "helm"
      image   = module.bash_sandbox.image_ref
      content = [{ source = path.module }]
      cmd     = "/imagetest/test.sh"
    }
  ]
}
```

Will produce the following test image:

```
"config": {
    "Cmd": [
      "/imagetest/test.sh"
    ],
    "Entrypoint": [
      "/ko-app/entrypoint",
      "/var/run/ko/entrypoint-wrapper.sh"
    ],
    ...
}
```

This is really similar to prow and tektons entrypoint, in that it runs as PID 1, forks logs, and handles signalling. The difference with this one is it doesn't use prow's markers or tekton's step files, and instead uses a stupid simple health endpoint for querying the status of the wrapped process.

This means the runtime (ie k8s or docker) can poll the container using this entrypoint for status on the wrapped process, and react accordingly. Since we don't need to support multiple steps, we don't pull in the same logic as tektons entrypoint, and since we use a healthcheck endpoint instead of markers, we don't pull in prow's entrypoint.

This also includes the `ko` publishing steps, which publish the entypoint image and its wrapper sh script as an image on this repo which `imagetest` (the provider) will ultimately use to append to the test sandboxes.