### PR TITLE
plumb through the TestResource skipping logic

### DIFF
--- a/docs/resources/tests.md
+++ b/docs/resources/tests.md
@@ -23,7 +23,9 @@ description: |-
 ### Optional
 
 - `drivers` (Attributes) The resource specific driver configuration. This is merged with the provider scoped drivers configuration. (see [below for nested schema](#nestedatt--drivers))
+- `labels` (Map of String) Metadata to attach to the tests resource. Used for filtering and grouping.
 - `name` (String) The name of the test. If one is not provided, a random name will be generated.
+- `skipped` (Boolean) Whether or not the tests were skipped. This is set to true if the tests were skipped, and false otherwise.
 - `tests` (Attributes List) An ordered list of test suites to run (see [below for nested schema](#nestedatt--tests))
 - `timeout` (String) The maximum amount of time to wait for all tests to complete. This includes the time it takes to start and destroy the driver.
 

--- a/internal/drivers/docker_in_docker/driver.go
+++ b/internal/drivers/docker_in_docker/driver.go
@@ -34,7 +34,7 @@ type driver struct {
 
 func NewDriver(n string, opts ...DriverOpts) (drivers.Tester, error) {
 	d := &driver{
-		ImageRef: name.MustParseReference("docker:dind"),
+		ImageRef: name.MustParseReference("cgr.dev/chainguard/docker-dind:latest"),
 		name:     n,
 		stack:    harness.NewStack(),
 		ropts: []remote.Option{

--- a/internal/provider/testdata/TestAccTestsResource/docker-in-docker-basic.sh
+++ b/internal/provider/testdata/TestAccTestsResource/docker-in-docker-basic.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+echo "Hello from foo"
+
+docker run --rm hello-world

--- a/internal/provider/testdata/TestAccTestsResource/docker-in-docker-fails.sh
+++ b/internal/provider/testdata/TestAccTestsResource/docker-in-docker-fails.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+cat imalittleteapot


### PR DESCRIPTION
this brings `imagetests_tests` up to parity with some of the existing inventory/harness/feature features:

- warn instead of error on harness teardown errors
- support test skipping
- support tests labeling