### PR TITLE
use v1.Layers

### DIFF
--- a/internal/bundler/apko.go
+++ b/internal/bundler/apko.go
@@ -10,7 +10,9 @@ import (
 	apko_types "chainguard.dev/apko/pkg/build/types"
 	"chainguard.dev/apko/pkg/tarfs"
 	"github.com/google/go-containerregistry/pkg/name"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/empty"
+	"github.com/google/go-containerregistry/pkg/v1/mutate"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 )
 
@@ -78,7 +80,7 @@ func NewApko(opts ...ApkoOpt) (Bundler, error) {
 	return a, nil
 }
 
-func (a *apko) Bundle(ctx context.Context, repo name.Repository, layers ...Layerer) (name.Reference, error) {
+func (a *apko) Bundle(ctx context.Context, repo name.Repository, layers ...v1.Layer) (name.Reference, error) {
 	bopts := []apko_build.Option{
 		apko_build.WithImageConfiguration(a.apkoConfig),
 		apko_build.WithArch(a.arch),
@@ -105,7 +107,7 @@ func (a *apko) Bundle(ctx context.Context, repo name.Repository, layers ...Layer
 		return nil, fmt.Errorf("failed to build image: %w", err)
 	}
 
-	img, err := appendLayers(base, layers...)
+	img, err := mutate.AppendLayers(base, layers...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to append layers: %w", err)
 	}

--- a/internal/bundler/appender.go
+++ b/internal/bundler/appender.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/google/go-containerregistry/pkg/name"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 )
 
@@ -30,7 +31,7 @@ func NewAppender(base name.Reference, opts ...AppenderOpt) (Bundler, error) {
 	return a, nil
 }
 
-func (a *appender) Bundle(ctx context.Context, repo name.Repository, layers ...Layerer) (name.Reference, error) {
+func (a *appender) Bundle(ctx context.Context, repo name.Repository, layers ...v1.Layer) (name.Reference, error) {
 	opts := AppendOpts{
 		RemoteOptions: a.ropts,
 		Layers:        layers,

--- a/internal/bundler/bundler.go
+++ b/internal/bundler/bundler.go
@@ -4,8 +4,9 @@ import (
 	"context"
 
 	"github.com/google/go-containerregistry/pkg/name"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
 )
 
 type Bundler interface {
-	Bundle(ctx context.Context, repo name.Repository, layers ...Layerer) (name.Reference, error)
+	Bundle(ctx context.Context, repo name.Repository, layers ...v1.Layer) (name.Reference, error)
 }


### PR DESCRIPTION
I'm not sure what I was on when I created `Layerer`, but this is a lot simpler to use if we just use the existing `v1.Layer` and create some helpers around creating static layers from FS/paths

this is hoisted out of #272, where appending will be more common as the creation method for creating the test sandboxes