### PR TITLE
k3s_in_docker: Rename context to cluster name

### DIFF
--- a/internal/drivers/k3s_in_docker/driver.go
+++ b/internal/drivers/k3s_in_docker/driver.go
@@ -254,6 +254,13 @@ configs:
 			cluster.Server = config.Host
 		}
 
+		// Rename the kube context to the name of the test harness.
+		// This makes life easier for someone interacting with the test cluster from their host machine
+		clog.DebugContext(ctx, "renaming kubeconfig context", "context", k.name)
+		kcfg.Contexts[k.name] = kcfg.Contexts["default"]
+		kcfg.CurrentContext = k.name
+		delete(kcfg.Contexts, "default")
+
 		if err := os.MkdirAll(filepath.Dir(k.kubeconfigWritePath), 0o755); err != nil {
 			return fmt.Errorf("failed to create kubeconfig directory: %w", err)
 		}

--- a/internal/drivers/k3s_in_docker/driver.go
+++ b/internal/drivers/k3s_in_docker/driver.go
@@ -259,7 +259,6 @@ configs:
 		clog.DebugContext(ctx, "renaming kubeconfig context", "context", k.name)
 		kcfg.Contexts[k.name] = kcfg.Contexts["default"]
 		kcfg.CurrentContext = k.name
-		delete(kcfg.Contexts, "default")
 
 		if err := os.MkdirAll(filepath.Dir(k.kubeconfigWritePath), 0o755); err != nil {
 			return fmt.Errorf("failed to create kubeconfig directory: %w", err)


### PR DESCRIPTION
This commit renames the default context in the k3s cluster to be the
name of the cluster itself.  This will make it easier for people to
interact with the test cluster(s) from their host machine (watch this
space).
