### PR TITLE
lambda: take execution role as a parameter

### DIFF
--- a/docs/resources/tests_lambda.md
+++ b/docs/resources/tests_lambda.md
@@ -17,6 +17,7 @@ description: |-
 
 ### Required
 
+- `execution_role` (String) The ARN of the IAM role to use for the Lambda function.
 - `image_ref` (String) The image ref to deploy and test.
 
 ### Optional

--- a/internal/drivers/lambda/TESTING.md
+++ b/internal/drivers/lambda/TESTING.md
@@ -18,7 +18,7 @@ aws iam create-role \
 
 ```
 IMAGETEST_LAMBDA_TEST_IMAGE_REF=12345.dkr.ecr.us-west-2.amazonaws.com/foo@sha256:07a99c... \
-IMAGETEST_LAMBDA_ROLE=arn:aws:iam::12345:role/lambda-ex \
+IMAGETEST_LAMBDA_TEST_EXECUTION_ROLE=arn:aws:iam::12345:role/lambda-ex \
 TF_ACC=1 \
   go test -tags=lambda ./internal/provider/... -count=1 -v -run=Lambda -timeout=5m
 ```

--- a/internal/provider/tests_lambda_resource.go
+++ b/internal/provider/tests_lambda_resource.go
@@ -35,10 +35,11 @@ type TestsLambdaResource struct {
 }
 
 type TestsLambdaResourceModel struct {
-	Id       types.String `tfsdk:"id"`
-	Name     types.String `tfsdk:"name"`
-	ImageRef types.String `tfsdk:"image_ref"`
-	Region   types.String `tfsdk:"region"`
+	Id            types.String `tfsdk:"id"`
+	Name          types.String `tfsdk:"name"`
+	ImageRef      types.String `tfsdk:"image_ref"`
+	ExecutionRole types.String `tfsdk:"execution_role"`
+	Region        types.String `tfsdk:"region"`
 }
 
 func (t *TestsLambdaResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
@@ -57,6 +58,10 @@ func (t *TestsLambdaResource) Schema(ctx context.Context, req resource.SchemaReq
 			},
 			"image_ref": schema.StringAttribute{
 				Description: "The image ref to deploy and test.",
+				Required:    true,
+			},
+			"execution_role": schema.StringAttribute{
+				Description: "The ARN of the IAM role to use for the Lambda function.",
 				Required:    true,
 			},
 			"region": schema.StringAttribute{
@@ -113,7 +118,7 @@ func (t *TestsLambdaResource) do(ctx context.Context, data *TestsLambdaResourceM
 
 	t.ropts = append(t.ropts, remote.WithContext(ctx))
 
-	dr, err := lambda.NewDriver(data.ImageRef.ValueString(), data.Region.ValueString())
+	dr, err := lambda.NewDriver(data.ImageRef.ValueString(), data.Region.ValueString(), data.ExecutionRole.ValueString())
 	if err != nil {
 		return []diag.Diagnostic{diag.NewErrorDiagnostic("failed to create driver", err.Error())}
 	}

--- a/internal/provider/tests_lambda_resource_test.go
+++ b/internal/provider/tests_lambda_resource_test.go
@@ -18,14 +18,20 @@ func TestAccTestsResource_Lambda(t *testing.T) {
 	if ref == "" {
 		t.Fatal("IMAGETEST_LAMBDA_TEST_IMAGE_REF must be set")
 	}
+	executionRole := os.Getenv("IMAGETEST_LAMBDA_TEST_EXECUTION_ROLE")
+	if executionRole == "" {
+		t.Fatal("IMAGETEST_LAMBDA_TEST_EXECUTION_ROLE must be set")
+	}
+
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
 			"imagetest": providerserver.NewProtocol6WithError(&ImageTestProvider{}),
 		},
 		Steps: []resource.TestStep{{Config: fmt.Sprintf(`resource "imagetest_tests_lambda" "foo" {
-  name      = "foo"
-  image_ref = %q
-}`, ref)}},
+  name           = "foo"
+  execution_role = %q
+  image_ref      = %q
+}`, executionRole, ref)}},
 	})
 }


### PR DESCRIPTION
Rather than making this get passed in via env vars.

We could do something smart and try to determine the role ARN from the image ref and some convention about what the role is called, but that feels too magical.