### PR TITLE
just warn instead of erroring

### DIFF
--- a/internal/drivers/pod/pod.go
+++ b/internal/drivers/pod/pod.go
@@ -358,7 +358,7 @@ func startLogStream(ctx context.Context, cli kubernetes.Interface, pod *corev1.P
 		}
 
 		if err := scanner.Err(); err != nil && err != io.EOF {
-			errch <- fmt.Errorf("scanning logs: %w", err)
+			clog.WarnContext(ctx, "error scanning logs, continuing", "error", err)
 		}
 	}()
 


### PR DESCRIPTION
scanning a line can fail for a variety of flakey reasons, so just flag a warn instead of halting everything. if the error is truly unrecoverable from, the error will surface from the pod watcher