### PR TITLE
remove unused slog-multi

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -49,7 +49,6 @@ provider "imagetest" {
 ### Optional
 
 - `harnesses` (Attributes) (see [below for nested schema](#nestedatt--harnesses))
-- `log` (Attributes) (see [below for nested schema](#nestedatt--log))
 - `repo` (String) The target repository the provider will use for pushing/pulling dynamically built images.
 - `sandbox` (Attributes) The optional configuration for all test sandboxes. (see [below for nested schema](#nestedatt--sandbox))
 - `test_execution` (Attributes) (see [below for nested schema](#nestedatt--test_execution))
@@ -171,23 +170,6 @@ Optional:
 - `key_file` (String)
 
 
-
-
-
-<a id="nestedatt--log"></a>
-### Nested Schema for `log`
-
-Optional:
-
-- `file` (Attributes) Output logs to a file. (see [below for nested schema](#nestedatt--log--file))
-
-<a id="nestedatt--log--file"></a>
-### Nested Schema for `log.file`
-
-Optional:
-
-- `directory` (String) The directory to write the log file to.
-- `format` (String) The format of the log entries (text|json).
 
 
 

--- a/internal/log/tf.go
+++ b/internal/log/tf.go
@@ -23,11 +23,14 @@ func (h *TFHandler) Enabled(_ context.Context, _ slog.Level) bool {
 
 // Handle implements slog.Handler.
 func (h *TFHandler) Handle(ctx context.Context, record slog.Record) error {
-	ctx = tflog.NewSubsystem(
-		ctx,
-		subsystem,
-		tflog.WithAdditionalLocationOffset(3),
-		tflog.WithLevelFromEnv("TF_LOG_PROVIDER", subsystem))
+	// This is a bit of a hack, but it's the only way to get the correct
+	// source location for the log message.
+	//
+	// This creates a new tflog subsystem for logging, with the location
+	// offset set to 4, which is the number of frames between this function
+	// and the actual logging call site. Then we use this subsystem below to log
+	// the message to TF's logger.
+	ctx = tflog.NewSubsystem(ctx, subsystem, tflog.WithAdditionalLocationOffset(4))
 
 	attrs := make(map[string]any)
 	for _, attr := range h.attrs {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -29,7 +29,6 @@ type ImageTestProvider struct {
 
 // ImageTestProviderModel describes the provider data model.
 type ImageTestProviderModel struct {
-	Log           *ProviderLoggerModel           `tfsdk:"log"`
 	Harnesses     *ImageTestProviderHarnessModel `tfsdk:"harnesses"`
 	TestExecution *ProviderTestExecutionModel    `tfsdk:"test_execution"`
 	Repo          types.String                   `tfsdk:"repo"`
@@ -63,15 +62,6 @@ type ProviderHarnessDockerModel struct {
 	Envs           *HarnessContainerEnvs                  `tfsdk:"envs"`
 	Mounts         []ContainerMountModel                  `tfsdk:"mounts"`
 	Registries     map[string]DockerRegistryResourceModel `tfsdk:"registries"`
-}
-
-type ProviderLoggerModel struct {
-	File *ProviderLoggerFileModel `tfsdk:"file"`
-}
-
-type ProviderLoggerFileModel struct {
-	Directory types.String `tfsdk:"directory"`
-	Format    types.String `tfsdk:"format"`
 }
 
 type ProviderTestExecutionModel struct {
@@ -116,25 +106,6 @@ func (p *ImageTestProvider) Schema(ctx context.Context, req provider.SchemaReque
 						Description:         "Skips the teardown of test harnesses to allow debugging test failures",
 						MarkdownDescription: "Skips the teardown of test harnesses to allow debugging test failures. Harness teardown can also be skipped by setting the environment variable `IMAGETEST_SKIP_TEARDOWN` to `true`",
 						Optional:            true,
-					},
-				},
-			},
-			"log": schema.SingleNestedAttribute{
-				Optional: true,
-				Attributes: map[string]schema.Attribute{
-					"file": schema.SingleNestedAttribute{
-						Description: "Output logs to a file.",
-						Optional:    true,
-						Attributes: map[string]schema.Attribute{
-							"format": schema.StringAttribute{
-								Description: "The format of the log entries (text|json).",
-								Optional:    true,
-							},
-							"directory": schema.StringAttribute{
-								Description: "The directory to write the log file to.",
-								Optional:    true,
-							},
-						},
 					},
 				},
 			},

--- a/main.go
+++ b/main.go
@@ -12,7 +12,6 @@ import (
 	log2 "github.com/chainguard-dev/terraform-provider-imagetest/internal/log"
 	"github.com/chainguard-dev/terraform-provider-imagetest/internal/provider"
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
-	slogmulti "github.com/samber/slog-multi"
 )
 
 // Run "go generate" to format example terraform files and generate the docs for the registry/website
@@ -56,10 +55,7 @@ func main() {
 
 // setupLog sets up the default logging configuration.
 func setupLog(ctx context.Context) context.Context {
-	logger := clog.New(slogmulti.Fanout(
-		&log2.TFHandler{},
-	))
-	ctx = clog.WithLogger(ctx, logger)
-	slog.SetDefault(&logger.Logger)
-	return ctx
+	slog.SetDefault(slog.New(&log2.TFHandler{}))
+	log := clog.New(slog.Default().Handler())
+	return clog.WithLogger(ctx, log)
 }


### PR DESCRIPTION
`slog-multi` was added a while ago to attempt to prepare to tee logs to multiple sinks, with the advent of `imagetest_tests` and other log collectors, this is no longer needed.

we also never really got the location offset right, so all messages were coming from the wrong (slog-multi) call site instead. this fixes that:

```
2025-02-05T10:32:17.609-0500 [INFO]  provider.terraform-provider-imagetest: }: @caller=/Users/wolf/dev/gh/chainguard/terraform-provider-imagetest/internal/drivers/docker_in_docker/driver.go:147 @module=imagetest.imagetest test_name=sample test_ref=localhost:5555/foo/imagetest@sha256:d612f122ed1b576cbbb2aa3a78bdacf1892868e05538c331a6f83ff8deae39ad timestamp=2025-02-05T10:32:17.609-0500
```