### PR TITLE
plumb through mirrors to drivers

### DIFF
--- a/cmd/entrypoint/kodata/entrypoint-wrapper.sh
+++ b/cmd/entrypoint/kodata/entrypoint-wrapper.sh
@@ -2,15 +2,15 @@
 set -eu
 
 info() {
-  printf '%s [INFO] %s\n' "$(date "+%Y-%m-%dT%H:%M:%S")" "$1" >&2
+  printf '%s INFO %s\n' "$(date "+%Y-%m-%dT%H:%M:%S")" "$1" >&2
 }
 
 warn() {
-  printf '%s [WARN] %s\n' "$(date "+%Y-%m-%dT%H:%M:%S")" "$1" >&2
+  printf '%s WARN %s\n' "$(date "+%Y-%m-%dT%H:%M:%S")" "$1" >&2
 }
 
 error() {
-  printf '%s [ERROR] %s\n' "$(date "+%Y-%m-%dT%H:%M:%S")" "$1" >&2
+  printf '%s ERROR %s\n' "$(date "+%Y-%m-%dT%H:%M:%S")" "$1" >&2
 }
 
 # Print usage and exit with error
@@ -49,7 +49,7 @@ init_docker_in_docker() {
   mkdir -p "$log_dir"
 
   # Start Docker daemon in background, capturing logs
-  /usr/bin/dockerd-entrypoint.sh dockerd --default-address-pool "base=192.0.0.0/20,size=24" >"$log_dir/dockerd.log" 2>&1 &
+  /usr/bin/dockerd-entrypoint.sh dockerd >"$log_dir/dockerd.log" 2>&1 &
 
   # Wait for Docker to be ready
   info "Waiting for Docker daemon to be ready..."

--- a/docs/resources/tests.md
+++ b/docs/resources/tests.md
@@ -49,6 +49,7 @@ Optional:
 Optional:
 
 - `image` (String) The image reference to use for the docker-in-docker driver
+- `mirrors` (List of String)
 
 
 <a id="nestedatt--drivers--eks_with_eksctl"></a>

--- a/internal/drivers/docker_in_docker/opts.go
+++ b/internal/drivers/docker_in_docker/opts.go
@@ -35,14 +35,14 @@ func WithRemoteOptions(opts ...remote.Option) DriverOpts {
 // TODO: Replace this with Jon's cred proxy: https://gist.github.com/jonjohnsonjr/6d20148edca0f187cfed050cee669685
 func WithRegistryAuth(registry string) DriverOpts {
 	return func(d *driver) error {
-		if d.config == nil {
-			d.config = &dockerConfig{
+		if d.cliCfg == nil {
+			d.cliCfg = &dockerConfig{
 				Auths: make(map[string]dockerAuthEntry),
 			}
 		}
 
-		if d.config.Auths == nil {
-			d.config.Auths = make(map[string]dockerAuthEntry)
+		if d.cliCfg.Auths == nil {
+			d.cliCfg.Auths = make(map[string]dockerAuthEntry)
 		}
 
 		r, err := name.NewRegistry(registry)
@@ -60,7 +60,7 @@ func WithRegistryAuth(registry string) DriverOpts {
 			return err
 		}
 
-		d.config.Auths[registry] = dockerAuthEntry{
+		d.cliCfg.Auths[registry] = dockerAuthEntry{
 			Username: acfg.Username,
 			Password: acfg.Password,
 			Auth:     acfg.Auth,
@@ -88,6 +88,23 @@ func WithExtraEnvs(envs map[string]string) DriverOpts {
 		for k, v := range envs {
 			d.Envs[k] = v
 		}
+		return nil
+	}
+}
+
+func WithRegistryMirrors(mirrors ...string) DriverOpts {
+	return func(d *driver) error {
+		if d.daemonCfg == nil {
+			d.daemonCfg = &daemonConfig{
+				Mirrors: make([]string, 0),
+			}
+		}
+
+		if d.daemonCfg.Mirrors == nil {
+			d.daemonCfg.Mirrors = make([]string, 0)
+		}
+
+		d.daemonCfg.Mirrors = append(d.daemonCfg.Mirrors, mirrors...)
 		return nil
 	}
 }

--- a/internal/provider/drivers.go
+++ b/internal/provider/drivers.go
@@ -55,7 +55,8 @@ type K3sInDockerDriverHooksModel struct {
 }
 
 type DockerInDockerDriverResourceModel struct {
-	Image types.String `tfsdk:"image"`
+	Image   types.String `tfsdk:"image"`
+	Mirrors []string     `tfsdk:"mirrors"`
 }
 
 type EKSWithEksctlDriverResourceModel struct{}
@@ -157,6 +158,10 @@ func (t TestsResource) LoadDriver(ctx context.Context, drivers *TestsDriversReso
 			opts = append(opts, dockerindocker.WithImageRef(cfg.Image.ValueString()))
 		}
 
+		if len(cfg.Mirrors) > 0 {
+			opts = append(opts, dockerindocker.WithRegistryMirrors(cfg.Mirrors...))
+		}
+
 		if isLocalRegistry(t.repo.Registry) {
 			u, err := url.Parse("http://" + t.repo.RegistryStr())
 			if err != nil {
@@ -256,6 +261,10 @@ func DriverResourceSchema(ctx context.Context) schema.SingleNestedAttribute {
 				Attributes: map[string]schema.Attribute{
 					"image": schema.StringAttribute{
 						Description: "The image reference to use for the docker-in-docker driver",
+						Optional:    true,
+					},
+					"mirrors": schema.ListAttribute{
+						ElementType: types.StringType,
 						Optional:    true,
 					},
 				},


### PR DESCRIPTION
the k3s driver already supports this, so this just plumbs through "mirrors" to the dind driver in the appropriate `/etc/docker/daemon.json`.

while we're here, this also hoists the cli arg for `--default-address-pool` into its appropriate `/etc/docker/daemon.json` format.

finally, this changes the `default-address-pool` to something RFC 1918 compliant that doesn't overlap with dockerd's default address pool (since we're docker in docker)
