### PR TITLE
redirect stdout/stderr better, and hoist some more constants

### DIFF
--- a/cmd/entrypoint/kodata/entrypoint-wrapper.sh
+++ b/cmd/entrypoint/kodata/entrypoint-wrapper.sh
@@ -64,8 +64,7 @@ init_docker_in_docker() {
   fi
 
   # Execute test script with strict shell options
-  set -eux
-  exec /bin/sh -c ". $test_script"
+  exec /bin/sh -euxc ". $test_script"
 }
 
 # Initialize and manage a K3s-in-Docker environment.
@@ -87,8 +86,7 @@ init_k3s_in_docker() {
   fi
 
   # Execute test script with strict shell options
-  set -eux
-  exec /bin/sh -c ". $test_script"
+  exec /bin/sh -euxc ". $test_script"
 }
 
 # Validate command-line arguments

--- a/internal/entrypoint/entrypoint.go
+++ b/internal/entrypoint/entrypoint.go
@@ -1,11 +1,20 @@
 package entrypoint
 
-var ImageRef = "ghcr.io/chainguard-dev/terraform-provider-imagetest:latest"
+// ImageRef is replaced at provider build time (ldflag) with the :tag@digest of
+// the ./cmd/entrypoint binary.
+var ImageRef = "gcr.io/wolf-chainguard/entrypoint@sha256:d0d087f258b646f8d52edd6aecd9c72a99f38ab75ff1994799a427a30206f89e"
 
 const (
-	BinaryPath            = "/ko-app/entrypoint"
-	WrapperPath           = "/var/run/ko/entrypoint-wrapper.sh"
+	BinaryPath  = "/ko-app/entrypoint"
+	WrapperPath = "/var/run/ko/entrypoint-wrapper.sh"
+
+	// DefaultProcessLogPath contains both stdout and stderr. It is only used
+	// when specified at runtime.
 	DefaultProcessLogPath = "/tmp/imagetest.log"
+	// DefaultStderrLogPath contains only stderr. It is always used to write
+	// stderr.
+	DefaultStderrLogPath     = "/tmp/imagetest.stderr.log"
+	DefaultHealthCheckSocket = "/tmp/imagetest.health.sock"
 
 	// Return code if entrypoint fails.
 	InternalErrorCode = 1000


### PR DESCRIPTION
to be used in #272. currently requires landing/releasing this first until CI is updated to build the provider with an ldflag for the final entrypoint image.