### PR TITLE
wire in LDFLAGS for pinning entrypoint image at build time

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,30 +5,13 @@ on:
       - 'v*'
 
 jobs:
-  entrypoint:
-    permissions:
-      contents: write # To publish the release.
-      packages: write # To publish the release.
-
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - run: git fetch --prune --unshallow
-      - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
-        with:
-          go-version-file: 'go.mod'
-          cache: false
-      - run: go test -v -cover ./cmd/entrypoint
-      - uses: ko-build/setup-ko@d982fec422852203cfb2053a8ec6ad302280d04d # v0.8
-      - run: ko build --base-import-paths ./cmd/entrypoint
-
   goreleaser:
     permissions:
       contents: write # To publish the release.
       id-token: write # To federate for the GPG key.
+      packages: write # To publish the entrypoint image
 
     runs-on: ubuntu-latest
-    needs: entrypoint
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - run: git fetch --prune --unshallow
@@ -36,6 +19,12 @@ jobs:
         with:
           go-version-file: 'go.mod'
           cache: false
+
+      - uses: ko-build/setup-ko@d982fec422852203cfb2053a8ec6ad302280d04d # v0.8
+      - id: entrypoint-build
+        run: |
+          ref=$(ko build --base-import-paths ./cmd/entrypoint)
+          echo "entrypoint_ref=${ref}" >> $GITHUB_OUTPUT
 
       # This is provisioned here: https://github.com/chainguard-dev/secrets/blob/main/terraform-provider-imagetest.tf
       - uses: google-github-actions/auth@a6e2e39c0a0331da29f7fd2c2a20a427e8d3ad1f # v2.1.1
@@ -64,3 +53,4 @@ jobs:
         env:
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          IMAGETEST_ENTRYPOINT_REF: ${{ steps.entrypoint-build.outputs.entrypoint_ref }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,6 +33,15 @@ jobs:
         uses: golangci/golangci-lint-action@a4f60bb28d35aeee14e6880718e0c85ff1882e64 # v6.0.1
         with:
           version: latest
+      - uses: ko-build/setup-ko@d982fec422852203cfb2053a8ec6ad302280d04d # v0.8
+        env:
+          KO_DOCKER_REPO: "ttl.sh/imagetest" # Avoid using GH registry for presubmit and plumbing auth
+      - id: entrypoint-build
+        run: |
+          ref=$(ko build --base-import-paths ./cmd/entrypoint)
+          echo "entrypoint_ref=${ref}" >> $GITHUB_OUTPUT
+    outputs:
+      entrypoint_ref: ${{ steps.entrypoint-build.outputs.entrypoint_ref }}
 
   generate:
     runs-on: ubuntu-latest
@@ -51,18 +60,6 @@ jobs:
         run: |
           git diff --compact-summary --exit-code || \
             (echo; echo "Unexpected difference in directories after code generation. Run 'go generate ./...' command and commit."; exit 1)
-
-  entrypoint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-      - uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
-        with:
-          go-version-file: "go.mod"
-          cache: true
-      - run: go test -v -cover ./cmd/entrypoint
-      - uses: ko-build/setup-ko@d982fec422852203cfb2053a8ec6ad302280d04d # v0.8
-      - run: ko build --base-import-paths --push=false ./cmd/entrypoint
 
   # Run acceptance tests in a matrix with Terraform CLI versions
   test:
@@ -91,12 +88,14 @@ jobs:
       - env:
           TF_ACC: "1"
           TF_LOG: "info"
+          IMAGETEST_ENTRYPOINT_REF: ${{ needs.build.outputs.entrypoint_ref }}
         run: go test -v -cover ./internal/provider/
         timeout-minutes: 10
 
   images-test:
     name: Run imagetest against images
     runs-on: ubuntu-latest
+    needs: build
     timeout-minutes: 30
     strategy:
       fail-fast: false
@@ -135,6 +134,7 @@ jobs:
         working-directory: images
         env:
           TF_VAR_target_repository: "ttl.sh/imagetest"
+          IMAGETEST_ENTRYPOINT_REF: ${{ needs.build.outputs.entrypoint_ref }}
         run: |
           make init-upgrade
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -6,7 +6,7 @@ builds:
     flags:
       - -trimpath
     ldflags:
-      - "-s -w -X main.version={{.Version}} -X main.commit={{.Commit}}"
+      - "-s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X github.com/chainguard-dev/terraform-provider-imagetest/internal/entrypoint.ImageRef={{.Env.IMAGETEST_ENTRYPOINT_REF}}"
     goos:
       - linux
       - darwin

--- a/internal/provider/store.go
+++ b/internal/provider/store.go
@@ -148,7 +148,13 @@ func (s *ProviderStore) SkipTeardown() bool {
 }
 
 func getEntrypointLayers(opts ...remote.Option) (map[string][]v1.Layer, error) {
-	eref, err := name.ParseReference(entrypoint.ImageRef)
+	rawRef := entrypoint.ImageRef
+	// Allow for runtimes to override
+	if o := os.Getenv("IMAGETEST_ENTRYPOINT_REF"); o != "" {
+		rawRef = o
+	}
+
+	eref, err := name.ParseReference(rawRef)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse entrypoint reference: %w", err)
 	}


### PR DESCRIPTION
currently the entrypoint image is floated at whatever :latest is at build time. this means we  currently need a release for entrypoint first, before releasing for the provider.

this wires in the ko build output to pin the entrypoint image to the digest at provider build time, allowing everything to be released at once.

this also wires in presubmit to properly use the temporary image for tests. presubmit uses ttl.sh so we can avoid wiring repo auth in presubmit