### PR TITLE
Build imagetest using sbin-merged busybox

### DIFF
--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,4 +1,4 @@
-defafultBaseImage: cgr.dev/chainguard/busybox:latest
+defafultBaseImage: cgr.dev/chainguard/busybox@sha256:d59ebd4475c8bbab39d5909f06593febb9effcce6aa895871150ce39ed1937f6
 
 defaultPlatforms:
 - linux/arm64


### PR DESCRIPTION
Build imagetest using sbin-merged busybox

Currently image busybox/static/go/rust fail release, due to missbuilt dind imagetest harness container that is reverting /sbin from symlink to a dir.

Rebuild imagetest entrypoint provider with up to date byhash busybox.