### PR TITLE
feat(providers/drivers/eks): enable to create pod identity associations

### DIFF
--- a/docs/resources/tests.md
+++ b/docs/resources/tests.md
@@ -60,8 +60,19 @@ Optional:
 - `node_ami` (String) The AMI to use for the eks_with_eksctl driver (default is the latest EKS optimized AMI)
 - `node_count` (Number) The number of nodes to use for the eks_with_eksctl driver (default is 1)
 - `node_type` (String) The instance type to use for the eks_with_eksctl driver (default is m5.large)
+- `pod_identity_associations` (Attributes List) Pod Identity Associations for the EKS driver (see [below for nested schema](#nestedatt--drivers--eks_with_eksctl--pod_identity_associations))
 - `region` (String) The AWS region to use for the eks_with_eksctl driver (default is us-west-2)
 - `storage` (Attributes) Storage configuration for the eks_with_eksctl driver (see [below for nested schema](#nestedatt--drivers--eks_with_eksctl--storage))
+
+<a id="nestedatt--drivers--eks_with_eksctl--pod_identity_associations"></a>
+### Nested Schema for `drivers.eks_with_eksctl.pod_identity_associations`
+
+Optional:
+
+- `namespace` (String) Kubernetes namespace of the service account
+- `permission_policy_arn` (String) ARN of the permission policy
+- `service_account_name` (String) Name of the Kubernetes service account
+
 
 <a id="nestedatt--drivers--eks_with_eksctl--storage"></a>
 ### Nested Schema for `drivers.eks_with_eksctl.storage`

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.228.0
 	github.com/aws/aws-sdk-go-v2/service/lambda v1.72.0
 	github.com/chainguard-dev/clog v1.7.0
+	github.com/charmbracelet/log v0.4.2
 	github.com/docker/cli v28.3.0+incompatible
 	github.com/docker/go-connections v0.5.0
 	github.com/google/go-containerregistry v0.20.5
@@ -60,7 +61,6 @@ require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/charmbracelet/colorprofile v0.2.3-0.20250311203215-f60798e515dc // indirect
 	github.com/charmbracelet/lipgloss v1.1.0 // indirect
-	github.com/charmbracelet/log v0.4.2 // indirect
 	github.com/charmbracelet/x/ansi v0.8.0 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.13-0.20250311204145-2c3ea96c31dd // indirect
 	github.com/charmbracelet/x/term v0.2.1 // indirect

--- a/internal/drivers/eks_with_eksctl/driver.go
+++ b/internal/drivers/eks_with_eksctl/driver.go
@@ -14,11 +14,18 @@ import (
 	"github.com/chainguard-dev/clog"
 	"github.com/chainguard-dev/terraform-provider-imagetest/internal/drivers"
 	"github.com/chainguard-dev/terraform-provider-imagetest/internal/drivers/pod"
+	"github.com/charmbracelet/log"
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/uuid"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+)
+
+const (
+	regionDefault    = "us-west-2"
+	namespaceDefault = "imagetest"
+	nodeTypeDefault  = "m5.large"
 )
 
 type driver struct {
@@ -38,20 +45,35 @@ type driver struct {
 	launchTemplate   string
 	launchTemplateId string
 	nodeGroup        string
+
+	podIdentityAssociations []*podIdentityAssociation
 }
 
 type Options struct {
-	Region    string
-	NodeType  string
-	NodeAMI   string
-	NodeCount int
-	Namespace string
-	Storage   *StorageOptions
+	Region                  string
+	NodeType                string
+	NodeAMI                 string
+	NodeCount               int
+	Namespace               string
+	Storage                 *StorageOptions
+	PodIdentityAssociations []*PodIdentityAssociationOptions
 }
 
 type StorageOptions struct {
 	Size string
 	Type string
+}
+
+type PodIdentityAssociationOptions struct {
+	PermissionPolicyARN string // For now we support attaching just policies.
+	ServiceAccountName  string
+	Namespace           string
+}
+
+type podIdentityAssociation struct {
+	permissionPolicyARN string // For now we support attaching just policies.
+	serviceAccountName  string
+	namespace           string
 }
 
 func NewDriver(name string, opts Options) (drivers.Tester, error) {
@@ -65,16 +87,28 @@ func NewDriver(name string, opts Options) (drivers.Tester, error) {
 		storage:   opts.Storage,
 	}
 	if k.region == "" {
-		k.region = "us-west-2"
+		k.region = regionDefault
 	}
 	if k.namespace == "" {
-		k.namespace = "imagetest"
+		k.namespace = namespaceDefault
 	}
 	if k.nodeType == "" {
-		k.nodeType = "m5.large"
+		k.nodeType = nodeTypeDefault
 	}
 	if k.nodeCount <= 0 {
 		k.nodeCount = 1 // Default to 1 node if not specified
+	}
+	if opts.PodIdentityAssociations != nil {
+		for _, v := range opts.PodIdentityAssociations {
+			if v == nil {
+				continue
+			}
+			k.podIdentityAssociations = append(k.podIdentityAssociations, &podIdentityAssociation{
+				namespace:           v.Namespace,
+				permissionPolicyARN: v.PermissionPolicyARN,
+				serviceAccountName:  v.ServiceAccountName,
+			})
+		}
 	}
 
 	if _, err := exec.LookPath("eksctl"); err != nil {
@@ -268,6 +302,58 @@ func (k *driver) deleteNodeGroup(ctx context.Context) error {
 	return nil
 }
 
+// createPodIdentityAssociation creates a pod identity association for EKS workload.
+// Please refer to the official documentation of eksctl:
+//
+//	https://docs.aws.amazon.com/eks/latest/eksctl/pod-identity-associations.html
+func (k *driver) createPodIdentityAssociation(ctx context.Context) error {
+	if k.podIdentityAssociations == nil {
+		return fmt.Errorf("pod identity associations is nil")
+	}
+
+	for _, v := range k.podIdentityAssociations {
+		if v == nil {
+			continue
+		}
+		if err := k.eksctl(ctx, "create", "podidentityassociation",
+			"--region="+k.region,
+			"--cluster="+k.clusterName,
+			"--service-account-name="+v.serviceAccountName,
+			"--namespace="+v.namespace,
+			"--permission-policy-arns="+v.permissionPolicyARN); err != nil {
+			return fmt.Errorf("eksctl create podidentityassociation: %w", err)
+		}
+		log.Infof("Created pod identity association for service account %s/%s and policy ARN %s for cluster %s",
+			v.namespace, v.serviceAccountName, k.nodeCount, v.permissionPolicyARN, k.clusterName)
+	}
+
+	return nil
+}
+
+// deletePodIdentityAssociation deletes a pod identity association for EKS workload.
+func (k *driver) deletePodIdentityAssociation(ctx context.Context) error {
+	if k.podIdentityAssociations == nil {
+		return fmt.Errorf("pod identity associations is nil")
+	}
+
+	for _, v := range k.podIdentityAssociations {
+		if v == nil {
+			continue
+		}
+		if err := k.eksctl(ctx, "delete", "podidentityassociation",
+			"--region="+k.region,
+			"--cluster="+k.clusterName,
+			"--service-account-name="+v.serviceAccountName,
+			"--namespace="+v.namespace); err != nil {
+			return fmt.Errorf("eksctl delete podidentityassociation : %w", err)
+		}
+		log.Infof("Deleted pod identity associations for service account %s/%s for cluster %s",
+			v.namespace, v.serviceAccountName, k.nodeCount, v.permissionPolicyARN, k.clusterName)
+	}
+
+	return nil
+}
+
 func (k *driver) Setup(ctx context.Context) error {
 	log := clog.FromContext(ctx)
 
@@ -326,6 +412,12 @@ func (k *driver) Setup(ctx context.Context) error {
 		return err
 	}
 
+	if k.podIdentityAssociations != nil {
+		if err = k.createPodIdentityAssociation(ctx); err != nil {
+			return fmt.Errorf("creating pod identity association: %w", err)
+		}
+	}
+
 	config, err := clientcmd.BuildConfigFromFlags("", k.kubeconfig)
 	if err != nil {
 		return fmt.Errorf("building kubeconfig: %w", err)
@@ -360,6 +452,12 @@ func (k *driver) Teardown(ctx context.Context) error {
 	if k.launchTemplate != "" {
 		if err := k.deleteLaunchTemplate(ctx); err != nil {
 			return err
+		}
+	}
+
+	if k.podIdentityAssociations != nil {
+		if err := k.deletePodIdentityAssociation(ctx); err != nil {
+			return fmt.Errorf("deleting pod identity association: %w", err)
 		}
 	}
 


### PR DESCRIPTION
Enable to create pod identity associations for the eks cluster being created as imagetest tests driver. Pod Identity allows Kubernetes identities to access AWS resources.

This change attempts to resolve the problem of testing workload that needs access to AWS resources in order to work, like EBS or EFS CSI driver controllers.

With this change we should be able to configure the Pod Identity associations with `pod_identity_associations` field of the `eks_with_eksctl` driver configuration, like you can read below:
```hcl
resource "imagetest_tests" "foo_with_pod_identity" {
  name   = "foo"
  driver = "eks_with_eksctl"
  drivers = {
    eks_with_eksctl = {
      pod_identity_associations = [
        {
          permission_policy_arn = "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess",
          service_account_name = "default",
          namespace = "default",
        },
      ]
    }
  }
  images = {
    foo = "REF"
  }
  tests = [
    {
      name    = "sample"
      image   = "REF"
      cmd     = "./test-k8s.sh"
    }
  ]
}
```

More information on the official documentation:
- https://docs.aws.amazon.com/eks/latest/userguide/pod-identities.html
- https://docs.aws.amazon.com/eks/latest/eksctl/pod-identity-associations.html
