### PR TITLE
Feat/ec2-driver: SSH Keygen & Command Execution

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -221,7 +221,7 @@ require (
 	github.com/vmihailenco/msgpack/v5 v5.4.1 // indirect
 	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
 	github.com/zclconf/go-cty v1.16.3 // indirect
-	golang.org/x/crypto v0.40.0 // indirect
+	golang.org/x/crypto v0.40.0
 	golang.org/x/exp v0.0.0-20250408133849-7e4ce0ab07d0 // indirect
 	golang.org/x/mod v0.25.0 // indirect
 	golang.org/x/net v0.42.0 // indirect

--- a/internal/ssh/doc.go
+++ b/internal/ssh/doc.go
@@ -1,0 +1,9 @@
+// ssh implements a facade over the 'x/crypto/ssh' package, simplifying the
+// following workflows:
+//   - ED25519 key generation, conversion and marshaling
+//   - SSH client construction
+//   - SSH client command execution and sequencing
+//
+// NOTE: ALL errors returned by this package will be wrapped with well-known (
+// 'errors.Is(...') errors.
+package ssh

--- a/internal/ssh/internal/mock/auth.go
+++ b/internal/ssh/internal/mock/auth.go
@@ -1,0 +1,30 @@
+package mock
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"golang.org/x/crypto/ssh"
+)
+
+var ErrUnauthorized = fmt.Errorf("public key is not authorized")
+
+func PublicKeyCallback(t *testing.T, allowedPubKeys ...ssh.PublicKey) PubKeyCallback {
+	marshaledPubKeys := make([][]byte, len(allowedPubKeys))
+	for i := range len(marshaledPubKeys) {
+		marshaledPubKeys[i] = allowedPubKeys[i].Marshal()
+	}
+	return func(conn ssh.ConnMetadata, key ssh.PublicKey) (*ssh.Permissions, error) {
+		// Expect the "user" public key defined above on SSH connections
+		keyMarshaled := key.Marshal()
+		for _, marshaledPubKey := range marshaledPubKeys {
+			if bytes.Equal(marshaledPubKey, keyMarshaled) {
+				return nil, nil
+			}
+		}
+		// require.Contains(t, marshaledPubKeys, key.Marshal(), "public key is not authorized", string(key.Marshal()))
+		// require.True(t, bytes.Equal(userPubKey.Marshal(), key.Marshal()))
+		return nil, ErrUnauthorized
+	}
+}

