### PR TITLE
plumb through k3s hooks

### DIFF
--- a/docs/resources/tests.md
+++ b/docs/resources/tests.md
@@ -61,11 +61,21 @@ Optional:
 Optional:
 
 - `cni` (Boolean) Enable the CNI plugin
+- `hooks` (Attributes) Run commands at various lifecycle events (see [below for nested schema](#nestedatt--drivers--k3s_in_docker--hooks))
 - `image` (String) The image reference to use for the k3s_in_docker driver
 - `metrics_server` (Boolean) Enable the metrics server
 - `network_policy` (Boolean) Enable the network policy
 - `registries` (Attributes Map) A map of registries containing configuration for optional auth, tls, and mirror configuration. (see [below for nested schema](#nestedatt--drivers--k3s_in_docker--registries))
+- `snapshotter` (String) The snapshotter to use for the k3s_in_docker driver
 - `traefik` (Boolean) Enable the traefik ingress controller
+
+<a id="nestedatt--drivers--k3s_in_docker--hooks"></a>
+### Nested Schema for `drivers.k3s_in_docker.hooks`
+
+Optional:
+
+- `post_start` (List of String)
+
 
 <a id="nestedatt--drivers--k3s_in_docker--registries"></a>
 ### Nested Schema for `drivers.k3s_in_docker.registries`

--- a/internal/drivers/k3s_in_docker/opts.go
+++ b/internal/drivers/k3s_in_docker/opts.go
@@ -112,3 +112,16 @@ func WithRegistryMirror(registry string, endpoints ...string) DriverOpts {
 		return nil
 	}
 }
+
+func WithPostStartHook(hook string) DriverOpts {
+	return func(k *driver) error {
+		if k.Hooks == nil {
+			k.Hooks = &K3sHooks{}
+		}
+		if k.Hooks.PostStart == nil {
+			k.Hooks.PostStart = make([]string, 0)
+		}
+		k.Hooks.PostStart = append(k.Hooks.PostStart, hook)
+		return nil
+	}
+}

--- a/internal/provider/testdata/TestAccTestsResource/k3s-in-docker-hooks.sh
+++ b/internal/provider/testdata/TestAccTestsResource/k3s-in-docker-hooks.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+# ensure something we created in the post hook is present
+kubectl wait --for=condition=Ready pod foo -n default --timeout=2m

--- a/internal/provider/tests_resource_test.go
+++ b/internal/provider/tests_resource_test.go
@@ -91,6 +91,40 @@ resource "imagetest_tests" "foo" {
 		// 		},
 		// 	},
 		// },
+		"k3sindocker-hooks": {
+			{
+				Config: fmt.Sprintf(`
+resource "imagetest_tests" "foo" {
+  name   = "foo"
+  driver = "k3s_in_docker"
+
+  drivers = {
+    k3s_in_docker = {
+      hooks = {
+        post_start = ["kubectl run foo --image=cgr.dev/chainguard/busybox:latest --restart=Never -- tail -f /dev/null"]
+      }
+    }
+  }
+
+  images = {
+    foo = "cgr.dev/chainguard/busybox:latest@sha256:98fa8044785ff59248ec9e5747bff259c6fe4b526ebb77d95d8a98ad958847dd"
+  }
+
+  tests = [
+    {
+      name    = "sample"
+      image   = "cgr.dev/chainguard/kubectl:latest-dev@sha256:1d8c1f0c437628aafa1bca52c41ff310aea449423cce9b2feae2767ac53c336f"
+      content = [{ source = "${path.module}/testdata/TestAccTestsResource" }]
+      cmd     = "/imagetest/%s"
+    }
+  ]
+
+  // Something before GHA timeouts
+  timeout = "5m"
+}
+        `, "k3s-in-docker-hooks.sh"),
+			},
+		},
 
 		"dockerindocker-basic": {{Config: fmt.Sprintf(dockerindockerTpl, "docker-in-docker-basic.sh")}},
 		"dockerindocker-fails-message": {


### PR DESCRIPTION
this is almost identical to how `imagetest_harness_k3s` handles hooks, only now plumbed in through `k3s_in_docker`.

the only delta here is now we properly handle the potential race, where the `default` serviceaccount might not exist when we start the hooks.