### PR TITLE
use /imagetest/work as the default working directory

### DIFF
--- a/internal/drivers/pod/pod.go
+++ b/internal/drivers/pod/pod.go
@@ -41,7 +41,7 @@ func Run(ctx context.Context, client kubernetes.Interface, options ...RunOpts) e
 		Name:       "imagetest",
 		Namespace:  "imagetest",
 		ImageRef:   name.MustParseReference("cgr.dev/chainguard/kubectl:latest-dev"),
-		WorkingDir: "/imagetest",
+		WorkingDir: entrypoint.DefaultWorkDir,
 		ExtraLabels: map[string]string{
 			"dev.chainguard.imagetest": "true",
 		},

--- a/internal/entrypoint/entrypoint.go
+++ b/internal/entrypoint/entrypoint.go
@@ -25,6 +25,8 @@ const (
 	DriverLocalRegistryEnvVar         = "IMAGETEST_LOCAL_REGISTRY"
 	DriverLocalRegistryHostnameEnvVar = "IMAGETEST_LOCAL_REGISTRY_HOSTNAME"
 	DriverLocalRegistryPortEnvVar     = "IMAGETEST_LOCAL_REGISTRY_PORT"
+
+	DefaultWorkDir = "/imagetest/work"
 )
 
 var DefaultEntrypoint = []string{

--- a/internal/provider/tests_resource.go
+++ b/internal/provider/tests_resource.go
@@ -342,7 +342,7 @@ func (t *TestsResource) do(ctx context.Context, data *TestsResourceModel) (ds di
 		for _, c := range test.Content {
 			target := c.Target.ValueString()
 			if target == "" {
-				target = "/imagetest"
+				target = entrypoint.DefaultWorkDir
 			}
 
 			layer, err := bundler.NewLayerFromPath(c.Source.ValueString(), target)
@@ -422,7 +422,7 @@ func (t *TestsResource) do(ctx context.Context, data *TestsResourceModel) (ds di
 					cfgf.Config.Cmd = []string{test.Cmd.ValueString()}
 
 					if cfgf.Config.WorkingDir == "" {
-						cfgf.Config.WorkingDir = "/imagetest"
+						cfgf.Config.WorkingDir = entrypoint.DefaultWorkDir
 					}
 
 					cfgf.Config.User = "0:0"

--- a/internal/provider/tests_resource_test.go
+++ b/internal/provider/tests_resource_test.go
@@ -30,7 +30,7 @@ resource "imagetest_tests" "foo" {
       name    = "sample"
       image   = "cgr.dev/chainguard/kubectl:latest-dev"
       content = [{ source = "${path.module}/testdata/TestAccTestsResource" }]
-      cmd     = "/imagetest/%s"
+      cmd     = "./%s"
     }
   ]
 
@@ -53,7 +53,7 @@ resource "imagetest_tests" "foo" {
       name    = "sample"
       image   = "cgr.dev/chainguard/busybox:latest"
       content = [{ source = "${path.module}/testdata/TestAccTestsResource" }]
-      cmd     = "/imagetest/%s"
+      cmd     = "./%s"
     }
   ]
 
@@ -116,7 +116,7 @@ resource "imagetest_tests" "foo" {
       name    = "sample"
       image   = "cgr.dev/chainguard/kubectl:latest-dev"
       content = [{ source = "${path.module}/testdata/TestAccTestsResource" }]
-      cmd     = "/imagetest/%s"
+      cmd     = "./%s"
     }
   ]
 
@@ -177,7 +177,7 @@ resource "imagetest_tests" "foo" {
       name    = "sample"
       image   = "cgr.dev/chainguard/kubectl:latest-dev"
       content = [{ source = "${path.module}/testdata/TestAccTestsResource" }]
-      cmd     = "/imagetest/%[1]s"
+      cmd     = "./%[1]s"
     }
   ]
 


### PR DESCRIPTION
we want to start throwing more things into `/imagetest`, so adding a new `work/` subdir helps segment things better than just throwing everything into `/imagetest`