--- a/internal/ssh/internal/mock/auth.go
+++ b/internal/ssh/internal/mock/auth.go
@@ -10,21 +10,22 @@ import (
 
 var ErrUnauthorized = fmt.Errorf("public key is not authorized")
 
+// PublicKeyCallback returns a closure for use with an 'ssh.ServerConfig' to
+// perform validation of offered public keys from inbound SSH connections
+// against the public keys provided in 'allowedPubKeys'.
 func PublicKeyCallback(t *testing.T, allowedPubKeys ...ssh.PublicKey) PubKeyCallback {
 	marshaledPubKeys := make([][]byte, len(allowedPubKeys))
 	for i := range len(marshaledPubKeys) {
 		marshaledPubKeys[i] = allowedPubKeys[i].Marshal()
 	}
 	return func(conn ssh.ConnMetadata, key ssh.PublicKey) (*ssh.Permissions, error) {
-		// Expect the "user" public key defined above on SSH connections
+		// Expect the "user" public key to exist in 'allowedPubKeys'.
 		keyMarshaled := key.Marshal()
 		for _, marshaledPubKey := range marshaledPubKeys {
 			if bytes.Equal(marshaledPubKey, keyMarshaled) {
 				return nil, nil
 			}
 		}
-		// require.Contains(t, marshaledPubKeys, key.Marshal(), "public key is not authorized", string(key.Marshal()))
-		// require.True(t, bytes.Equal(userPubKey.Marshal(), key.Marshal()))
 		return nil, ErrUnauthorized
 	}
 }

--- a/internal/ssh/internal/mock/doc.go
+++ b/internal/ssh/internal/mock/doc.go
@@ -1,0 +1,3 @@
+// mock provides, primarily, a mock SSH server for testing of the outer 'ssh'
+// package.
+package mock

--- a/internal/ssh/internal/mock/io.go
+++ b/internal/ssh/internal/mock/io.go
@@ -1,6 +1,7 @@
 package mock
 
 import (
+	"bufio"
 	"io"
 	"testing"
 
@@ -10,20 +11,17 @@ import (
 // asyncRead continuously reads from the provided 'io.Reader', string-converting
 // any read data and passing it through the returned channel.
 func asyncRead(t *testing.T, r io.Reader) <-chan string {
+	br := bufio.NewReader(r)
 	ch := make(chan string, 64)
 	go func(ch chan<- string) {
-		buf := make([]byte, 1024)
 		defer close(ch)
 		for {
-			n, err := r.Read(buf)
+			s, err := br.ReadString('\n')
 			if err != nil {
 				require.ErrorIs(t, err, io.EOF)
 				return
 			}
-			if n == 0 {
-				continue
-			}
-			ch <- string(buf[:n])
+			ch <- string(s)
 		}
 	}(ch)
 	return ch

--- a/internal/ssh/internal/mock/io.go
+++ b/internal/ssh/internal/mock/io.go
@@ -1,0 +1,30 @@
+package mock
+
+import (
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// asyncRead continuously reads from the provided 'io.Reader', string-converting
+// any read data and passing it through the returned channel.
+func asyncRead(t *testing.T, r io.Reader) <-chan string {
+	ch := make(chan string, 64)
+	go func(ch chan<- string) {
+		buf := make([]byte, 1024)
+		defer close(ch)
+		for {
+			n, err := r.Read(buf)
+			if err != nil {
+				require.ErrorIs(t, err, io.EOF)
+				return
+			}
+			if n == 0 {
+				continue
+			}
+			ch <- string(buf[:n])
+		}
+	}(ch)
+	return ch
+}

--- a/internal/ssh/internal/mock/io.go
+++ b/internal/ssh/internal/mock/io.go
@@ -21,7 +21,7 @@ func asyncRead(t *testing.T, r io.Reader) <-chan string {
 				require.ErrorIs(t, err, io.EOF)
 				return
 			}
-			ch <- string(s)
+			ch <- s
 		}
 	}(ch)
 	return ch

--- a/internal/ssh/internal/mock/log.go
+++ b/internal/ssh/internal/mock/log.go
@@ -1,0 +1,21 @@
+package mock
+
+var log Logger = noopLogger{}
+
+func SetLogger(l Logger) {
+	log = l
+}
+
+type Logger interface {
+	Debug(string, ...any)
+	Info(string, ...any)
+	Warn(string, ...any)
+	Error(string, ...any)
+}
+
+type noopLogger struct{}
+
+func (noopLogger) Debug(string, ...any) {}
+func (noopLogger) Info(string, ...any)  {}
+func (noopLogger) Warn(string, ...any)  {}
+func (noopLogger) Error(string, ...any) {}

--- a/internal/ssh/internal/mock/marshal.go
+++ b/internal/ssh/internal/mock/marshal.go
@@ -1,0 +1,11 @@
+package mock
+
+import "golang.org/x/crypto/ssh"
+
+// marshalExitStatus marshals the standard 'exit-status' message body to
+// indicate to the caller the exit code of the executed process.
+func marshalExitStatus(exitCode uint32) []byte {
+	return ssh.Marshal(struct {
+		Status uint32
+	}{exitCode})
+}

--- a/internal/ssh/internal/mock/server.go
+++ b/internal/ssh/internal/mock/server.go
@@ -1,0 +1,289 @@
+package mock
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/ssh"
+)
+
+type (
+	// server represents an SSH server.
+	//
+	// server is constructed by 'NewServer', can be started (begin listening and
+	// serving connections) by calling its 'ListenAndServe' method. When finished,
+	// a call to 'Shutdown' will gracefully shutdown the TCP listener.
+	server struct {
+		// The SSH server configuration.
+		//
+		// These options may be modified _prior_ to calling 'ListenAndServe',
+		// modifying after will have no effect.
+		Config *ssh.ServerConfig
+
+		// Holds the closure we'll use to shut down the Server.
+		cancel context.CancelFunc
+
+		// The TCP port to listen on.
+		port uint16
+
+		// 'Waiter' is a 'sync.WaitGroup'-like construct, save that it accepts a
+		// 'context.Context' on its 'Done' method, supporting deadlines.
+		wait Waiter
+	}
+	// PubKeyCallback is the function called when the server receives an
+	// authentication attempt via public key. Any non-nil error returned will
+	// immediately abort the connection.
+	PubKeyCallback func(ssh.ConnMetadata, ssh.PublicKey) (*ssh.Permissions, error)
+
+	// ReqChannel produces all *ssh.Requests, which are out-of-band well-known
+	// marshaled data structures which arrive from either a specific channel or
+	// the ssh.SSHConn.
+	ReqChannel <-chan *ssh.Request
+
+	// MsgChannel produces all messages which arrive directly over the ssh
+	// connection (think simple writes to stdin on the client's side).
+	MsgChannel <-chan string
+)
+
+func NewServer(t *testing.T, port uint16, signer ssh.Signer, fn PubKeyCallback) (*server, error) {
+	if t == nil {
+		return nil, fmt.Errorf("no *testing.T provided in call to NewServer")
+	}
+	require.NotNil(t, fn != nil, "a non-nil public key callback is required")
+	require.NotNil(t, signer, "a non-nil ssh.Signer is required")
+	// Init the SSH server config, add the host key
+	config := &ssh.ServerConfig{
+		PublicKeyCallback: fn,
+	}
+	config.AddHostKey(signer)
+	return &server{
+		Config: config,
+
+		wait: NewWaiter(),
+		port: port,
+	}, nil
+}
+
+func (self *server) ListenAndServe(t *testing.T, ctx context.Context) (ReqChannel, MsgChannel, error) {
+	// Wrap the context with a cancellation.
+	//
+	// We'll use this 'context.CancelFunc' to shutdown the server in the
+	// 'Shutdown' method.
+	ctx, self.cancel = context.WithCancel(ctx)
+	// Init the TCP listener
+	listener, err := net.ListenTCP("tcp", &net.TCPAddr{
+		Port: int(self.port),
+	})
+	require.NoError(t, err, "failed to listen on TCP/%d: %s", self.port, err)
+	// Init the channel we'll send a copy of all SSH requests into
+	outReqChan := make(chan *ssh.Request, 64)
+	outMsgChan := make(chan string, 64)
+	// Begin serving SSH requests
+	self.wait.Add()
+	go self.serve(t, ctx, listener, outReqChan, outMsgChan)
+	return outReqChan, outMsgChan, nil
+}
+
+func (self *server) serve(
+	t *testing.T,
+	ctx context.Context,
+	listener *net.TCPListener,
+	outReqChan chan<- *ssh.Request,
+	outMsgChan chan<- string,
+) {
+	defer self.wait.Done()
+	for {
+		select {
+		case <-ctx.Done():
+			// Close all channels.
+			close(outReqChan)
+			close(outMsgChan)
+			// Close TCP listener.
+			require.NoError(t, listener.Close())
+			return
+		default:
+			// Don't block forever.
+			listener.SetDeadline(time.Now().Add(100 * time.Millisecond))
+			conn, err := listener.AcceptTCP()
+			if err != nil {
+				var operr *net.OpError
+				if errors.As(err, &operr) && operr.Timeout() {
+					continue
+				}
+			}
+			require.NoError(t, err)
+			self.wait.Add()
+			go self.handleTCPConn(t, ctx, conn, outReqChan, outMsgChan)
+		}
+	}
+}
+
+// handleTCPConn attempts an SSH handshake over the provided '*net.TCPConn'.
+//
+// If successful it will continuously drain the inbound channel requests
+// channel, accepting 'session' channel requests and spawning a channel handler
+// in a separate Goroutine.
+//
+// See 'handleChannel' for more details.
+func (self *server) handleTCPConn(
+	t *testing.T,
+	ctx context.Context,
+	conn *net.TCPConn,
+	outReqChan chan<- *ssh.Request,
+	outMsgChan chan<- string,
+) {
+	defer self.wait.Done()
+	// Perform the SSH handshake.
+	sshConn, inChanReqChan, inReqChan, err := ssh.NewServerConn(
+		conn,
+		self.Config,
+	)
+	require.NoError(t, err)
+	defer sshConn.Close()
+	// Discard everything from the request chan (we don't care about anything
+	// in here).
+	go func() {
+		// This just ACKs all requests, if one was received and requested a reply.
+		ssh.DiscardRequests(inReqChan)
+	}()
+	// Field all new channel requests.
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case newChannelRequest := <-inChanReqChan:
+			// Reject non-session channels
+			if newChannelRequest.ChannelType() != "session" {
+				newChannelRequest.Reject(ssh.UnknownChannelType, "unknown channel type")
+				continue
+			}
+			// Accept 'session' channels.
+			channel, inReqChan, err := newChannelRequest.Accept()
+			require.NoError(t, err)
+			// Continuously read from 'channel', relaying messages read back over
+			// a channel.
+			inMsgChan := asyncRead(t, channel)
+			// Handle the channel in a separate Goroutine.
+			go self.handleChannel(t, ctx, channel, inMsgChan, inReqChan, outReqChan, outMsgChan)
+		}
+	}
+}
+
+// handleChannel processes all in-band and out-of-band messages delivered over
+// its 'ssh.Channel'.
+//
+// INBOUND REQUESTS from 'inReqChan' of type 'exec' are ACKed, lightly processed
+// and delivered back over 'outReqChan' for the caller of this package to
+// inspect. All other message types will panic (none of these are required
+// today).
+//
+// INBOUND MESSAGES from 'inMsgChan' are lightly processed and delivered back
+// over 'outMsgChan' for the caller of this package to inspect.
+//
+// This function exits when either the 'context.Context' is marked done, or
+// the 'inMsgChan' is closed, whichever comes first. On exit, the SSH channel
+// is closed. See 'asyncRead' for more details on 'inMsgChan' closure.
+func (self *server) handleChannel(
+	t *testing.T,
+	ctx context.Context,
+	channel ssh.Channel,
+	inMsgChan <-chan string,
+	inReqChan <-chan *ssh.Request,
+	outReqChan chan<- *ssh.Request,
+	outMsgChan chan<- string,
+) {
+	defer func() {
+		self.wait.Done()
+		require.NoError(t, channel.Close())
+	}()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case channelRequest := <-inReqChan:
+			// An '*ssh.Request' is a request from the client being sent _in_ the
+			// established channel. 'Request' in this context is essentially a message
+			// of a well-known structure. For example, 'exec' is the request message
+			// type which executes a program, 'shell' just means start this user's
+			// default shell.
+			switch channelRequest.Type {
+			case "exec":
+				log.Debug("received an 'exec' channel request")
+				// If the request wants a reply, it _must_ be replied to.
+				if channelRequest.WantReply {
+					log.Debug("ACKing channel request")
+					// Since these are "Channel-specific" 'ssh.Request's, the returned
+					// payload is ignored.
+					err := channelRequest.Reply(true, nil)
+					require.NoError(t, err)
+				}
+				// All SSH 'exec' commands expect a response payload in uint32 byte
+				// order where the last 8-bits indicates the command's exit code.
+				//
+				// NOTE: This could be extended to allow for deeper testing with mock
+				// non-zero exit codes.
+				_, err := channel.SendRequest("exit-status", false, marshalExitStatus(0))
+				require.NoError(t, err)
+				// For convenience sake, remove all leading control characters in the
+				// payload.
+				channelRequest.Payload = bytes.TrimLeftFunc(channelRequest.Payload, func(r rune) bool {
+					return r < 0x20
+				})
+				outReqChan <- channelRequest
+			case "shell":
+				log.Error("received a 'shell' channel request, but this request type is not implemented")
+				continue
+			case "env":
+				log.Error("received an 'env' channel request, but this request type is not implemented")
+				continue
+			}
+		case channelMessage, more := <-inMsgChan:
+			// channelMessage means raw data sent over the wire from our client
+			// that isn't a well-known 'Request'. An example would be stdin to send
+			// to a running process.
+			//
+			// For convenience sake on the receiver's side, we send each line
+			// individually.
+			//
+			// Every message will have a trailing newline, trim that off first.
+			channelMessage = strings.TrimSpace(channelMessage)
+			for line := range strings.SplitSeq(channelMessage, "\n") {
+				// Each line will be prefixed with some control codes, trim those.
+				line = strings.TrimFunc(line, func(r rune) bool {
+					return r < 0x20
+				})
+				// Ignore blank lines.
+				if line == "" {
+					continue
+				}
+				log.Debug("sending channel message", "message", line)
+				outMsgChan <- line
+			}
+			// When the 'asyncRead' Goroutine closes this channel ('io.EOF' received),
+			// that means the client has signalled a disconnect and we're all done.
+			if !more {
+				return
+			}
+		}
+	}
+}
+
+var ErrServerNotStarted = fmt.Errorf(
+	"shutdown called without a call to 'ListenAndServe' first",
+)
+
+// Shutdown calls the 'context.CancelFunc' and waits for all Goroutines to exit.
+func (self *server) Shutdown(ctx context.Context) error {
+	if self.cancel == nil {
+		return ErrServerNotStarted
+	}
+	self.cancel()
+	return self.wait.WaitContext(ctx)
+}

