### PR TITLE
add an "exiting_cluster" driver

### DIFF
--- a/cmd/entrypoint/kodata/entrypoint-wrapper.sh
+++ b/cmd/entrypoint/kodata/entrypoint-wrapper.sh
@@ -17,7 +17,7 @@ error() {
 usage() {
   error "Usage: $0 <test-script-path>"
   error "Environment variables:"
-  error "  IMAGETEST_DRIVER: Type of test environment (docker_in_docker, k3s_in_docker, eks_with_eksctl)"
+  error "  IMAGETEST_DRIVER: Type of test environment (docker_in_docker, k3s_in_docker, eks_with_eksctl, existing_cluster)"
   exit 1
 }
 
@@ -132,6 +132,27 @@ init_eks_with_eksctl() {
   exec "$cmd"
 }
 
+# Initialize and manage an existing cluster environment.
+# Arguments:
+#   $1: Path to the test script (already validated)
+init_existing_cluster() {
+  cmd="$1"
+
+  # Ensure required environment variables are set
+  if [ -z "${POD_NAME-}" ] || [ -z "${POD_NAMESPACE-}" ]; then
+    error "POD_NAME and POD_NAMESPACE environment variables must be set"
+    exit 1
+  fi
+
+  info "Waiting for pod ${POD_NAME} to be ready..."
+  if ! kubectl wait --for=condition=Ready=true pod/"${POD_NAME}" -n "${POD_NAMESPACE}" --timeout=60s; then
+    error "Pod ${POD_NAME} failed to become ready"
+    exit 1
+  fi
+
+  exec "$cmd"
+}
+
 # Validate command-line arguments
 if [ $# -ne 1 ]; then
   usage
@@ -158,6 +179,9 @@ k3s_in_docker)
   ;;
 eks_with_eksctl)
   init_eks_with_eksctl "$cmd"
+  ;;
+existing_cluster)
+  init_existing_cluster "$cmd"
   ;;
 *)
   error "Unknown driver '$IMAGETEST_DRIVER'"

