### PR TITLE
publish without the trailing hash

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
           cache: false
       - run: go test -v -cover ./cmd/entrypoint
       - uses: ko-build/setup-ko@d982fec422852203cfb2053a8ec6ad302280d04d # v0.8
-      - run: ko build ./cmd/entrypoint
+      - run: ko build --base-import-paths ./cmd/entrypoint
 
   goreleaser:
     permissions:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,7 +62,7 @@ jobs:
           cache: true
       - run: go test -v -cover ./cmd/entrypoint
       - uses: ko-build/setup-ko@d982fec422852203cfb2053a8ec6ad302280d04d # v0.8
-      - run: ko build --push=false ./cmd/entrypoint
+      - run: ko build --base-import-paths --push=false ./cmd/entrypoint
 
   # Run acceptance tests in a matrix with Terraform CLI versions
   test:


### PR DESCRIPTION
ghcr.io/chainguard-dev/terraform-provider-imagetest/entrypoint-eef1784c8c5f20440c81298838ff7a2e:latest

becomes:

ghcr.io/chainguard-dev/terraform-provider-imagetest/entrypoint:latest