### PR TITLE
lambda: fail if the function fails, improve debugging

### DIFF
--- a/docs/resources/tests_lambda.md
+++ b/docs/resources/tests_lambda.md
@@ -22,9 +22,8 @@ description: |-
 
 ### Optional
 
-- `name` (String) The name of the test. If one is not provided, a random name will be generated.
 - `region` (String) The AWS region to deploy the test in. If not provided, the default region will be used.
 
 ### Read-Only
 
-- `id` (String) The unique identifier for the test. If a name is provided, this will be the name appended with a random suffix.
+- `id` (String) The unique identifier for the test. This will be the same as the image ref's digest.

--- a/internal/drivers/lambda/driver.go
+++ b/internal/drivers/lambda/driver.go
@@ -15,7 +15,6 @@ import (
 )
 
 type driver struct {
-	name          string
 	region        string
 	executionRole string
 	functionName  string
@@ -27,9 +26,8 @@ type driver struct {
 //
 // This isn't used by the typical imagetest_tests resource, but is instead used by
 // the imagetest_tests_lambda resource. It satisfies the same interface anyway.
-func NewDriver(name, region, executionRole string) (drivers.Tester, error) {
+func NewDriver(region, executionRole string) (drivers.Tester, error) {
 	return &driver{
-		name:          name,
 		region:        region,
 		executionRole: executionRole,
 	}, nil
@@ -65,7 +63,7 @@ func (k *driver) Run(ctx context.Context, ref name.Reference) (*drivers.RunResul
 		return nil, fmt.Errorf("expected digest reference, got %T %q", ref, ref)
 	}
 
-	k.functionName = fmt.Sprintf("imagetest-%s-%d", dig.DigestStr()[8:16], time.Now().Unix())
+	k.functionName = fmt.Sprintf("imagetest-%s-%d", dig.DigestStr()[8:16], time.Now().UnixNano())
 	if _, err := k.client.CreateFunction(ctx, &lambda.CreateFunctionInput{
 		FunctionName: &k.functionName,
 		Code:         &types.FunctionCode{ImageUri: &[]string{ref.String()}[0]},

--- a/internal/drivers/lambda/driver.go
+++ b/internal/drivers/lambda/driver.go
@@ -108,7 +108,7 @@ L:
 	} else if out.StatusCode != 200 {
 		return nil, fmt.Errorf("function returned %d: %s", out.StatusCode, string(out.Payload))
 	} else if out.FunctionError != nil {
-		return nil, fmt.Errorf("function returned error: %q", *out.FunctionError)
+		return nil, fmt.Errorf("function returned error: %q: %s", *out.FunctionError, string(out.Payload))
 	} else {
 		if out == nil {
 			return nil, fmt.Errorf("function returned nil output")

--- a/internal/drivers/lambda/driver.go
+++ b/internal/drivers/lambda/driver.go
@@ -104,7 +104,7 @@ L:
 
 	// Invoke the function to ensure it is ready.
 	if out, err := k.client.Invoke(ctx, &lambda.InvokeInput{FunctionName: &k.functionName}); err != nil {
-		return nil, fmt.Errorf("failed to invoke Lambda function:q %w", err)
+		return nil, fmt.Errorf("failed to invoke Lambda function: %w", err)
 	} else if out.StatusCode != 200 {
 		return nil, fmt.Errorf("function returned %d: %s", out.StatusCode, string(out.Payload))
 	} else if out.FunctionError != nil {

--- a/internal/provider/tests_lambda_resource_test.go
+++ b/internal/provider/tests_lambda_resource_test.go
@@ -29,7 +29,6 @@ func TestAccTestsResource_Lambda(t *testing.T) {
 			"imagetest": providerserver.NewProtocol6WithError(&ImageTestProvider{}),
 		},
 		Steps: []resource.TestStep{{Config: fmt.Sprintf(`resource "imagetest_tests_lambda" "foo" {
-  name           = "foo"
   execution_role = %q
   image_ref      = %q
 }`, executionRole, ref)}},


### PR DESCRIPTION
Previously if deploying failed it would proceed to invoke, and fail there just saying "function is Failed"

With this change we get a better experience when the image is invalid:

```
=== RUN   TestAccTestsResource_Lambda
    tests_lambda_resource_test.go:26: Step 1/1 error: Error running apply: exit status 1
        
        Error: test failed
        
          with imagetest_tests_lambda.foo,
          on terraform_plugin_test.tf line 11, in resource "imagetest_tests_lambda" "foo":
          11: resource "imagetest_tests_lambda" "foo" {
        
        function failed: MissingParentDirectory: Parent directory does not exist for
        file: function/snapshot_restore_py-1.0.0.dist-info/RECORD
```