### PR TITLE
Fix EKS nodegroup deletion timeout by disabling pod eviction

### DIFF
--- a/internal/drivers/eks_with_eksctl/driver.go
+++ b/internal/drivers/eks_with_eksctl/driver.go
@@ -294,7 +294,7 @@ func (k *driver) deleteNodeGroup(ctx context.Context) error {
 
 	log := clog.FromContext(ctx)
 
-	if err := k.eksctl(ctx, "delete", "nodegroup", "--region="+k.region, "--cluster="+k.clusterName, "--name="+k.nodeGroup); err != nil {
+	if err := k.eksctl(ctx, "delete", "nodegroup", "--region="+k.region, "--cluster="+k.clusterName, "--name="+k.nodeGroup, "--disable-eviction"); err != nil {
 		return fmt.Errorf("eksctl delete nodegroup: %w", err)
 	}
 


### PR DESCRIPTION
## Summary

- Add `--disable-eviction` flag to `eksctl delete nodegroup` command to prevent pods from blocking deletion
- One of https://github.com/chainguard-dev/internal-dev/issues/17424

## Rationale

@vishal-chdhry reported https://chainguard-dev.slack.com/archives/C083P5AQNQ2/p1754380972082689, and in particular [this error](https://github.com/chainguard-images/images-private/actions/runs/16743261627/job/47395921032#step:26:1179):

```
 | ***********************************************************************
  | * AWS Node Termination Handler                                        *
  | ***********************************************************************
  |   Chart version: 0.27.2
  |   App version:   1.25.2
  |   Image tag:     ***.dkr.ecr.us-west-2.amazonaws.com/imagetest:unused@sha256:0050093f20e4474a6bca98e2dfa18a9487f1a6c4bf2e60ac71f1a118ce52b3e3
  |   Mode :         IMDS
  | ***********************************************************************
  | pod/aws-node-termination-handler-2nr44 condition met
  | \x1b[0;32m[INFO]\x1b[0m Installing webhook-test-proxy
  | Release "webhook-test-proxy" does not exist. Installing it now.
  | NAME: webhook-test-proxy
  | LAST DEPLOYED: Tue Aug  5 07:32:30 2025
  | NAMESPACE: kube-system
  | STATUS: deployed
  | REVISION: 1
  | TEST SUITE: None
  | error: timed out waiting for the condition on pods/webhook-test-proxy-kw9gq
  | 2025/08/05 07:42:30 ERROR wrapped process exited with exit code 1
  | 2025/08/05 07:42:30 INFO finished bundling artifacts target=/mnt/imagetest/artifacts.tar.gz dir=/mnt/imagetest/artifacts size=1307 hash=901f3bd515cc4b9a722dd79fbc0b26806c26f3213c62c5387262178ac818e499
  | 2025/08/05 07:42:30 INFO exiting with code: 1
   diagnostic_summary="failed to run test" tf_proto_version=6.9 tf_provider_addr=registry.terraform.io/chainguard-dev/imagetest tf_resource_type=imagetest_tests tf_rpc=ApplyResourceChange @caller=github.com/hashicorp/terraform-plugin-go@v0.28.0/tfprotov6/internal/diag/diagnostics.go:58 timestamp=2025-08-05T07:48:49.752Z
2025-08-05T07:48:49.752Z [WARN]  provider.terraform-provider-imagetest_v0.0.92: Response contains warning diagnostic: @module=sdk.proto
  diagnostic_detail=
  | eksctl delete nodegroup: eksctl [delete nodegroup --region=us-west-2 --cluster=imagetest-48872c4c-63cc-429a-9abb-94f067365636 --name=ng-3953ff86-c5ad-468d-99a8-0b09cc884bfc --color false]: signal: killed: 2025-08-05 07:42:32 [ℹ]  1 nodegroup (ng-3953ff86-c5ad-468d-99a8-0b09cc884bfc) was included (based on the include/exclude rules)
  | 2025-08-05 07:42:32 [ℹ]  will drain 1 nodegroup(s) in cluster "imagetest-48872c4c-63cc-429a-9abb-94f067365636"
  | 2025-08-05 07:42:32 [ℹ]  starting parallel draining, max in-flight of 1
  | 2025-08-05 07:42:33 [ℹ]  cordon node "ip-192-168-79-75.us-west-2.compute.internal"
  | 2025-08-05 07:42:33 [!]  deleting Pods not managed by ReplicationController, ReplicaSet, Job, DaemonSet or StatefulSet: imagetest/imagetest-mb8zj
  | 2025-08-05 07:43:36 [!]  2 pods are unevictable from node ip-192-168-79-75.us-west-2.compute.internal
  | 2025-08-05 07:44:39 [!]  2 pods are unevictable from node ip-192-168-79-75.us-west-2.compute.internal
  | 2025-08-05 07:45:42 [!]  2 pods are unevictable from node ip-192-168-79-75.us-west-2.compute.internal
  | 2025-08-05 07:46:45 [!]  2 pods are unevictable from node ip-192-168-79-75.us-west-2.compute.internal
  | 2025-08-05 07:47:48 [!]  2 pods are unevictable from node ip-192-168-79-75.us-west-2.compute.internal
   diagnostic_severity=WARNING diagnostic_summary="failed to teardown test driver" @caller=github.com/hashicorp/terraform-plugin-go@v0.28.0/tfprotov6/internal/diag/diagnostics.go:60 tf_proto_version=6.9 tf_req_id=018e9a8f-07dd-b353-44e5-17a3d4e32c6a tf_rpc=ApplyResourceChange tf_provider_addr=registry.terraform.io/chainguard-dev/imagetest tf_resource_type=imagetest_tests timestamp=2025-08-05T07:48:49.752Z
2025-08-05T07:48:49.764Z [INFO]  provider: plugin process exited: plugin=.terraform/providers/registry.terraform.io/chainguard-dev/oci/0.0.23/linux_amd64/terraform-provider-oci_v0.0.23 id=17996
2025-08-05T07:48:49.764Z [INFO]  provider: plugin process exited: plugin=.terraform/providers/registry.terraform.io/chainguard-dev/oci/0.0.23/linux_amd64/terraform-provider-oci_v0.0.23 id=18814
2025-08-05T07:48:49.764Z [INFO]  provider: plugin process exited: plugin=.terraform/providers/registry.terraform.io/chainguard-dev/apko/0.29.10/linux_amd64/terraform-provider-apko_v0.29.10 id=18076
2025-08-05T07:48:49.766Z [INFO]  provider: plugin process exited: plugin=.terraform/providers/registry.terraform.io/chainguard-dev/imagetest/0.0.92/linux_amd64/terraform-provider-imagetest_v0.0.92 id=18042
module.aws-node-termination-handler.module.test-versioned["aws-node-termination-handler"].module.eks_tests.imagetest_tests.ekswitheksctl: Still creating... [27m20s elapsed]
[ ... REDACTED ...]
handler"].module.eks_tests.imagetest_tests.ekswitheksctl: Still creating... [29m50s elapsed]
module.aws-node-termination-handler.module.test-versioned["aws-node-termination-handler"].module.eks_tests.imagetest_tests.ekswitheksctl: Creation errored after 30m0s
Error: failed to run test
Warning: failed to teardown test driver
```

The problem is caused because deleting a node group first drains those nodes. If there are pods running, they will be evicted to other nodes. These pods cannot. I can't be sure of the exact reason as I haven't yet seen a live cluster that failed to tear down, but since they don't have local volumes or a pod disruption, it's likely that there simply aren't nodes to evict them to.

One way of solving the problem is to track running pods and make sure they are cleaned up fully before we try to drain the cluster. The other, easier way of solving this is to not drain the nodes at all, and simply let the pods die.

This is arguably acceptable for a test workload like this one. The downside I can see is that we might lose valuable diagnostic information about what caused these failures (a fairly common trade-off in test resource teardown). But we're not capturing that information anyway, so I reckon it's okay to double-down on cleanup.

## Test plan
- [x] Verify EKS driver tests pass without timeout issues
- [ ] Confirm nodegroup deletion completes quickly in CI
