### PR TITLE
use a registry proxy builtin to the entrypoint instead of socat

### DIFF
--- a/cmd/entrypoint/kodata/entrypoint-wrapper.sh
+++ b/cmd/entrypoint/kodata/entrypoint-wrapper.sh
@@ -36,25 +36,6 @@ validate_cmd() {
   fi
 }
 
-init_registry_proxy() {
-  # Check if IMAGETEST_REGISTRY is set and contains "localhost"
-  if [ -z "${IMAGETEST_REGISTRY:-}" ] || ! echo "$IMAGETEST_REGISTRY" | grep -q "localhost"; then
-    return
-  fi
-
-  info "Local registry detected, attempting to start registry proxy"
-
-  # Extract port number following "localhost:"
-  port=$(echo "$IMAGETEST_REGISTRY" | sed -n 's/.*localhost:\([0-9]\+\).*/\1/p')
-
-  if [ -n "$port" ]; then
-    info "Detected localhost and port ${port}, starting registry proxy"
-
-    # Start a non-forked socat process to proxy localhost to dockers magic dns
-    setsid socat -d -lf /tmp/local-registry-proxy.log TCP-LISTEN:"${port}",fork,reuseaddr TCP:host.docker.internal:"${port}" </dev/null >/dev/null 2>&1 &
-  fi
-}
-
 # Initialize and manage a Docker-in-Docker environment.
 # This function handles the Docker daemon startup and monitoring.
 # Arguments:
@@ -86,9 +67,6 @@ init_docker_in_docker() {
     error "Docker daemon failed to start"
     exit 1
   fi
-
-  # Maybe start a registry proxy
-  init_registry_proxy
 
   exec "$cmd"
 }

--- a/internal/drivers/docker_in_docker/opts.go
+++ b/internal/drivers/docker_in_docker/opts.go
@@ -69,3 +69,25 @@ func WithRegistryAuth(registry string) DriverOpts {
 		return nil
 	}
 }
+
+func WithExtraHosts(hosts ...string) DriverOpts {
+	return func(d *driver) error {
+		if d.ExtraHosts == nil {
+			d.ExtraHosts = make([]string, 0)
+		}
+		d.ExtraHosts = append(d.ExtraHosts, hosts...)
+		return nil
+	}
+}
+
+func WithExtraEnvs(envs map[string]string) DriverOpts {
+	return func(d *driver) error {
+		if d.Envs == nil {
+			d.Envs = make(map[string]string)
+		}
+		for k, v := range envs {
+			d.Envs[k] = v
+		}
+		return nil
+	}
+}

--- a/internal/drivers/k3s_in_docker/driver.go
+++ b/internal/drivers/k3s_in_docker/driver.go
@@ -37,8 +37,9 @@ type driver struct {
 	NetworkPolicy bool           // Toggles whether the default k3s network policy controller is enabled
 	Snapshotter   string         // The containerd snapshotter to use
 	Registries    map[string]*K3sRegistryConfig
-	Namespace     string    // The namespace to use for the test pods
-	Hooks         *K3sHooks // Run commands at various lifecycle events
+	Namespace     string            // The namespace to use for the test pods
+	Hooks         *K3sHooks         // Run commands at various lifecycle events
+	SandboxEnvs   map[string]string // Additional environment variables to set in the sandbox
 
 	kubeconfigWritePath string // When set, the generated kubeconfig will be written to this path on the host
 
@@ -287,6 +288,7 @@ func (k *driver) Run(ctx context.Context, ref name.Reference) error {
 		pod.WithExtraEnvs(map[string]string{
 			"IMAGETEST_DRIVER": "k3s_in_docker",
 		}),
+		pod.WithExtraEnvs(k.SandboxEnvs),
 	)
 }
 

--- a/internal/drivers/k3s_in_docker/opts.go
+++ b/internal/drivers/k3s_in_docker/opts.go
@@ -125,3 +125,25 @@ func WithPostStartHook(hook string) DriverOpts {
 		return nil
 	}
 }
+
+func WithSandboxEnv(key, value string) DriverOpts {
+	return func(k *driver) error {
+		if k.SandboxEnvs == nil {
+			k.SandboxEnvs = make(map[string]string)
+		}
+		k.SandboxEnvs[key] = value
+		return nil
+	}
+}
+
+func WithSandboxEnvs(envs map[string]string) DriverOpts {
+	return func(d *driver) error {
+		if d.SandboxEnvs == nil {
+			d.SandboxEnvs = make(map[string]string)
+		}
+		for k, v := range envs {
+			d.SandboxEnvs[k] = v
+		}
+		return nil
+	}
+}

--- a/internal/entrypoint/entrypoint.go
+++ b/internal/entrypoint/entrypoint.go
@@ -21,6 +21,10 @@ const (
 
 	// Healthcheck return code if wrapped command fails and we're paused.
 	ProcessPausedErrorCode = 927
+
+	DriverLocalRegistryEnvVar         = "IMAGETEST_LOCAL_REGISTRY"
+	DriverLocalRegistryHostnameEnvVar = "IMAGETEST_LOCAL_REGISTRY_HOSTNAME"
+	DriverLocalRegistryPortEnvVar     = "IMAGETEST_LOCAL_REGISTRY_PORT"
 )
 
 var DefaultEntrypoint = []string{


### PR DESCRIPTION
replace the existing naive `socat` tcp proxy with something _ever so slightly_ smarter. and hoist all the existing sh logic for determining local registries into the provider itself.

also ensure that `*.localhost` is added as an `ExtraHost` in docker, such that on linux environments that do not autoresolve `*.localhost` to `localhost`, that requests can find the proxy