### PR TITLE
use the default namespace

### DIFF
--- a/cmd/entrypoint/kodata/entrypoint-wrapper.sh
+++ b/cmd/entrypoint/kodata/entrypoint-wrapper.sh
@@ -77,6 +77,10 @@ init_docker_in_docker() {
 init_k3s_in_docker() {
   cmd="$1"
 
+  # Set a default context to better mimic a local setup
+  kubectl config set-context default --cluster=kubernetes --user=default --namespace=default
+  kubectl config use-context default
+
   # Ensure required environment variables are set
   if [ -z "${POD_NAME-}" ] || [ -z "${POD_NAMESPACE-}" ]; then
     error "POD_NAME and POD_NAMESPACE environment variables must be set"
@@ -97,6 +101,10 @@ init_k3s_in_docker() {
 #   $1: Path to the test script (already validated)
 init_eks_with_eksctl() {
   cmd="$1"
+
+  # Set a default context to better mimic a local setup
+  kubectl config set-context default --cluster=kubernetes --user=default --namespace=default
+  kubectl config use-context default
 
   # Ensure required environment variables are set
   if [ -z "${POD_NAME-}" ] || [ -z "${POD_NAMESPACE-}" ]; then

--- a/internal/drivers/pod/pod.go
+++ b/internal/drivers/pod/pod.go
@@ -439,9 +439,10 @@ func (o *opts) pod() *corev1.Pod {
 			Annotations:  map[string]string{},
 		},
 		Spec: corev1.PodSpec{
-			ServiceAccountName: o.Name,
-			SecurityContext:    &corev1.PodSecurityContext{},
-			RestartPolicy:      corev1.RestartPolicyNever,
+			ServiceAccountName:           o.Name,
+			AutomountServiceAccountToken: ptr.To(false),
+			SecurityContext:              &corev1.PodSecurityContext{},
+			RestartPolicy:                corev1.RestartPolicyNever,
 			Volumes: []corev1.Volume{
 				{
 					Name: "kube-api-access",
@@ -463,18 +464,6 @@ func (o *opts) pod() *corev1.Pod {
 											{
 												Key:  "ca.crt",
 												Path: "ca.crt",
-											},
-										},
-									},
-								},
-								{
-									DownwardAPI: &corev1.DownwardAPIProjection{
-										Items: []corev1.DownwardAPIVolumeFile{
-											{
-												Path: "namespace",
-												FieldRef: &corev1.ObjectFieldSelector{
-													FieldPath: "metadata.namespace",
-												},
 											},
 										},
 									},

--- a/internal/provider/testdata/TestAccTestsResource/k3s-in-docker-default-namespace.sh
+++ b/internal/provider/testdata/TestAccTestsResource/k3s-in-docker-default-namespace.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+kubectl get serviceaccount default -o jsonpath='{.metadata.namespace}' | grep default

--- a/internal/provider/tests_resource_test.go
+++ b/internal/provider/tests_resource_test.go
@@ -70,8 +70,9 @@ resource "imagetest_tests" "foo" {
   `
 
 	testCases := map[string][]resource.TestStep{
-		"k3sindocker-basic":          {{Config: fmt.Sprintf(k3sindockerTpl, "k3s-in-docker-basic.sh")}},
-		"k3sindocker-non-executable": {{Config: fmt.Sprintf(k3sindockerTpl, "k3s-in-docker-non-executable.sh")}},
+		"k3sindocker-basic":             {{Config: fmt.Sprintf(k3sindockerTpl, "k3s-in-docker-basic.sh")}},
+		"k3sindocker-non-executable":    {{Config: fmt.Sprintf(k3sindockerTpl, "k3s-in-docker-non-executable.sh")}},
+		"k3sindocker-default-namespace": {{Config: fmt.Sprintf(k3sindockerTpl, "k3s-in-docker-default-namespace.sh")}},
 		// ensure command's exit code surfaces in tf error
 		"k3sindocker-fails-with-proper-exit-code": {
 			{


### PR DESCRIPTION
projecting the SA makes the testing sandbox default to `-n imagetest`, which is confusing when you're used to the default being `-n default`. this removes that footgun and treats the sandbox more like a standard env with a `default` context.