### PR TITLE
drivers/pod: Increase logs buffer size

### DIFF
--- a/internal/drivers/pod/pod.go
+++ b/internal/drivers/pod/pod.go
@@ -385,6 +385,8 @@ func (o *opts) startLogStream(ctx context.Context, podName string) <-chan error 
 		defer close(errch)
 
 		scanner := bufio.NewScanner(logs)
+		buf := make([]byte, 0, 1024*1024)
+		scanner.Buffer(buf, 1024*1024)
 		for scanner.Scan() {
 			select {
 			case <-ctx.Done():

--- a/internal/drivers/pod/pod.go
+++ b/internal/drivers/pod/pod.go
@@ -385,8 +385,8 @@ func (o *opts) startLogStream(ctx context.Context, podName string) <-chan error 
 		defer close(errch)
 
 		scanner := bufio.NewScanner(logs)
-		buf := make([]byte, 0, 1024*1024)
-		scanner.Buffer(buf, 1024*1024)
+		buf := make([]byte, 0, 512*1024)
+		scanner.Buffer(buf, 512*1024)
 		for scanner.Scan() {
 			select {
 			case <-ctx.Done():


### PR DESCRIPTION
Here I increase the size of the buffer for logs to 1MiB (1024^2).  This
matches the LimitBytes argument passed in maybeLog.  The impetus for
this is

> `failed to stream logs: scanning logs: bufio.Scanner: token too long`

which was encountered in migrating victoriametrics-operator to
k3s-in-docker.