--- a/docs/resources/tests.md
+++ b/docs/resources/tests.md
@@ -41,6 +41,7 @@ Optional:
 
 - `docker_in_docker` (Attributes) The docker_in_docker driver (see [below for nested schema](#nestedatt--drivers--docker_in_docker))
 - `eks_with_eksctl` (Attributes) The eks_with_eksctl driver (see [below for nested schema](#nestedatt--drivers--eks_with_eksctl))
+- `existing_cluster` (Attributes) The existing_cluster driver (see [below for nested schema](#nestedatt--drivers--existing_cluster))
 - `k3s_in_docker` (Attributes) The k3s_in_docker driver (see [below for nested schema](#nestedatt--drivers--k3s_in_docker))
 
 <a id="nestedatt--drivers--docker_in_docker"></a>
@@ -55,6 +56,10 @@ Optional:
 ### Nested Schema for `drivers.eks_with_eksctl`
 
 
+<a id="nestedatt--drivers--existing_cluster"></a>
+### Nested Schema for `drivers.existing_cluster`
+
+
 <a id="nestedatt--drivers--k3s_in_docker"></a>
 ### Nested Schema for `drivers.k3s_in_docker`
 
@@ -65,6 +70,7 @@ Optional:
 - `metrics_server` (Boolean) Enable the metrics server
 - `network_policy` (Boolean) Enable the network policy
 - `registries` (Attributes Map) A map of registries containing configuration for optional auth, tls, and mirror configuration. (see [below for nested schema](#nestedatt--drivers--k3s_in_docker--registries))
+- `snapshotter` (String) The containerd snapshotter to use
 - `traefik` (Boolean) Enable the traefik ingress controller
 
 <a id="nestedatt--drivers--k3s_in_docker--registries"></a>

--- a/internal/drivers/existing_cluster/doc.go
+++ b/internal/drivers/existing_cluster/doc.go
@@ -1,0 +1,3 @@
+// existingk8s is a driver that runs each test in a pod using
+// whatever the currently scoped kube client is
+package existingcluster

--- a/internal/drivers/existing_cluster/driver.go
+++ b/internal/drivers/existing_cluster/driver.go
@@ -1,0 +1,82 @@
+package existingcluster
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/chainguard-dev/terraform-provider-imagetest/internal/drivers"
+	"github.com/chainguard-dev/terraform-provider-imagetest/internal/drivers/pod"
+	"github.com/chainguard-dev/terraform-provider-imagetest/internal/harness"
+	"github.com/google/go-containerregistry/pkg/name"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+type driver struct {
+	stack *harness.Stack
+	kcli  *kubernetes.Clientset
+}
+
+func NewDriver(n string, opts ...DriverOpts) (drivers.Tester, error) {
+	k := &driver{
+		stack: harness.NewStack(),
+	}
+
+	for _, opt := range opts {
+		if err := opt(k); err != nil {
+			return nil, err
+		}
+	}
+
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		rules := clientcmd.NewDefaultClientConfigLoadingRules()
+		overrides := &clientcmd.ConfigOverrides{}
+
+		kcfg := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(rules, overrides)
+
+		config, err = kcfg.ClientConfig()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	kcli, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, err
+	}
+	k.kcli = kcli
+
+	return k, nil
+}
+
+func (k *driver) Setup(ctx context.Context) error {
+	req := k.kcli.RESTClient().Get().AbsPath("/healthz").Do(ctx)
+
+	code := 0
+	req.StatusCode(&code)
+
+	if code != 200 {
+		return fmt.Errorf("kubernetes cluster is not healthy")
+	}
+
+	return nil
+}
+
+func (k *driver) Teardown(ctx context.Context) error {
+	return k.stack.Teardown(ctx)
+}
+
+func (k *driver) Run(ctx context.Context, ref name.Reference) error {
+	return pod.Run(ctx, k.kcli,
+		pod.WithImageRef(ref),
+		pod.WithExtraEnvs(map[string]string{
+			"IMAGETEST_DRIVER": "existing_cluster",
+		}),
+		// Use our own stack since we have to try to clean up k8s resources after
+		// tests are run with this driver, instead of just destroying the cluster
+		// itself like we normally do
+		pod.WithStack(k.stack),
+	)
+}

--- a/internal/drivers/existing_cluster/opts.go
+++ b/internal/drivers/existing_cluster/opts.go
@@ -1,0 +1,3 @@
+package existingcluster
+
+type DriverOpts func(*driver) error

--- a/internal/drivers/pod/opts.go
+++ b/internal/drivers/pod/opts.go
@@ -1,6 +1,9 @@
 package pod
 
-import "github.com/google/go-containerregistry/pkg/name"
+import (
+	"github.com/chainguard-dev/terraform-provider-imagetest/internal/harness"
+	"github.com/google/go-containerregistry/pkg/name"
+)
 
 func WithImageRef(ref name.Reference) RunOpts {
 	return func(o *opts) error {
@@ -15,6 +18,13 @@ func WithExtraEnvs(envs map[string]string) RunOpts {
 			envs = make(map[string]string)
 		}
 		o.ExtraEnvs = envs
+		return nil
+	}
+}
+
+func WithStack(stack *harness.Stack) RunOpts {
+	return func(o *opts) error {
+		o.stack = stack
 		return nil
 	}
 }


### PR DESCRIPTION
add a new `existing_cluster` driver which mostly exists for the exception cases where folks may want to "byo" cluster, instead of having the provider provision one for you.

notably, because of the landscape of what "byo" cluster can entail, this provider currently (and likely never will) handle:

- registry auth (also needs to be "byo")
- local registry networking (also needs to be "byo")

additionally, because we're restricted to being in a terraform provider, there's a chance that despite the ugly global lock we take out at the provider level, that another provider daemon can spin up and squash any locking attempts we try to take.

in general its not recommend to use this driver unless you:

- know and plan around the caveats
- are running a _single_ test