### PR TITLE
refactor pod.Run and fix a race

### DIFF
--- a/internal/drivers/pod/pod.go
+++ b/internal/drivers/pod/pod.go
@@ -9,7 +9,6 @@ import (
 	"io"
 	"os"
 	"strings"
-	"sync"
 
 	"github.com/chainguard-dev/clog"
 	"github.com/chainguard-dev/terraform-provider-imagetest/internal/drivers"
@@ -44,9 +43,8 @@ type opts struct {
 	ExtraAnnotations map[string]string
 	ExtraLabels      map[string]string
 
-	client   kubernetes.Interface
-	cfg      *rest.Config
-	logErrCh <-chan error
+	client kubernetes.Interface
+	cfg    *rest.Config
 }
 
 type RunOpts func(*opts) error
@@ -90,16 +88,13 @@ func Run(ctx context.Context, kcfg *rest.Config, options ...RunOpts) (*drivers.R
 		return nil, fmt.Errorf("failed to create pod: %w", err)
 	}
 
-	ctx = clog.WithValues(ctx,
-		"pod_name", pobj.Name,
-		"pod_namespace", pobj.Namespace,
-	)
-
-	if err := o.wait(ctx, pobj); err != nil {
-		return nil, err
+	pw, err := o.client.CoreV1().Pods(pobj.Namespace).Watch(ctx, metav1.ListOptions{
+		FieldSelector: fmt.Sprintf("metadata.name=%s", pobj.Name),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to watch pod: %w", err)
 	}
-
-	clog.InfoContext(ctx, "pod successfully started")
+	defer pw.Stop()
 
 	ew, err := o.client.CoreV1().Events(pobj.Namespace).Watch(ctx, metav1.ListOptions{
 		FieldSelector: fmt.Sprintf("involvedObject.name=%s", pobj.Name),
@@ -109,140 +104,21 @@ func Run(ctx context.Context, kcfg *rest.Config, options ...RunOpts) (*drivers.R
 	}
 	defer ew.Stop()
 
-	pw, err := o.client.CoreV1().Pods(pobj.Namespace).Watch(ctx, metav1.ListOptions{
-		FieldSelector: fmt.Sprintf("metadata.name=%s", pobj.Name),
-	})
-	if err != nil {
-		return nil, fmt.Errorf("failed to watch pod: %w", err)
-	}
-	defer pw.Stop()
+	ctx = clog.WithValues(ctx,
+		"pod_name", pobj.Name,
+		"pod_namespace", pobj.Namespace,
+	)
 
-	var sandboxErr error
+	if err := monitor(ctx, o.client, pobj); err != nil {
+		return nil, err
+	}
 
 	result := &drivers.RunResult{Artifact: &drivers.RunArtifactResult{}}
-
-	// defer trying to get the artifact
-	defer func() {
-		if err := o.getArtifact(ctx, pobj, result); err != nil {
-			clog.ErrorContext(ctx, "failed to get artifact", "error", err)
-		}
-	}()
-
-	for {
-		select {
-		case w, ok := <-ew.ResultChan():
-			if !ok {
-				continue
-			}
-
-			e, ok := w.Object.(*corev1.Event)
-			if !ok {
-				continue
-			}
-
-			clog.InfoContext(ctx, "noticed event", "message", e.Message, "reason", e.Reason, "name", e.Name)
-
-			if e.Reason == string(corev1.ResourceHealthStatusUnhealthy) && strings.Contains(e.Message, "Readiness probe failed") {
-				// this filters out "Readiness probe errored" events, which are always
-				// fired after a pod successfully completes (0/1 Completed)
-				clog.InfoContext(ctx, "test sandbox pod failed and is paused in debug mode")
-
-				pe := &PodRunError{
-					Name:      pobj.Name,
-					Namespace: pobj.Namespace,
-					ExitCode:  -1,
-					Reason:    fmt.Sprintf("readiness probe failed: %s", e.Message),
-					Logs:      o.maybeLog(ctx, pobj),
-				}
-
-				// nastiness here is to parse the health check's exit code from the
-				// readiness probe events' message. there's got to be a better way...
-				//
-				// A parseable message looks like:
-				// 	Readiness probe failed: {"time":"2025-04-02T00:10:53.017770929Z","level":"INFO","msg":"pausing after error observed","exit_code":75}
-				//
-				// This splits on the first ":", and then processes the json structured message after it
-				parts := strings.Split(e.Message, ": ")
-				if len(parts) != 2 {
-					// just return the whole message
-					pe.Reason = fmt.Sprintf("readiness probe failed with unknown readiness check message: %s", e.Message)
-					return result, pe
-				}
-
-				// extract the exit code from the error
-				var rmsg struct {
-					ExitCode int64  `json:"exit_code"`
-					Msg      string `json:"msg"`
-				}
-				if err := json.Unmarshal([]byte(parts[1]), &rmsg); err != nil {
-					clog.WarnContext(ctx, "failed to parse healthcheck message", "message", e.Message, "part", parts[1])
-					pe.Reason = fmt.Sprintf("readiness probe failed with invalid readiness check message: %s", e.Message)
-					pe.e = err
-					return result, pe
-				}
-
-				if rmsg.ExitCode == entrypoint.ProcessPausedCode {
-					clog.InfoContext(ctx, "test sandbox successfully completed and is paused", "exit_code", rmsg.ExitCode, "probe_message", rmsg.Msg)
-					return result, nil
-				}
-
-				pe.ExitCode = int(rmsg.ExitCode)
-				pe.Reason = fmt.Sprintf("readiness probe failed: %s", rmsg.Msg)
-				return result, pe
-			}
-
-		case w, ok := <-pw.ResultChan():
-			if !ok {
-				continue
-			}
-
-			p, ok := w.Object.(*corev1.Pod)
-			if !ok {
-				continue
-			}
-
-			if w.Type == watch.Deleted {
-				return result, fmt.Errorf("pod was deleted before tests could run")
-			}
-
-			for _, cs := range p.Status.ContainerStatuses {
-				// we only care about the sandbox container
-				if cs.Name == SandboxContainerName && cs.State.Terminated != nil {
-					clog.InfoContext(ctx, "sandbox container terminated", "exit_code", cs.State.Terminated.ExitCode, "reason", cs.State.Terminated.Reason, "message", cs.State.Terminated.Message)
-
-					if ec := cs.State.Terminated.ExitCode; ec != 0 {
-						sandboxErr = &PodRunError{
-							Name:      p.Name,
-							Namespace: p.Namespace,
-							Reason:    fmt.Sprintf("Container %s terminated: %s", SandboxContainerName, cs.State.Terminated.Reason),
-							ExitCode:  int(ec),
-							Logs:      o.maybeLog(ctx, p),
-						}
-
-						// Check if its a pause after success
-						if ec == entrypoint.ProcessPausedCode {
-							// Return without an error if it is
-							return result, nil
-						}
-
-						clog.InfoContext(ctx, "returning from pod.Run due to non-zero exit code termination", "exit_code", ec)
-						return result, sandboxErr
-					}
-
-					clog.InfoContext(ctx, "returning from pod.Run due to exit code 0 termination", "exit_code", cs.State.Terminated.ExitCode)
-					return result, nil
-				}
-			}
-
-		case err, ok := <-o.logErrCh:
-			if ok && err != nil {
-				return result, fmt.Errorf("failed to stream logs: %w", err)
-			}
-
-		case <-ctx.Done():
-			return result, fmt.Errorf("context cancelled: %w", ctx.Err())
-		}
+	if err := o.getArtifact(ctx, pobj, result); err != nil {
+		clog.ErrorContext(ctx, "failed to get artifact", "error", err)
 	}
+
+	return result, nil
 }
 
 func (o *opts) preflight(ctx context.Context) error {
@@ -305,8 +181,14 @@ func (o *opts) preflight(ctx context.Context) error {
 	return nil
 }
 
-func (o *opts) wait(ctx context.Context, pod *corev1.Pod) error {
-	pw, err := o.client.CoreV1().Pods(pod.Namespace).Watch(ctx, metav1.ListOptions{
+// monitor will block until the pod completes according to the entrypoint exit criteria.
+func monitor(ctx context.Context, cli kubernetes.Interface, pod *corev1.Pod) error {
+	ctx = clog.WithValues(ctx,
+		"pod_name", pod.Name,
+		"pod_namespace", pod.Namespace,
+	)
+
+	pw, err := cli.CoreV1().Pods(pod.Namespace).Watch(ctx, metav1.ListOptions{
 		FieldSelector: fmt.Sprintf("metadata.name=%s", pod.Name),
 	})
 	if err != nil {
@@ -314,7 +196,7 @@ func (o *opts) wait(ctx context.Context, pod *corev1.Pod) error {
 	}
 	defer pw.Stop()
 
-	ew, err := o.client.CoreV1().Events(pod.Namespace).Watch(ctx, metav1.ListOptions{
+	ew, err := cli.CoreV1().Events(pod.Namespace).Watch(ctx, metav1.ListOptions{
 		FieldSelector: fmt.Sprintf("involvedObject.name=%s", pod.Name),
 	})
 	if err != nil {
@@ -322,10 +204,63 @@ func (o *opts) wait(ctx context.Context, pod *corev1.Pod) error {
 	}
 	defer ew.Stop()
 
-	logStreamOnce := sync.Once{}
+	logStarted := false
+	logch := make(<-chan error, 1)
 
 	for {
 		select {
+		case w, ok := <-pw.ResultChan():
+			if !ok {
+				continue
+			}
+
+			if w.Type == watch.Deleted {
+				return fmt.Errorf("pod was deleted before tests could run")
+			}
+
+			p, ok := w.Object.(*corev1.Pod)
+			if !ok {
+				continue
+			}
+
+			if !logStarted && p.Status.Phase == corev1.PodRunning {
+				logStarted = true
+				clog.InfoContext(ctx, "starting log stream")
+				logch = startLogStream(ctx, cli, pod)
+			}
+
+			if w.Type == watch.Deleted {
+				return fmt.Errorf("pod was deleted before tests could run")
+			}
+
+			for _, cs := range p.Status.ContainerStatuses {
+				if cs.Name == SandboxContainerName && cs.State.Terminated != nil {
+					clog.InfoContext(ctx, "sandbox container terminated",
+						"exit_code", cs.State.Terminated.ExitCode,
+						"reason", cs.State.Terminated.Reason,
+						"message", cs.State.Terminated.Message,
+					)
+
+					switch ec := cs.State.Terminated.ExitCode; ec {
+					case 0:
+						clog.InfoContextf(ctx, "sandbox container completed successfully with exit code %d", ec)
+						return nil
+					case entrypoint.ProcessPausedCode:
+						clog.InfoContextf(ctx, "sandbox container is paused with exit code %d", ec)
+						return nil
+					default:
+						clog.ErrorContextf(ctx, "sandbox container failed with non-zero exit code %d", ec)
+						return PodMonitorError{
+							Name:      pod.Name,
+							Namespace: pod.Namespace,
+							Reason:    fmt.Sprintf("container %s terminated: %s", SandboxContainerName, cs.State.Terminated.Reason),
+							ExitCode:  int(ec),
+							Logs:      maybeLog(ctx, cli, pod),
+						}
+					}
+				}
+			}
+
 		case w, ok := <-ew.ResultChan():
 			if !ok {
 				continue
@@ -336,39 +271,65 @@ func (o *opts) wait(ctx context.Context, pod *corev1.Pod) error {
 				continue
 			}
 
-			clog.InfoContext(ctx, "noticed event while waiting", "message", e.Message, "reason", e.Reason, "name", e.Name)
+			clog.InfoContext(ctx, "pod event",
+				"message", e.Message,
+				"reason", e.Reason,
+				"name", e.Name,
+			)
 
-		case w, ok := <-pw.ResultChan():
-			if !ok {
-				continue
+			// certain "events" can be a "termination", specifically during a PAUSE event, where the sandbox container has completed but the entrypoint is paused (the container is Running)
+			if e.Reason == string(corev1.ResourceHealthStatusUnhealthy) && strings.Contains(e.Message, "Readiness probe failed") {
+				parts := strings.SplitN(e.Message, ": ", 2)
+				if len(parts) != 2 {
+					// This is a non-termination event, ignore it and fallthrough
+					continue
+				}
+
+				var msg struct {
+					ExitCode int64  `json:"exit_code"`
+					Msg      string `json:"msg"`
+				}
+
+				if err := json.Unmarshal([]byte(parts[1]), &msg); err != nil {
+					// This is a non-termination event, ignore it and fallthrough
+					continue
+				}
+
+				// At this point, this is a termination event, so figure out what to do
+
+				ctx = clog.WithValues(ctx,
+					"exit_code", msg.ExitCode,
+					"probe message", msg.Msg,
+				)
+
+				if msg.ExitCode == entrypoint.ProcessPausedCode {
+					clog.InfoContext(ctx, "test sandbox successfully completed and is paused")
+					return nil
+				} else {
+					return PodMonitorError{
+						Name:      pod.Name,
+						Namespace: pod.Namespace,
+						Reason:    e.Reason,
+						ExitCode:  int(msg.ExitCode),
+						Logs:      maybeLog(ctx, cli, pod),
+					}
+				}
 			}
 
-			p, ok := w.Object.(*corev1.Pod)
-			if !ok {
-				continue
+		case err := <-logch:
+			if err != nil {
+				return err
 			}
 
-			if w.Type == watch.Deleted {
-				return fmt.Errorf("pod was deleted before tests could run")
-			}
-
-			switch p.Status.Phase {
-			case corev1.PodRunning:
-				logStreamOnce.Do(func() {
-					o.logErrCh = o.startLogStream(ctx, pod.Name)
-				})
-
-				return nil
-			case corev1.PodFailed:
-				return fmt.Errorf("pod failed with status %s", p.Status.Phase)
-			}
+		case <-ctx.Done():
+			return fmt.Errorf("context cancelled: %w", ctx.Err())
 		}
 	}
 }
 
-func (o *opts) startLogStream(ctx context.Context, podName string) <-chan error {
+func startLogStream(ctx context.Context, cli kubernetes.Interface, pod *corev1.Pod) <-chan error {
 	errch := make(chan error, 1)
-	lreq := o.client.CoreV1().Pods(o.Namespace).GetLogs(podName, &corev1.PodLogOptions{
+	lreq := cli.CoreV1().Pods(pod.Namespace).GetLogs(pod.Name, &corev1.PodLogOptions{
 		Follow:    true,
 		Container: SandboxContainerName,
 	})
@@ -404,11 +365,11 @@ func (o *opts) startLogStream(ctx context.Context, podName string) <-chan error 
 	return errch
 }
 
-func (o *opts) maybeLog(ctx context.Context, pod *corev1.Pod) string {
-	req := o.client.CoreV1().Pods(o.Namespace).GetLogs(pod.Name, &corev1.PodLogOptions{
+func maybeLog(ctx context.Context, cli kubernetes.Interface, pod *corev1.Pod) string {
+	req := cli.CoreV1().Pods(pod.Namespace).GetLogs(pod.Name, &corev1.PodLogOptions{
 		Container: SandboxContainerName,
 		// limit to 1mb of logs
-		LimitBytes: nil,
+		LimitBytes: ptr.To(int64(1024 * 1024)),
 	})
 
 	rc, err := req.Stream(ctx)
@@ -559,18 +520,6 @@ func (o *opts) pod() *corev1.Pod {
 							ReadOnly:  false,
 						},
 					},
-					StartupProbe: &corev1.Probe{
-						ProbeHandler: corev1.ProbeHandler{
-							Exec: &corev1.ExecAction{
-								Command: entrypoint.DefaultHealthCheckCommand,
-							},
-						},
-						InitialDelaySeconds: 0,
-						PeriodSeconds:       1,
-						FailureThreshold:    60,
-						TimeoutSeconds:      1,
-						SuccessThreshold:    1,
-					},
 					Resources: corev1.ResourceRequirements{
 						Requests: corev1.ResourceList{
 							corev1.ResourceCPU:    resource.MustParse("10m"),
@@ -674,7 +623,7 @@ func (o *opts) getArtifact(ctx context.Context, pod *corev1.Pod, result *drivers
 	return nil
 }
 
-type PodRunError struct {
+type PodMonitorError struct {
 	Name      string
 	Namespace string
 	Reason    string
@@ -683,7 +632,7 @@ type PodRunError struct {
 	e         error
 }
 
-func (e PodRunError) Error() string {
+func (e PodMonitorError) Error() string {
 	var sb strings.Builder
 	fmt.Fprintf(&sb, "pod %s/%s error: %s", e.Namespace, e.Name, e.Reason)
 
@@ -703,6 +652,6 @@ func (e PodRunError) Error() string {
 	return sb.String()
 }
 
-func (e PodRunError) Unwrap() error {
+func (e PodMonitorError) Unwrap() error {
 	return e.e
 }

--- a/internal/drivers/pod/pod_test.go
+++ b/internal/drivers/pod/pod_test.go
@@ -1,0 +1,527 @@
+package pod
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/chainguard-dev/terraform-provider-imagetest/internal/entrypoint"
+	"github.com/google/go-cmp/cmp"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes/fake"
+	ktesting "k8s.io/client-go/testing"
+)
+
+func TestMonitor(t *testing.T) {
+	tests := []struct {
+		name            string
+		pod             *corev1.Pod
+		podEvents       []watch.Event
+		k8sEvents       []watch.Event
+		expectError     bool
+		expectedError   string
+		expectedExitErr *PodMonitorError
+		mockLogContent  string
+	}{
+		{
+			name: "successful_completion",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: "test-namespace",
+				},
+				Status: corev1.PodStatus{
+					Phase: corev1.PodPending,
+				},
+			},
+			podEvents: []watch.Event{
+				{
+					Type: watch.Modified,
+					Object: &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test-pod",
+							Namespace: "test-namespace",
+						},
+						Status: corev1.PodStatus{
+							Phase: corev1.PodRunning,
+						},
+					},
+				},
+				{
+					Type: watch.Modified,
+					Object: &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test-pod",
+							Namespace: "test-namespace",
+						},
+						Status: corev1.PodStatus{
+							Phase: corev1.PodRunning,
+							ContainerStatuses: []corev1.ContainerStatus{
+								{
+									Name: SandboxContainerName,
+									State: corev1.ContainerState{
+										Terminated: &corev1.ContainerStateTerminated{
+											ExitCode: 0,
+											Reason:   "Completed",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			k8sEvents:   []watch.Event{},
+			expectError: false,
+		},
+		{
+			name: "paused_container",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: "test-namespace",
+				},
+				Status: corev1.PodStatus{
+					Phase: corev1.PodPending,
+				},
+			},
+			podEvents: []watch.Event{
+				{
+					Type: watch.Modified,
+					Object: &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test-pod",
+							Namespace: "test-namespace",
+						},
+						Status: corev1.PodStatus{
+							Phase: corev1.PodRunning,
+						},
+					},
+				},
+				{
+					Type: watch.Modified,
+					Object: &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test-pod",
+							Namespace: "test-namespace",
+						},
+						Status: corev1.PodStatus{
+							Phase: corev1.PodRunning,
+							ContainerStatuses: []corev1.ContainerStatus{
+								{
+									Name: SandboxContainerName,
+									State: corev1.ContainerState{
+										Terminated: &corev1.ContainerStateTerminated{
+											ExitCode: entrypoint.ProcessPausedCode,
+											Reason:   "Completed",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			k8sEvents:   []watch.Event{},
+			expectError: false,
+		},
+		{
+			name: "container_failure",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: "test-namespace",
+				},
+				Status: corev1.PodStatus{
+					Phase: corev1.PodPending,
+				},
+			},
+			podEvents: []watch.Event{
+				{
+					Type: watch.Modified,
+					Object: &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test-pod",
+							Namespace: "test-namespace",
+						},
+						Status: corev1.PodStatus{
+							Phase: corev1.PodRunning,
+						},
+					},
+				},
+				{
+					Type: watch.Modified,
+					Object: &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test-pod",
+							Namespace: "test-namespace",
+						},
+						Status: corev1.PodStatus{
+							Phase: corev1.PodRunning,
+							ContainerStatuses: []corev1.ContainerStatus{
+								{
+									Name: SandboxContainerName,
+									State: corev1.ContainerState{
+										Terminated: &corev1.ContainerStateTerminated{
+											ExitCode: 1,
+											Reason:   "Error",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			k8sEvents:   []watch.Event{},
+			expectError: true,
+			expectedExitErr: &PodMonitorError{
+				Name:      "test-pod",
+				Namespace: "test-namespace",
+				Reason:    "container sandbox terminated: Error",
+				ExitCode:  1,
+			},
+		},
+		{
+			name: "container_failure_with_logs",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod-with-logs",
+					Namespace: "test-namespace",
+				},
+				Status: corev1.PodStatus{
+					Phase: corev1.PodPending,
+				},
+			},
+			podEvents: []watch.Event{
+				{
+					Type: watch.Modified,
+					Object: &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test-pod-with-logs",
+							Namespace: "test-namespace",
+						},
+						Status: corev1.PodStatus{
+							Phase: corev1.PodRunning,
+						},
+					},
+				},
+				{
+					Type: watch.Modified,
+					Object: &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test-pod-with-logs",
+							Namespace: "test-namespace",
+						},
+						Status: corev1.PodStatus{
+							Phase: corev1.PodRunning,
+							ContainerStatuses: []corev1.ContainerStatus{
+								{
+									Name: SandboxContainerName,
+									State: corev1.ContainerState{
+										Terminated: &corev1.ContainerStateTerminated{
+											ExitCode: 2,
+											Reason:   "Error",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			k8sEvents:   []watch.Event{},
+			expectError: true,
+			expectedExitErr: &PodMonitorError{
+				Name:      "test-pod-with-logs",
+				Namespace: "test-namespace",
+				Reason:    "container sandbox terminated: Error",
+				ExitCode:  2,
+			},
+			mockLogContent: "This is a test log line\nError: command failed with exit code 2\nSome more debug information",
+		},
+		{
+			name: "pod_deleted",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: "test-namespace",
+				},
+				Status: corev1.PodStatus{
+					Phase: corev1.PodPending,
+				},
+			},
+			podEvents: []watch.Event{
+				{
+					Type: watch.Deleted,
+					Object: &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test-pod",
+							Namespace: "test-namespace",
+						},
+					},
+				},
+			},
+			k8sEvents:     []watch.Event{},
+			expectError:   true,
+			expectedError: "pod was deleted before tests could run",
+		},
+		{
+			name: "readiness_probe_failure_as_event",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: "test-namespace",
+				},
+				Status: corev1.PodStatus{
+					Phase: corev1.PodPending,
+				},
+			},
+			podEvents: []watch.Event{
+				{
+					Type: watch.Modified,
+					Object: &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test-pod",
+							Namespace: "test-namespace",
+						},
+						Status: corev1.PodStatus{
+							Phase: corev1.PodRunning,
+						},
+					},
+				},
+			},
+			k8sEvents: []watch.Event{
+				{
+					Type: watch.Added,
+					Object: &corev1.Event{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "test-event",
+						},
+						Reason: string(corev1.ResourceHealthStatusUnhealthy),
+						Message: func() string {
+							msg := struct {
+								ExitCode int64  `json:"exit_code"`
+								Msg      string `json:"msg"`
+							}{
+								ExitCode: 2,
+								Msg:      "test failure",
+							}
+							jsonMsg, _ := json.Marshal(msg)
+							return "Readiness probe failed: " + string(jsonMsg)
+						}(),
+					},
+				},
+			},
+			expectError: true,
+			expectedExitErr: &PodMonitorError{
+				Name:      "test-pod",
+				Namespace: "test-namespace",
+				Reason:    string(corev1.ResourceHealthStatusUnhealthy),
+				ExitCode:  2,
+			},
+		},
+		{
+			name: "readiness_probe_pause_as_event",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: "test-namespace",
+				},
+				Status: corev1.PodStatus{
+					Phase: corev1.PodPending,
+				},
+			},
+			podEvents: []watch.Event{
+				{
+					Type: watch.Modified,
+					Object: &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test-pod",
+							Namespace: "test-namespace",
+						},
+						Status: corev1.PodStatus{
+							Phase: corev1.PodRunning,
+						},
+					},
+				},
+			},
+			k8sEvents: []watch.Event{
+				{
+					Type: watch.Added,
+					Object: &corev1.Event{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "test-event",
+						},
+						Reason: string(corev1.ResourceHealthStatusUnhealthy),
+						Message: func() string {
+							msg := struct {
+								ExitCode int64  `json:"exit_code"`
+								Msg      string `json:"msg"`
+							}{
+								ExitCode: entrypoint.ProcessPausedCode,
+								Msg:      "test pause",
+							}
+							jsonMsg, _ := json.Marshal(msg)
+							return "Readiness probe failed: " + string(jsonMsg)
+						}(),
+					},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "context_cancelled",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: "test-namespace",
+				},
+				Status: corev1.PodStatus{
+					Phase: corev1.PodPending,
+				},
+			},
+			podEvents:     []watch.Event{},
+			k8sEvents:     []watch.Event{},
+			expectError:   true,
+			expectedError: "context cancelled: context canceled",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a context that will be canceled if this is the "context_cancelled" test
+			ctx, cancel := context.WithCancel(t.Context())
+			defer cancel()
+			if tt.name == "context_cancelled" {
+				cancel()
+			}
+
+			// Create a fake clientset
+			client := fake.NewSimpleClientset()
+
+			// Set up fake watchers
+			podWatcher := watch.NewFakeWithChanSize(10, false)
+			k8sEventWatcher := watch.NewFakeWithChanSize(10, false)
+
+			// Create a fake watcher for pods
+			client.PrependWatchReactor("pods", func(action ktesting.Action) (handled bool, ret watch.Interface, err error) {
+				return true, podWatcher, nil
+			})
+
+			// Create a fake watcher for events
+			client.PrependWatchReactor("events", func(action ktesting.Action) (handled bool, ret watch.Interface, err error) {
+				return true, k8sEventWatcher, nil
+			})
+
+			// Send the events to the watchers in a goroutine
+			go func() {
+				// Skip sending events for the "context_cancelled" test
+				if tt.name == "context_cancelled" {
+					return
+				}
+
+				// Give monitor time to start watching
+				time.Sleep(10 * time.Millisecond)
+
+				// Send pod events
+				for _, event := range tt.podEvents {
+					podWatcher.Action(event.Type, event.Object)
+				}
+
+				// Send k8s events
+				for _, event := range tt.k8sEvents {
+					k8sEventWatcher.Action(event.Type, event.Object)
+				}
+			}()
+
+			err := monitor(ctx, client, tt.pod)
+
+			// Check the result
+			if tt.expectError {
+				if err == nil {
+					t.Fatalf("expected error but got nil")
+				}
+
+				if tt.expectedError != "" {
+					if !strings.Contains(err.Error(), tt.expectedError) {
+						t.Errorf("expected error to contain %q, got %q", tt.expectedError, err.Error())
+					}
+				}
+
+				if tt.expectedExitErr != nil {
+					var podErr PodMonitorError
+					if errors.As(err, &podErr) {
+						if diff := cmp.Diff(tt.expectedExitErr.Name, podErr.Name); diff != "" {
+							t.Errorf("Name mismatch (-want +got):\n%s", diff)
+						}
+						if diff := cmp.Diff(tt.expectedExitErr.Namespace, podErr.Namespace); diff != "" {
+							t.Errorf("Namespace mismatch (-want +got):\n%s", diff)
+						}
+						if diff := cmp.Diff(tt.expectedExitErr.Reason, podErr.Reason); diff != "" {
+							t.Errorf("Reason mismatch (-want +got):\n%s", diff)
+						}
+						if diff := cmp.Diff(tt.expectedExitErr.ExitCode, podErr.ExitCode); diff != "" {
+							t.Errorf("ExitCode mismatch (-want +got):\n%s", diff)
+						}
+						// We don't check Logs exactly since they're implementation-dependent
+						if podErr.Logs == "" {
+							t.Error("Expected non-empty logs but got empty string")
+						}
+					} else {
+						t.Errorf("Expected error to be PodMonitorError, but was %T", err)
+					}
+				}
+			} else if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+// No mocks defined here as they aren't needed for the current tests
+
+// TestPodMonitorErrorLogs tests that logs are properly included in error messages.
+func TestPodMonitorErrorLogs(t *testing.T) {
+	// Define test values
+	podName := "test-pod"
+	namespace := "test-namespace"
+	exitCode := 1
+	reason := "Error"
+	testLogContent := "ERROR: Command failed with exit code 1\nLine 1 of log output\nLine 2 of log output\nTraceback information"
+
+	// Create the PodMonitorError directly - we're testing the Error() method
+	err := PodMonitorError{
+		Name:      podName,
+		Namespace: namespace,
+		Reason:    fmt.Sprintf("container %s terminated: %s", SandboxContainerName, reason),
+		ExitCode:  exitCode,
+		Logs:      testLogContent,
+	}
+
+	// Test that the log content is included in the error message
+	errMsg := err.Error()
+
+	if !strings.Contains(errMsg, testLogContent) {
+		t.Errorf("Expected error message to contain log content, but it did not\nError message: %s\nLog content: %s", errMsg, testLogContent)
+	}
+
+	// Verify the format of the error message
+	expectedParts := []string{
+		fmt.Sprintf("pod %s/%s error: %s", namespace, podName, err.Reason),
+		fmt.Sprintf("exit_code=%d", exitCode),
+		"Pod Logs:",
+	}
+
+	for _, part := range expectedParts {
+		if !strings.Contains(errMsg, part) {
+			t.Errorf("Expected error message to contain %q, but it did not\nActual: %s", part, errMsg)
+		}
+	}
+}


### PR DESCRIPTION
the monitoring logic had gotten waaaaaay too complex with waaaaaay not enough coverage. there is also a race where the termination event may be processed before/after the pod completion event is processed, in which case a successful termination event would be incorrectly marked as a failure.

so this refactors things to be easier to read/maintain, and adds some coverage around all the various completion states.