### PR TITLE
plumb through extra-repos

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -48,6 +48,7 @@ provider "imagetest" {
 
 ### Optional
 
+- `extra_repos` (List of String) An optional list of extra oci registries to wire in auth credentials for.
 - `harnesses` (Attributes) (see [below for nested schema](#nestedatt--harnesses))
 - `repo` (String) The target repository the provider will use for pushing/pulling dynamically built images.
 - `sandbox` (Attributes) The optional configuration for all test sandboxes. (see [below for nested schema](#nestedatt--sandbox))

--- a/internal/provider/drivers.go
+++ b/internal/provider/drivers.go
@@ -49,8 +49,7 @@ type DockerInDockerDriverResourceModel struct {
 	Image types.String `tfsdk:"image"`
 }
 
-type EKSWithEksctlDriverResourceModel struct {
-}
+type EKSWithEksctlDriverResourceModel struct{}
 
 func (t TestsResource) LoadDriver(ctx context.Context, drivers *TestsDriversResourceModel, driver DriverResourceModel, id string) (drivers.Tester, error) {
 	if drivers == nil {
@@ -66,6 +65,10 @@ func (t TestsResource) LoadDriver(ctx context.Context, drivers *TestsDriversReso
 
 		opts := []k3sindocker.DriverOpts{
 			k3sindocker.WithRegistry(t.repo.RegistryStr()),
+		}
+
+		for _, repo := range t.extraRepos {
+			opts = append(opts, k3sindocker.WithRegistry(repo.RegistryStr()))
 		}
 
 		tf, err := os.CreateTemp("", "imagetest-k3s-in-docker")

--- a/internal/provider/store.go
+++ b/internal/provider/store.go
@@ -38,6 +38,7 @@ type ProviderStore struct {
 	// model
 	providerResourceData ImageTestProviderModel
 	repo                 name.Repository
+	extraRepos           []name.Repository
 	ropts                []remote.Option
 	entrypointLayers     map[string][]v1.Layer
 }

--- a/internal/provider/tests_resource.go
+++ b/internal/provider/tests_resource.go
@@ -43,7 +43,8 @@ type TestsResource struct {
 	framework.WithNoOpDelete
 	framework.WithNoOpRead
 
-	repo             name.Repository
+	repo             name.Repository   // The primary target_repository used for publishing test sandboxes
+	extraRepos       []name.Repository // Extra repositories to wire auth creds into drivers
 	ropts            []remote.Option
 	entrypointLayers map[string][]v1.Layer
 	includeTests     map[string]string
@@ -203,6 +204,7 @@ func (t *TestsResource) Configure(ctx context.Context, req resource.ConfigureReq
 	}
 
 	t.repo = store.repo
+	t.extraRepos = store.extraRepos
 	t.ropts = store.ropts
 	t.entrypointLayers = store.entrypointLayers
 	t.includeTests = store.includeTests


### PR DESCRIPTION
plumb through an optional `extra_repos` provider scoped attribute, useable as a simpler way to wire in additional cred-helper auth to various harnesses/tests