### PR TITLE
plumb through k3s auth to ~/.docker/config.json as well

### DIFF
--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -578,3 +578,24 @@ func (d *Client) withDefaultLabels(labels map[string]string) map[string]string {
 
 	return labels
 }
+
+// DockerConfig is the structure of the config file used at
+// ~/.docker/config.json.
+type DockerConfig struct {
+	Auths map[string]DockerAuthConfig `json:"auths,omitempty"`
+}
+
+type DockerAuthConfig struct {
+	Username string `json:"username,omitempty"`
+	Password string `json:"password,omitempty"`
+	Auth     string `json:"auth,omitempty"`
+}
+
+func (d *DockerConfig) Content() (*Content, error) {
+	data, err := json.Marshal(d)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewContentFromString(string(data), "/root/.docker/config.json"), nil
+}

--- a/internal/drivers/docker_in_docker/driver.go
+++ b/internal/drivers/docker_in_docker/driver.go
@@ -35,7 +35,7 @@ type driver struct {
 	name      string
 	stack     *harness.Stack
 	cli       *docker.Client
-	cliCfg    *dockerConfig
+	cliCfg    *docker.DockerConfig
 	daemonCfg *daemonConfig
 	ropts     []remote.Option
 }
@@ -56,7 +56,7 @@ func NewDriver(n string, opts ...DriverOpts) (drivers.Tester, error) {
 				Architecture: runtime.GOARCH,
 			}),
 		},
-		cliCfg: &dockerConfig{},
+		cliCfg: &docker.DockerConfig{},
 		daemonCfg: &daemonConfig{
 			// DefaultAddressPool needs to be RFC 1918 compliant that doesn't overlap with the default dockerd's pool (172.17.0.0/16)
 			DefaultAddressPools: []daemonConfigDefaultAddressPool{defaultAddressPool},
@@ -253,25 +253,6 @@ func (d *driver) Run(ctx context.Context, ref name.Reference) (*drivers.RunResul
 	}
 
 	return result, nil
-}
-
-type dockerConfig struct {
-	Auths map[string]dockerAuthEntry `json:"auths,omitempty"`
-}
-
-type dockerAuthEntry struct {
-	Username string `json:"username,omitempty"`
-	Password string `json:"password,omitempty"`
-	Auth     string `json:"auth,omitempty"`
-}
-
-func (c dockerConfig) Content() (*docker.Content, error) {
-	data, err := json.Marshal(c)
-	if err != nil {
-		return nil, err
-	}
-
-	return docker.NewContentFromString(string(data), "/root/.docker/config.json"), nil
 }
 
 type daemonConfigDefaultAddressPool struct {

--- a/internal/drivers/docker_in_docker/opts.go
+++ b/internal/drivers/docker_in_docker/opts.go
@@ -1,6 +1,7 @@
 package dockerindocker
 
 import (
+	"github.com/chainguard-dev/terraform-provider-imagetest/internal/docker"
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
@@ -36,13 +37,13 @@ func WithRemoteOptions(opts ...remote.Option) DriverOpts {
 func WithRegistryAuth(registry string) DriverOpts {
 	return func(d *driver) error {
 		if d.cliCfg == nil {
-			d.cliCfg = &dockerConfig{
-				Auths: make(map[string]dockerAuthEntry),
+			d.cliCfg = &docker.DockerConfig{
+				Auths: make(map[string]docker.DockerAuthConfig),
 			}
 		}
 
 		if d.cliCfg.Auths == nil {
-			d.cliCfg.Auths = make(map[string]dockerAuthEntry)
+			d.cliCfg.Auths = make(map[string]docker.DockerAuthConfig)
 		}
 
 		r, err := name.NewRegistry(registry)
@@ -60,7 +61,7 @@ func WithRegistryAuth(registry string) DriverOpts {
 			return err
 		}
 
-		d.cliCfg.Auths[registry] = dockerAuthEntry{
+		d.cliCfg.Auths[registry] = docker.DockerAuthConfig{
 			Username: acfg.Username,
 			Password: acfg.Password,
 			Auth:     acfg.Auth,

--- a/internal/drivers/pod/opts.go
+++ b/internal/drivers/pod/opts.go
@@ -1,6 +1,9 @@
 package pod
 
-import "github.com/google/go-containerregistry/pkg/name"
+import (
+	"github.com/chainguard-dev/terraform-provider-imagetest/internal/docker"
+	"github.com/google/go-containerregistry/pkg/name"
+)
 
 func WithImageRef(ref name.Reference) RunOpts {
 	return func(o *opts) error {
@@ -15,6 +18,13 @@ func WithExtraEnvs(envs map[string]string) RunOpts {
 			envs = make(map[string]string)
 		}
 		o.ExtraEnvs = envs
+		return nil
+	}
+}
+
+func WithRegistryStaticAuth(cfg *docker.DockerConfig) RunOpts {
+	return func(o *opts) error {
+		o.DockerConfig = cfg
 		return nil
 	}
 }


### PR DESCRIPTION
piggyback off of the existing k3s auth, which wires things up according to the k3s/containerd format, to also pass this into the imagetest pod in a format that most other clients support: `~/.docker/config.json`. this will let tests using clients that need to talk to an authenticated registry do so, instead of currently where its only the driver (containerd) with the auth

I didn't wire this in for the eks driver, which relies on a native ecr auth