--- a/internal/ssh/internal/mock/server.go
+++ b/internal/ssh/internal/mock/server.go
@@ -110,7 +110,9 @@ func (self *server) serve(
 			return
 		default:
 			// Don't block forever.
-			listener.SetDeadline(time.Now().Add(100 * time.Millisecond))
+			require.NoError(t, listener.SetDeadline(
+				time.Now().Add(100*time.Millisecond),
+			))
 			conn, err := listener.AcceptTCP()
 			if err != nil {
 				var operr *net.OpError
@@ -161,7 +163,10 @@ func (self *server) handleTCPConn(
 		case newChannelRequest := <-inChanReqChan:
 			// Reject non-session channels
 			if newChannelRequest.ChannelType() != "session" {
-				newChannelRequest.Reject(ssh.UnknownChannelType, "unknown channel type")
+				require.NoError(t, newChannelRequest.Reject(
+					ssh.UnknownChannelType,
+					"unknown channel type",
+				))
 				continue
 			}
 			// Accept 'session' channels.

--- a/internal/ssh/internal/mock/wait.go
+++ b/internal/ssh/internal/mock/wait.go
@@ -1,0 +1,48 @@
+package mock
+
+import (
+	"context"
+	"fmt"
+	"runtime"
+	"strings"
+	"sync/atomic"
+	"time"
+)
+
+func NewWaiter() Waiter {
+	return Waiter{
+		active: new(atomic.Int32),
+	}
+}
+
+// Waiter is like a 'sync.WaitGroup', save that its 'Wait' function accepts a
+// 'context.Context' and supports deadlines.
+type Waiter struct {
+	active *atomic.Int32
+}
+
+func (self Waiter) Add() {
+	self.active.Add(1)
+}
+
+func (self Waiter) Done() {
+	left := self.active.Add(-1)
+	_, file, line, _ := runtime.Caller(1)
+	i := strings.LastIndexByte(file, '/')
+	file = file[i+1:]
+	caller := fmt.Sprintf("%s:%d", file, line)
+	log.Debug("waiter.Done() called", "caller", caller, "left", left)
+}
+
+func (self Waiter) WaitContext(ctx context.Context) error {
+	for {
+		select {
+		case <-ctx.Done():
+			return context.DeadlineExceeded
+		case <-time.After(1 * time.Millisecond):
+			if self.active.Load() == 0 {
+				return nil
+			}
+		}
+	}
+}

--- a/internal/ssh/internal/mock/wait.go
+++ b/internal/ssh/internal/mock/wait.go
@@ -21,12 +21,12 @@ type Waiter struct {
 	active *atomic.Int32
 }
 
-func (self Waiter) Add() {
-	self.active.Add(1)
+func (w Waiter) Add() {
+	w.active.Add(1)
 }
 
-func (self Waiter) Done() {
-	left := self.active.Add(-1)
+func (w Waiter) Done() {
+	left := w.active.Add(-1)
 	_, file, line, _ := runtime.Caller(1)
 	i := strings.LastIndexByte(file, '/')
 	file = file[i+1:]
@@ -34,13 +34,13 @@ func (self Waiter) Done() {
 	log.Debug("waiter.Done() called", "caller", caller, "left", left)
 }
 
-func (self Waiter) WaitContext(ctx context.Context) error {
+func (w Waiter) WaitContext(ctx context.Context) error {
 	for {
 		select {
 		case <-ctx.Done():
 			return context.DeadlineExceeded
 		case <-time.After(1 * time.Millisecond):
-			if self.active.Load() == 0 {
+			if w.active.Load() == 0 {
 				return nil
 			}
 		}

--- a/internal/ssh/keys.go
+++ b/internal/ssh/keys.go
@@ -81,13 +81,13 @@ type ED25519PublicKey struct {
 
 // Verifies signature hash 'sig' against signed message 'msg' using the ed25519
 // public key.
-func (self ED25519PublicKey) Verify(msg, sig []byte) bool {
-	return ed25519.Verify(self.key, msg, sig)
+func (pubKey ED25519PublicKey) Verify(msg, sig []byte) bool {
+	return ed25519.Verify(pubKey.key, msg, sig)
 }
 
 // Converts the 'ed25519.PublicKey' to an 'ssh.PublicKey'.
-func (self ED25519PublicKey) ToSSH() (ssh.PublicKey, error) {
-	pub, err := ssh.NewPublicKey(self.key)
+func (pubKey ED25519PublicKey) ToSSH() (ssh.PublicKey, error) {
+	pub, err := ssh.NewPublicKey(pubKey.key)
 	if err != nil {
 		return nil, fmt.Errorf("%w: %w", ErrPubKeyConv, err)
 	}
@@ -95,9 +95,9 @@ func (self ED25519PublicKey) ToSSH() (ssh.PublicKey, error) {
 }
 
 // Marshals the 'ed25519.PublicKey' to the OpenSSH ('authorized_keys') format.
-func (self ED25519PublicKey) MarshalOpenSSH() ([]byte, error) {
+func (pubKey ED25519PublicKey) MarshalOpenSSH() ([]byte, error) {
 	// Convert the 'ed25519.PublicKey' to an 'ssh.PublicKey'.
-	publicKey, err := self.ToSSH()
+	publicKey, err := pubKey.ToSSH()
 	if err != nil {
 		return nil, err
 	}
@@ -116,14 +116,14 @@ type ED25519PrivateKey struct {
 // Signs a message with plain* ED25519 using the 'ed25519.PrivateKey'.
 //
 // * Plain means the message is not SHA-512 pre-hashed ('ed25519ph').
-func (self ED25519PrivateKey) Sign(msg []byte) ([]byte, error) {
-	return self.key.Sign(rand.Reader, msg, crypto.Hash(0))
+func (privKey ED25519PrivateKey) Sign(msg []byte) ([]byte, error) {
+	return privKey.key.Sign(rand.Reader, msg, crypto.Hash(0))
 }
 
 // Marshals the 'ed25519.PrivateKey' to the OpenSSH format.
-func (self ED25519PrivateKey) MarshalOpenSSH(comment string) ([]byte, error) {
+func (privKey ED25519PrivateKey) MarshalOpenSSH(comment string) ([]byte, error) {
 	// Marshal the 'ed25519.PrivateKey' to the standard OpenSSH format.
-	priv, err := ssh.MarshalPrivateKey(self.key, comment)
+	priv, err := ssh.MarshalPrivateKey(privKey.key, comment)
 	if err != nil {
 		return nil, fmt.Errorf("%w: %w", ErrPrivKeyMarshal, err)
 	}
@@ -136,8 +136,8 @@ func (self ED25519PrivateKey) MarshalOpenSSH(comment string) ([]byte, error) {
 }
 
 // Converts the 'ed25519.PrivateKey' to an 'ssh.Signer'.
-func (self ED25519PrivateKey) ToSSH() (ssh.Signer, error) {
-	return ssh.NewSignerFromKey(self.key)
+func (privKey ED25519PrivateKey) ToSSH() (ssh.Signer, error) {
+	return ssh.NewSignerFromKey(privKey.key)
 }
 
 var ErrSSHFailedKeyParse = fmt.Errorf("failed to parse SSH private key")

--- a/internal/ssh/keys.go
+++ b/internal/ssh/keys.go
@@ -1,0 +1,177 @@
+package ssh
+
+// keys.go implements a facade over standard library package 'crypto/ed25519'
+// for more ergonomic interactions with ED25519 public and private keys in the
+// context of SSH connections.
+//
+// Working with SSH clients and servers, there are many formats and key
+// representations that are commonly needed and achieving these formats requires
+// calls to four standard library packages ('crypto', 'crypto/ed25519',
+// 'x/crypto/ssh', 'encoding/pem') and entirely too much knowledge of SSH as a
+// protocol.
+//
+// All keys begin life as a 'crypto/*' (in this package's case 'crypto/ed25519')
+// then...
+//
+// FOR CLIENTS:
+// - For outbound connection authorization you'll need an 'ssh.PublicKey'.
+// - For outbound connection message signing you'll need an 'ssh.Signer'.
+// - For OpenSSH representations of your public key, you'll need to marshal it
+//   to the OpenSSH-specific ('authorized_keys') format.
+//
+// FOR SERVERS:
+// - For inbound connections you'll need your public key as an 'ssh.PublicKey' (
+//   host key).
+// - For connection message signing, you'll need an 'ssh.Signer'.
+// - For OpenSSH representations of your private key you'll need to marshal it
+//   to the OpenSSH-specific format (PEM with an 'OPENSSH' block header).
+//
+// For convenience, the standard 'Sign' and 'Verify' methods of the
+// 'crypto/ed25519' keys are also wrapped.
+//
+// NOTE: It may be confusing but 'x/crypto/ssh' doesn't have an implementation
+// of a 'PrivateKey' (though it does have a 'PublicKey'). The 'Signer' interface
+// fulfills all the roles of a private key within the 'x/crypto/ssh' package.
+
+import (
+	"crypto"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"fmt"
+
+	"golang.org/x/crypto/ssh"
+)
+
+var (
+	ErrKeyGen         = fmt.Errorf("failed to generate a 'crypto/ed25519' keypair")
+	ErrPubKeyConv     = fmt.Errorf("failed to convert the 'ed25519.PublicKey' to 'ssh.PublicKey'")
+	ErrPrivKeyConv    = fmt.Errorf("failed to convert the 'ed25519.PrivateKey' to an 'ssh.Signer'")
+	ErrPubKeyMarshal  = fmt.Errorf("failed to marshal the 'ssh.PublicKey' to OpenSSH format")
+	ErrPrivKeyMarshal = fmt.Errorf("failed to marshal the 'ssh.PrivateKey' to OpenSSH format")
+	ErrPEMEncode      = fmt.Errorf("failed to PEM-encode the ssh.PrivateKey")
+)
+
+// Generates a 'crypto/ed25519' public+private key pair, as an 'ED25519KeyPair'.
+func NewED25519KeyPair() (ED25519KeyPair, error) {
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return ED25519KeyPair{}, fmt.Errorf("%w: %w", ErrKeyGen, err)
+	}
+	return ED25519KeyPair{
+		Public: ED25519PublicKey{
+			key: pub,
+		},
+		Private: ED25519PrivateKey{
+			key: priv,
+		},
+	}, nil
+}
+
+type ED25519KeyPair struct {
+	Public  ED25519PublicKey
+	Private ED25519PrivateKey
+}
+
+type ED25519PublicKey struct {
+	key ed25519.PublicKey
+}
+
+// Verifies signature hash 'sig' against signed message 'msg' using the ed25519
+// public key.
+func (self ED25519PublicKey) Verify(msg, sig []byte) bool {
+	return ed25519.Verify(self.key, msg, sig)
+}
+
+// Converts the 'ed25519.PublicKey' to an 'ssh.PublicKey'.
+func (self ED25519PublicKey) ToSSH() (ssh.PublicKey, error) {
+	pub, err := ssh.NewPublicKey(self.key)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrPubKeyConv, err)
+	}
+	return pub, nil
+}
+
+// Marshals the 'ed25519.PublicKey' to the OpenSSH ('authorized_keys') format.
+func (self ED25519PublicKey) MarshalOpenSSH() ([]byte, error) {
+	// Convert the 'ed25519.PublicKey' to an 'ssh.PublicKey'.
+	publicKey, err := self.ToSSH()
+	if err != nil {
+		return nil, err
+	}
+	// Marshal the public key to the OpenSSH format.
+	marshaled := ssh.MarshalAuthorizedKey(publicKey)
+	if marshaled == nil {
+		return nil, ErrPubKeyMarshal
+	}
+	return marshaled, nil
+}
+
+type ED25519PrivateKey struct {
+	key ed25519.PrivateKey
+}
+
+// Signs a message with plain* ED25519 using the 'ed25519.PrivateKey'.
+//
+// * Plain means the message is not SHA-512 pre-hashed ('ed25519ph').
+func (self ED25519PrivateKey) Sign(msg []byte) ([]byte, error) {
+	return self.key.Sign(rand.Reader, msg, crypto.Hash(0))
+}
+
+// Marshals the 'ed25519.PrivateKey' to the OpenSSH format.
+func (self ED25519PrivateKey) MarshalOpenSSH(comment string) ([]byte, error) {
+	// Marshal the 'ed25519.PrivateKey' to the standard OpenSSH format.
+	priv, err := ssh.MarshalPrivateKey(self.key, comment)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrPrivKeyMarshal, err)
+	}
+	// Encode the 'pem.Block'.
+	encoded := pem.EncodeToMemory(priv)
+	if encoded == nil {
+		return nil, fmt.Errorf("%w: %w", ErrPEMEncode, err)
+	}
+	return encoded, nil
+}
+
+// Converts the 'ed25519.PrivateKey' to an 'ssh.Signer'.
+func (self ED25519PrivateKey) ToSSH() (ssh.Signer, error) {
+	return ssh.NewSignerFromKey(self.key)
+}
+
+var ErrSSHFailedKeyParse = fmt.Errorf("failed to parse SSH private key")
+
+// ParseKey attempts to parse the provided 'key' value as a PEM-encoded OpenSSH
+// format private key.
+//
+// If 'phrase' is nil or an empty slice, the key parse will be attempted
+// assuming no encryption.
+// If 'phrase' is provided, the key will be parsed assuming encryption. If the
+// parse fails with the key it will be reattempted assuming no encryption.
+func ParseKey(key, phrase []byte) (ssh.Signer, error) {
+	if len(key) == 0 {
+		return nil, nil
+	}
+	// If we received a passphrase, attempt parsing the encrypted key first
+	if len(phrase) > 0 {
+		// This looks a little funky because we _only_ want to return here if the
+		// error is nil
+		signer, err := ssh.ParsePrivateKeyWithPassphrase(key, phrase)
+		if err == nil {
+			return signer, nil
+		}
+		// If we received an x509.IncorrectPasswordError, reattempt parsing
+		// without the passphrase (key might not be encrypted), otherwise return
+		// all other errors
+		if !errors.Is(err, x509.IncorrectPasswordError) {
+			return nil, fmt.Errorf("%w: %w", ErrSSHFailedKeyParse, err)
+		}
+	}
+	// Attempt parsing a plaintext key
+	signer, err := ssh.ParsePrivateKey(key)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrSSHFailedKeyParse, err)
+	}
+	return signer, nil
+}

--- a/internal/ssh/keys_test.go
+++ b/internal/ssh/keys_test.go
@@ -78,7 +78,7 @@ func TestGenerateKeyPair(t *testing.T) {
 // of the provided byte slice 'input'.
 //
 // If all bytes are present, they are sliced off the front of the slice and
-// returned
+// returned.
 func expectPrefix(t *testing.T, input []byte, expects ...byte) []byte {
 	t.Helper()
 	require.True(t, len(input) >= len(expects))
@@ -93,7 +93,7 @@ func expectPrefix(t *testing.T, input []byte, expects ...byte) []byte {
 // of the provided byte slice 'input'.
 //
 // If all bytes are present, they are sliced off the back of the slice and
-// returned
+// returned.
 func expectSuffix(t *testing.T, input []byte, expects ...byte) []byte {
 	t.Helper()
 	require.True(t, len(input) >= len(expects))

--- a/internal/ssh/keys_test.go
+++ b/internal/ssh/keys_test.go
@@ -1,0 +1,105 @@
+package ssh
+
+import (
+	"bytes"
+	"encoding/base64"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenerateKeyPair(t *testing.T) {
+	// Generate a keypair, sign a message and verify its digest to confirm the
+	// keypair is valid
+	t.Run("validate-matching-keys", func(t *testing.T) {
+		pair, err := NewED25519KeyPair()
+		require.NoError(t, err)
+		const msg = "Hello, worldd"
+		sig, err := pair.Private.Sign([]byte(msg))
+		require.NoError(t, err)
+		require.True(t, len(sig) > 0)
+		assert.True(t, pair.Public.Verify([]byte(msg), sig))
+	})
+	t.Run("validate-public-key-marshal", func(t *testing.T) {
+		pair, err := NewED25519KeyPair()
+		require.NoError(t, err)
+		// Marshal the public key to the 'openssh' authorized_keys file format
+		pub, err := pair.Public.MarshalOpenSSH()
+		require.NoError(t, err)
+		// Verify the marshaled format of the public key
+		//
+		// Expect: Standard 'ssh-ed25519' key prefix
+		pub = expectPrefix(t, pub, []byte("ssh-ed25519 ")...)
+		// Expect: trailing newline
+		pub = expectSuffix(t, pub, '\n')
+		// Base64-decode the remainder
+		dec := make([]byte, len(pub)*2)
+		n, err := base64.StdEncoding.Decode(dec, pub)
+		require.NoError(t, err)
+		require.True(t, n > 0)
+		dec = dec[:n]
+		// Expect: 3 NUL bytes, vertical tab
+		dec = expectPrefix(t, dec, 0, 0, 0, '\x0b')
+		// Expect 'ssh-ed25519'
+		dec = expectPrefix(t, dec, []byte("ssh-ed25519")...)
+		// Expect: 3 NUL bytes, space
+		dec = expectPrefix(t, dec, 0, 0, 0, ' ')
+		// Expect: 32-bytes of remaining data
+		assert.True(t, len(dec) == 32)
+	})
+	t.Run("validate-private-key-marshal", func(t *testing.T) {
+		pair, err := NewED25519KeyPair()
+		require.NoError(t, err)
+		// Marshal the private key to the
+		priv, err := pair.Private.MarshalOpenSSH("test")
+		require.NoError(t, err)
+		// Expect: '-----BEGIN OPENSSH PRIVATE KEY-----' header
+		priv = expectPrefix(t, priv, []byte("-----BEGIN OPENSSH PRIVATE KEY-----")...)
+		// Expect: '-----END OPENSSH PRIVATE KEY-----' trailer with newline
+		priv = expectSuffix(t, priv, []byte("-----END OPENSSH PRIVATE KEY-----\n")...)
+		// Base64-decode the remainder, make sure there's no error and non-empty data
+		dec, err := base64.StdEncoding.DecodeString(string(priv))
+		require.NoError(t, err)
+		require.True(t, len(dec) > 0)
+		parts := bytes.Split(dec, []byte("ssh-ed25519"))
+		// We expect 3 parts:
+		// 1. Standard 'openssh-key-v1' header
+		// 2. Public key (with padding)
+		// 3. Private key (with padding)
+		require.True(t, len(parts) == 3)
+		expectPrefix(t, parts[0], []byte("openssh-key-v1\x00\x00\x00\x00")...)
+		assert.True(t, bytes.Contains(parts[1], pair.Public.key))
+		assert.True(t, bytes.Contains(parts[2], pair.Private.key))
+	})
+}
+
+// expectPrefix looks for a sequence of bytes 'expects' to occur from the start
+// of the provided byte slice 'input'.
+//
+// If all bytes are present, they are sliced off the front of the slice and
+// returned
+func expectPrefix(t *testing.T, input []byte, expects ...byte) []byte {
+	t.Helper()
+	require.True(t, len(input) >= len(expects))
+	for i, expect := range expects {
+		got := input[i]
+		assert.Equal(t, expect, got, "expected [%c], got [%c]", expect, got)
+	}
+	return input[len(expects):]
+}
+
+// expectPrefix looks for a sequence of bytes 'expects' to occur from the end
+// of the provided byte slice 'input'.
+//
+// If all bytes are present, they are sliced off the back of the slice and
+// returned
+func expectSuffix(t *testing.T, input []byte, expects ...byte) []byte {
+	t.Helper()
+	require.True(t, len(input) >= len(expects))
+	for i, expect := range expects {
+		got := input[len(input)-len(expects)+i]
+		assert.Equal(t, expect, got, "expected [%c], got [%c]", expect, got)
+	}
+	return input[:len(input)-len(expects)]
+}

--- a/internal/ssh/shell.go
+++ b/internal/ssh/shell.go
@@ -1,0 +1,14 @@
+package ssh
+
+// shell.go defines some string constants of the various well-known Linux
+// shells. These are used by 'ExecIn' to begin a shell session, then pipe one or
+// more commands to that process via stdin.
+
+type Shell = string
+
+const (
+	ShellSh   Shell = "sh"
+	ShellBash Shell = "bash"
+	ShellZSH  Shell = "zsh"
+	ShellFish Shell = "fish"
+)

--- a/internal/ssh/ssh.go
+++ b/internal/ssh/ssh.go
@@ -1,0 +1,210 @@
+package ssh
+
+// ssh.go implements a facade over 'x/crypto/ssh', simplifying  SSH connection
+// construction and SSH command execution/sequencing.
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"time"
+
+	"golang.org/x/crypto/ssh"
+)
+
+const sshDefaultTimeout = 3 * time.Second
+
+var (
+	ErrSSHFailedDial   = fmt.Errorf("failed to establish TCP/22 connection")
+	ErrFailedHostParse = fmt.Errorf("failed to parse ")
+	ErrHostKeyInvalid  = fmt.Errorf("target's host key is invalid")
+)
+
+// Connect establishes an SSH (tcp/22) connection to 'host' on TCP port 'port'.
+//
+// 'host' can be any of: hostname, ipv4 address or ipv6 address. If 'host' is
+// an empty string, ipv4 loopback is used.
+//
+// If 'port' is 0, a default value of '22' is used.
+//
+// 'keypair' is used for public key authentication when connecting to 'host'.
+//
+// Any values provided to 'hostKeys' will be used to compare against the host
+// key offered by 'host' when a connection is attempted. If no 'hostKeys' value
+// is provided, all host keys will be accepted.
+func Connect(host string, port uint16, user string, keypair ssh.Signer, hostKeys ...ssh.PublicKey) (*ssh.Client, error) {
+	if host == "" {
+		host = "127.0.0.1"
+	}
+	if port == 0 {
+		port = 22
+	}
+	// Init the SSH config.
+	config := &ssh.ClientConfig{
+		User: user,
+		Auth: []ssh.AuthMethod{
+			ssh.PublicKeys(keypair),
+		},
+		HostKeyCallback: func(hostname string, remote net.Addr, key ssh.PublicKey) error {
+			// If 'hostKeys' was not provided to 'Connect', simply return nil.
+			//
+			// This behavior is the same as 'ssh.InsecureIgnoreHostKey'.
+			if len(hostKeys) == 0 {
+				return nil
+			}
+			// If 'hostKeys' was provided to 'Connect', validate the SSH connection's
+			// host key matches one of 'hostKeys'.
+			for _, hostKey := range hostKeys {
+				if bytes.Equal(hostKey.Marshal(), key.Marshal()) {
+					return nil
+				}
+			}
+			return ErrHostKeyInvalid
+		},
+		Timeout: sshDefaultTimeout,
+	}
+	// Parse the host + port combination to a ssh.Dial-compatible 'addr' (host+
+	// port string).
+	target, err := joinHostPort(host, port)
+	if err != nil {
+		return nil, err
+	}
+	// Dial the SSH connection.
+	client, err := ssh.Dial("tcp", target, config)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrSSHFailedDial, err)
+	}
+	return client, nil
+}
+
+var (
+	dialer   = &net.Dialer{}
+	resolver = &net.Resolver{
+		Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
+			return dialer.DialContext(ctx, network, address)
+		},
+	}
+)
+
+// joinHostPort parses and validates 'host' is a valid IPv4 or IPv6 address,
+// then joins it with the port in the address-family-specific format.
+//
+// If 'host' is a hostname, the hostname will be resolved, then hostToPort will
+// recurse using the first of the resolved addresses.
+func joinHostPort(host string, port uint16) (string, error) {
+	// Set up a context for deadline.
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	// Parse and resolve the provided host, join the result with the port as
+	// appropriate.
+	if addr := net.ParseIP(host); addr == nil {
+		// Is it a hostname?
+		addrs, err := net.DefaultResolver.LookupHost(ctx, host)
+		if err != nil {
+			return "", fmt.Errorf("%w: %s", ErrFailedHostParse, host)
+		}
+		// Select the first address we resolved and parse that.
+		return joinHostPort(addrs[0], port)
+	} else if ipv4 := addr.To4(); ipv4 != nil {
+		// 'host' is ipv4
+		return fmt.Sprintf("%s:%d", ipv4.String(), port), nil
+	} else if ipv6 := addr.To16(); ipv6 != nil {
+		// 'host' is ipv6
+		return fmt.Sprintf("[%s]:%d", ipv6.String(), port), nil
+	} else {
+		panic("impossible")
+	}
+}
+
+var (
+	ErrSessionInit     = fmt.Errorf("failed to begin SSH session")
+	ErrCMDExec         = fmt.Errorf("failed to execute SSH command")
+	ErrInWait          = fmt.Errorf("SSH command did not exit cleanly")
+	ErrStdinWrite      = fmt.Errorf("failed to write command to stdin")
+	ErrStdinShortWrite = fmt.Errorf("short write to stdin")
+)
+
+// Exec executes a single command, returning any standard out/err received.
+func Exec(client *ssh.Client, cmd string) (string, string, error) {
+	// Init an SSH session.
+	session, err := client.NewSession()
+	if err != nil {
+		return "", "", fmt.Errorf("%w: %w", ErrSessionInit, err)
+	}
+	defer session.Close()
+	// Wire up standard streams.
+	stdout := new(bytes.Buffer)
+	session.Stdout = stdout
+	stderr := new(bytes.Buffer)
+	session.Stderr = stderr
+	// Execute the provided command.
+	if err = session.Run(cmd); err != nil {
+		return stdout.String(), stderr.String(), fmt.Errorf("%w: %w", ErrCMDExec, err)
+	}
+	return stdout.String(), stderr.String(), nil
+}
+
+// ExecIn executes all provided commands within the provided 'shell'.
+func ExecIn(client *ssh.Client, shell Shell, cmds ...string) (string, string, error) {
+	cmd := "/usr/bin/env " + shell
+	// Begin a new SSH session.
+	session, err := client.NewSession()
+	if err != nil {
+		log.Fatalf("failed to start SSH session: %s", err)
+		return "", "", fmt.Errorf("%w: %w", ErrSessionInit, err)
+	}
+	defer session.Close()
+	// Wire up standard streams.
+	//
+	// We use 'io.Pipe' here to ensure the 'session' reads match 1:1 with our
+	// stdin writes (sequenced commands).
+	stdinr, stdinw := io.Pipe()
+	defer stdinr.Close()
+	defer stdinw.Close()
+	session.Stdin = stdinr
+	stdout := new(bytes.Buffer)
+	session.Stdout = stdout
+	stderr := new(bytes.Buffer)
+	session.Stderr = stderr
+	// Begin the command (we'll pass the input 'cmds' via stdin further down).
+	if err = session.Start(cmd); err != nil {
+		log.Fatalf("failed to start session command: %s", err)
+		return "", "", fmt.Errorf("%w: %w", ErrCMDExec, err)
+	}
+	// Pass all provided commands in via stdin.
+	for _, cmd := range cmds {
+		// "Execute" the command.
+		_, err := stdinw.Write([]byte(cmd + "\n"))
+		if err != nil {
+			return stdout.String(), stderr.String(), fmt.Errorf(
+				"%w: %w",
+				ErrStdinWrite, err,
+			)
+		}
+	}
+	// Manually close the PipeWriter.
+	//
+	// This will signal an EOF to the 'PipeReader' and is safe to call multiple
+	// times.
+	stdinw.Close()
+	// Wait for the command to send an 'exit-status' request.
+	if err = session.Wait(); err != nil {
+		return stdout.String(), stderr.String(), fmt.Errorf("%w: %w", ErrInWait, err)
+	}
+	return stdout.String(), stderr.String(), nil
+}
+
+// marshalCommand appends a newline to 'cmd' then marshals it to the expected
+// SSH wire format (just len(cmd) followed by the actual data).
+func marshalCommand(cmd string) []byte {
+	return ssh.Marshal(struct{ Command string }{cmd + "\n"})
+	// cmd += "\n"
+	// size := uint32(len(cmd))
+	// ret := make([]byte, 0, 4+size)
+	// ret = append(ret, byte(size>>24), byte(size>>16), byte(size>>8), byte(size))
+	// ret = append(ret, cmd...)
+	// return ret
+}

--- a/internal/ssh/ssh.go
+++ b/internal/ssh/ssh.go
@@ -18,7 +18,7 @@ const sshDefaultTimeout = 3 * time.Second
 
 var (
 	ErrSSHFailedDial   = fmt.Errorf("failed to establish TCP/22 connection")
-	ErrFailedHostParse = fmt.Errorf("failed to parse ")
+	ErrFailedHostParse = fmt.Errorf("failed to parse hostname")
 	ErrHostKeyInvalid  = fmt.Errorf("target's host key is invalid")
 )
 

--- a/internal/ssh/ssh.go
+++ b/internal/ssh/ssh.go
@@ -105,7 +105,7 @@ func joinHostPort(host string, port uint16) (string, error) {
 		// 'host' is ipv6
 		return fmt.Sprintf("[%s]:%d", ipv6.String(), port), nil
 	} else {
-		panic("impossible")
+		return "", ErrFailedHostParse
 	}
 }
 

--- a/internal/ssh/ssh.go
+++ b/internal/ssh/ssh.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"log"
 	"net"
 	"time"
 
@@ -145,7 +144,6 @@ func ExecIn(client *ssh.Client, shell Shell, cmds ...string) (string, string, er
 	// Begin a new SSH session.
 	session, err := client.NewSession()
 	if err != nil {
-		log.Fatalf("failed to start SSH session: %s", err)
 		return "", "", fmt.Errorf("%w: %w", ErrSessionInit, err)
 	}
 	defer session.Close()
@@ -163,7 +161,6 @@ func ExecIn(client *ssh.Client, shell Shell, cmds ...string) (string, string, er
 	session.Stderr = stderr
 	// Begin the command (we'll pass the input 'cmds' via stdin further down).
 	if err = session.Start(cmd); err != nil {
-		log.Fatalf("failed to start session command: %s", err)
 		return "", "", fmt.Errorf("%w: %w", ErrCMDExec, err)
 	}
 	// Pass all provided commands in via stdin.

--- a/internal/ssh/ssh.go
+++ b/internal/ssh/ssh.go
@@ -80,15 +80,6 @@ func Connect(host string, port uint16, user string, keypair ssh.Signer, hostKeys
 	return client, nil
 }
 
-var (
-	dialer   = &net.Dialer{}
-	resolver = &net.Resolver{
-		Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
-			return dialer.DialContext(ctx, network, address)
-		},
-	}
-)
-
 // joinHostPort parses and validates 'host' is a valid IPv4 or IPv6 address,
 // then joins it with the port in the address-family-specific format.
 //
@@ -201,16 +192,4 @@ func ExecIn(client *ssh.Client, shell Shell, cmds ...string) (string, string, er
 		return stdout.String(), stderr.String(), fmt.Errorf("%w: %w", ErrInWait, err)
 	}
 	return stdout.String(), stderr.String(), nil
-}
-
-// marshalCommand appends a newline to 'cmd' then marshals it to the expected
-// SSH wire format (just len(cmd) followed by the actual data).
-func marshalCommand(cmd string) []byte {
-	return ssh.Marshal(struct{ Command string }{cmd + "\n"})
-	// cmd += "\n"
-	// size := uint32(len(cmd))
-	// ret := make([]byte, 0, 4+size)
-	// ret = append(ret, byte(size>>24), byte(size>>16), byte(size>>8), byte(size))
-	// ret = append(ret, cmd...)
-	// return ret
 }

--- a/internal/ssh/ssh_test.go
+++ b/internal/ssh/ssh_test.go
@@ -1,6 +1,7 @@
 package ssh
 
 import (
+	"bytes"
 	"context"
 	"log"
 	"log/slog"
@@ -81,9 +82,12 @@ func TestSSH(t *testing.T) {
 	// those returned values.
 	const cmd1 = "echo 'Hello, world!'"
 	const cmd2 = "echo 'Goodbyte, world!'"
-	_, _, err = ExecIn(
+	stdout, stderr := new(bytes.Buffer), new(bytes.Buffer)
+	err = ExecIn(
 		client,
 		ShellBash,
+		stdout,
+		stderr,
 		cmd1,
 		cmd2,
 	)

--- a/internal/ssh/ssh_test.go
+++ b/internal/ssh/ssh_test.go
@@ -1,0 +1,126 @@
+package ssh
+
+import (
+	"context"
+	"log"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/chainguard-dev/terraform-provider-imagetest/internal/ssh/internal/mock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	// The target for our SSH client test functions.
+	//
+	// The SSH server construction only allows an IP address, which when not
+	// supplied defaults to '0.0.0.0'. This is why 'mockListenHost' is not passed
+	// as a parameter into 'mock.NewServer'.
+	mockListenHost = "127.0.0.1"
+	// The port for our SSH client test functions.
+	//
+	// Ports <1024 are privileged, so we use '2222'.
+	mockListenPort uint16 = 2222
+)
+
+func TestSSH(t *testing.T) {
+	log.SetFlags(log.Lshortfile)
+	slog.SetLogLoggerLevel(slog.LevelDebug)
+	mock.SetLogger(slog.Default())
+	// Generate a "user" keypair.
+	userKeys, err := NewED25519KeyPair()
+	require.NoError(t, err)
+	// Convert the ed25519 private key to an ssh.Signer.
+	//
+	// The SSH client connection will sign messages with this key.
+	userSigner, err := userKeys.Private.ToSSH()
+	// Convert the ed25519 public key to an ssh.PublicKey
+	//
+	// The server will authenticate connections with this key.
+	userPubKey, err := userKeys.Public.ToSSH()
+	require.NoError(t, err)
+	// Generate a "server" keypair
+	serverKeys, err := NewED25519KeyPair()
+	require.NoError(t, err)
+	// Convert the server's ed25519 private key to an ssh.Signer.
+	//
+	// The server will sign responses to clients with this key.
+	serverSigner, err := serverKeys.Private.ToSSH()
+	require.NoError(t, err)
+	// Convert the server's ed25519 public key to an ssh.PublicKey.
+	//
+	// The client will authenticate the server's host key using this.
+	serverPubKey, err := serverKeys.Public.ToSSH()
+	require.NoError(t, err)
+	// Construct the mock SSH server on '0.0.0.0:[mockListenPort]'
+	server, err := mock.NewServer(
+		t,
+		mockListenPort,
+		serverSigner,
+		mock.PublicKeyCallback(t, userPubKey),
+	)
+	require.NoError(t, err)
+	// Begin serving SSH server connections
+	reqs, msgs, err := server.ListenAndServe(t, t.Context())
+	require.NoError(t, err)
+	// Connect to the server with our "user" keypair
+	client, err := Connect(
+		mockListenHost,
+		mockListenPort,
+		"hellope",
+		userSigner,
+		serverPubKey,
+	)
+	require.NoError(t, err)
+	// Execute two 'echo' commands in the 'Bash' shell.
+	//
+	// Our mock server will produce no stdout from these commands, so we discard
+	// those returned values.
+	const cmd1 = "echo 'Hello, world!'"
+	const cmd2 = "echo 'Goodbyte, world!'"
+	_, _, err = ExecIn(
+		client,
+		ShellBash,
+		cmd1,
+		cmd2,
+	)
+	require.NoError(t, err)
+	// Expect a request via the reqs channel stipulating the 'Bash' shell
+	req := <-reqs
+	require.Equal(t, req.Type, "exec")
+	require.Equal(t, string(req.Payload), "/usr/bin/env bash")
+	// Expect the 'Bash' commands we sent above in the order we sent them in
+	msg := <-msgs
+	require.Equal(t, cmd1, msg)
+	msg = <-msgs
+	require.Equal(t, cmd2, msg)
+	// Gracefully shutdown our mock SSH server with a 2-second deadline.
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+	defer cancel()
+	require.NoError(t, server.Shutdown(ctx))
+}
+
+func TestJoinHostPort(t *testing.T) {
+	// invalid ip4 address
+	s, err := joinHostPort("192.168.255.", 33)
+	assert.Error(t, err)
+	assert.Equal(t, "", s)
+	// invalid ipv6 address
+	s, err = joinHostPort("2001:db8:3333:4444:5555:6666:7777", 33)
+	assert.Error(t, err)
+	assert.Equal(t, "", s)
+	// valid ipv4 address
+	s, err = joinHostPort("192.168.255.50", 33)
+	assert.NoError(t, err)
+	assert.Equal(t, "192.168.255.50:33", s)
+	// valid ipv6 address
+	s, err = joinHostPort("2001:db8:3333:4444:5555:6666:7777:8888", 33)
+	assert.NoError(t, err)
+	assert.Equal(t, "[2001:db8:3333:4444:5555:6666:7777:8888]:33", s)
+	// valid hostname
+	s, err = joinHostPort("localhost", 33)
+	assert.NoError(t, err)
+	assert.Equal(t, "127.0.0.1:33", s)
+}

--- a/internal/ssh/ssh_test.go
+++ b/internal/ssh/ssh_test.go
@@ -36,6 +36,7 @@ func TestSSH(t *testing.T) {
 	//
 	// The SSH client connection will sign messages with this key.
 	userSigner, err := userKeys.Private.ToSSH()
+	require.NoError(t, err)
 	// Convert the ed25519 public key to an ssh.PublicKey
 	//
 	// The server will authenticate connections with this key.

--- a/internal/ssh/ssh_test.go
+++ b/internal/ssh/ssh_test.go
@@ -123,5 +123,5 @@ func TestJoinHostPort(t *testing.T) {
 	// valid hostname
 	s, err = joinHostPort("localhost", 33)
 	assert.NoError(t, err)
-	assert.Equal(t, "127.0.0.1:33", s)
+	assert.Contains(t, []string{"127.0.0.1:33", "[::1]:33"}, s)
 }


### PR DESCRIPTION
# Overview

In preparation for the inbound `ec2-driver` addition, this pull request adds an `ssh` package which implements a facade over `x/crypto/ssh`, `crypto`, `crypto/ed25519` and `encoding/pem` for:

- Generating SSH keys
- Performing all the necessary public+private key conversions
- Constructing an `*ssh.Client` (connecting)
- Executing individual or sequenced commands against a remote host and producing standard out+error
