### PR TITLE
support multiple pause states

### DIFF
--- a/internal/drivers/drivers.go
+++ b/internal/drivers/drivers.go
@@ -6,6 +6,11 @@ import (
 	"github.com/google/go-containerregistry/pkg/name"
 )
 
+const (
+	// LogAttributeKey is the key where log lines from drivers will be surfaced.
+	LogAttributeKey = "driver_log"
+)
+
 type Tester interface {
 	// Setup creates the driver's resources, it must be run before Run() is
 	// available

--- a/internal/entrypoint/entrypoint.go
+++ b/internal/entrypoint/entrypoint.go
@@ -19,14 +19,30 @@ const (
 	// Return code if entrypoint fails.
 	InternalErrorCode = 1000
 
-	// Healthcheck return code if wrapped command fails and we're paused.
-	ProcessPausedErrorCode = 927
+	// ProcessPausedWithErrorCode is the exit code emitted when the wrapped process
+	// has failed and the entrypoint is in the paused state.
+	ProcessPausedWithErrorCode = 75
+	// ProcessPausedCode is the exit code emitted when the entrypoint is in the
+	// paused state after successful execution. This needs to be a non-zero
+	// value since the orchestrator is depending on some completion signal.
+	ProcessPausedCode = 78
 
 	DriverLocalRegistryEnvVar         = "IMAGETEST_LOCAL_REGISTRY"
 	DriverLocalRegistryHostnameEnvVar = "IMAGETEST_LOCAL_REGISTRY_HOSTNAME"
 	DriverLocalRegistryPortEnvVar     = "IMAGETEST_LOCAL_REGISTRY_PORT"
 
 	DefaultWorkDir = "/imagetest/work"
+)
+
+// PauseMode are the states of pause the entrypoint can be in.
+type PauseMode string
+
+const (
+	PauseNever   PauseMode = "never"
+	PauseOnError PauseMode = "on-error"
+	PauseAlways  PauseMode = "always"
+
+	PauseModeEnvVar = "IMAGETEST_PAUSE_MODE"
 )
 
 var DefaultEntrypoint = []string{


### PR DESCRIPTION
the `imagetest_tests` resource executes pods/containers to completion, and uses an `entrypoint` to "pause" execution on failures.

to support keeping the containers running on successful completions (without a non-zero exit code), we have to create one ourselves, and then plumb it up through to the runtime (docker/k8s) so the client can determine whether to return a failure when we're in a pause-with-error state, or to return successfully when we're in a pause-without-error state.

this also cleans up some logging