### PR TITLE
Build imagetest using bin-merged static image

### DIFF
--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,4 +1,4 @@
-defaultBaseImage: cgr.dev/chainguard/static@sha256:3e9af2550ae5ff1fe5b9d69332955c01213c37c75874b184e5fbea500d1c9808
+defaultBaseImage: cgr.dev/chainguard/static@sha256:7a6456cc96ecde793b7c8ad9a3ccd5d610d6168a6f64d693ecc2e84f8276c6c6
 
 defaultPlatforms:
 - linux/arm64


### PR DESCRIPTION
Build imagetest using bin-merged static image

As seen on oci.chaindag.dev