### PR TITLE
update presubmit to only test terraform 1.9.x

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,7 +53,7 @@ jobs:
           cache: true
       - uses: hashicorp/setup-terraform@651471c36a6092792c552e8b1bef71e592b462d8 # v3.1.1
         with:
-          terraform_version: "1.8.*"
+          terraform_version: "1.9.*"
           terraform_wrapper: false
       - run: go generate ./...
       - name: git diff
@@ -72,7 +72,6 @@ jobs:
       matrix:
         # list whatever Terraform versions here you would like to support
         terraform:
-          - "1.8.*"
           - "1.9.*"
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
@@ -117,7 +116,7 @@ jobs:
           cache: true
       - uses: hashicorp/setup-terraform@651471c36a6092792c552e8b1bef71e592b462d8 # v3.1.1
         with:
-          terraform_version: "1.8.*"
+          terraform_version: "1.9.*"
           terraform_wrapper: false
 
       - name: Build the provider


### PR DESCRIPTION
this needs to mark 1.8 acceptance not required.