### PR TITLE
Feat: Implement `InstanceIP` Input, BYO-Instance Override

### DIFF
--- a/.github/scripts/acc-test-driver-ec2.sh
+++ b/.github/scripts/acc-test-driver-ec2.sh
@@ -33,10 +33,17 @@ export TF_ACC=1
 
 # Run the tests.
 echo "Beginning acceptance tests."
+
+# This sleep is here to make sure users have a chance to see any logged output
+# above before the avalanche of test messages.
+sleep 1
+
+# Run the EC2 acceptance tests.
 go test \
   -tags ec2 ./internal/provider \
   -run '^TestAccTestDriverEC2$' \
   -count 1 \
+  -timeout 0 \
   -v
 
 if [ $? -eq 0 ]; then

--- a/.github/scripts/acc-test-driver-ec2.sh
+++ b/.github/scripts/acc-test-driver-ec2.sh
@@ -14,10 +14,18 @@ else
 fi
 
 # Build the entrypoint image.
-export IMAGETEST_ENTRYPOINT_REF=$(
+IMAGETEST_ENTRYPOINT_REF=$(
 	KO_DOCKER_REPO="${IMAGETEST_REGISTRY}/imagetest" \
-		ko build "./cmd/entrypoint"
+		ko build "./cmd/entrypoint" 2> ./ko-build.error
 )
+if [ $? -ne 0 ]; then
+  echo 'ERROR: Failed entrypoint build.'
+  echo '========================= BEGIN KO BUILD LOG ========================='
+  cat ./ko-build.error
+  echo '========================== END KO BUILD LOG =========================='
+  exit 1
+fi
+export IMAGETEST_ENTRYPOINT_REF
 echo "Built entrypoint image ref [${IMAGETEST_ENTRYPOINT_REF}]."
 
 # "Enable" acceptance tests.

--- a/docs/resources/tests.md
+++ b/docs/resources/tests.md
@@ -61,6 +61,7 @@ Optional:
 - `ami` (String) The AMI to use for the AMI driver (default is Ubuntu-24.04).
 - `device_mounts` (List of String)
 - `exec` (Attributes) Comamnds to execute on the EC2 instance after launch. (see [below for nested schema](#nestedatt--drivers--ec2--exec))
+- `instance_ip` (String) By default the EC2 driver will create and destroy many AWS resources (instance, VPC, IGW, etc.). To instead use an SSH-enabled environment provisioned outside of this driver, you may provide its IP address here. **NOTE**: This will override 'instance_type' and 'AMI'!
 - `instance_type` (String) The AWS EC2 instance type to launch (default is TODO).
 - `mount_all_gpus` (Boolean)
 - `region` (String) The AWS region to use for the EC2 driver (default is us-west-2).

--- a/internal/drivers/ec2/driver.go
+++ b/internal/drivers/ec2/driver.go
@@ -131,15 +131,15 @@ func (d *Driver) mounts(ctx context.Context) []mount.Mount {
 	log := clog.FromContext(ctx)
 
 	mounts := make([]mount.Mount, len(d.VolumeMounts))
-	for _, volume := range d.VolumeMounts {
+	for i, volume := range d.VolumeMounts {
 		// Split the local+in-container paths.
 		if local, incontainer, ok := strings.Cut(volume, ":"); ok {
 			log.Debug("adding volume mount", "from", local, "to", incontainer)
-			mounts = append(mounts, mount.Mount{
+			mounts[i] = mount.Mount{
 				Type:   mount.TypeBind,
 				Source: local,
 				Target: incontainer,
-			})
+			}
 		} else {
 			log.Error("found ill-formed bind mount (bind mounts must "+
 				"be in the form of '/host/path:/container/path')", "mapping", volume)

--- a/internal/drivers/ec2/driver.go
+++ b/internal/drivers/ec2/driver.go
@@ -50,6 +50,13 @@ type Driver struct {
 	// The desired EC2 instance type (ex: 't3.medium').
 	InstanceType types.InstanceType
 
+	// An IP address of the instance.
+	//
+	// NOTE: If this is provided, fields 'AMI' + 'InstanceType' will be ignored
+	// and no AWS resources will be created! This is primarily intended for local
+	// dev.
+	InstanceIP string
+
 	// Post-launch provisioning commands to be executed within the EC2 instance.
 	Exec Exec
 
@@ -64,6 +71,21 @@ type Driver struct {
 	// This is the equivalent of the '--gpus all' command-line flag.
 	MountAllGPUs bool
 
+	// Instance holds all configuration information relating to the EC2 Instance
+	// and associated SSH keys.
+	Instance InstanceDeployment
+
+	// Network holds all configuration information relating to the VPC and related
+	// networking components.
+	Network NetworkDeployment
+
+	// skipInit means an instance IP was provided against which we will perform
+	// our tests. All EC2 resource creation will be skipped.
+	SkipCreate bool
+
+	// SkipTeardown hopefully is self-explanatory!
+	SkipTeardown bool
+
 	// runID holds a unique identifier generated for this run.
 	runID string
 
@@ -74,18 +96,6 @@ type Driver struct {
 	// stack is a LIFO queue of 'destructor's which, when called, perform a
 	// teardown of a resource created during the 'Setup' method call.
 	stack stack
-
-	//////////////////////////////////////////////////////////////////////////////
-	// Here there be dragons.
-	//
-	// Considering the control flow indirection between 'Setup' and 'Run' /
-	// 'Teardown', we're not able to make the whole driver workflow black-box
-	// functional.
-	//
-	// Everything below this line is stuff we might mutate within this driver's
-	// lifecycle.
-	instance InstanceDeployment
-	net      NetworkDeployment
 }
 
 func (d *Driver) deviceMappings(ctx context.Context) []container.DeviceMapping {

--- a/internal/drivers/ec2/driver.go
+++ b/internal/drivers/ec2/driver.go
@@ -42,27 +42,27 @@ func newRunID() (string, error) {
 
 type Driver struct {
 	// The targeted EC2 region to deploy resources to.
-	Region string `tfsdk:"region"`
+	Region string
 
 	// The AMI to launch the instance with
-	AMI string `tfsdk:"ami"`
+	AMI string
 
 	// The desired EC2 instance type (ex: 't3.medium').
-	InstanceType types.InstanceType `tfsdk:"instance_type"`
+	InstanceType types.InstanceType
 
 	// Post-launch provisioning commands to be executed within the EC2 instance.
-	Exec Exec `tfsdk:"commands"`
+	Exec Exec
 
 	// User-provided volume mounts from the EC2 instance to the container.
-	VolumeMounts []string `tfsdk:"volume_mounts"`
+	VolumeMounts []string
 
 	// User-provided device mounts from the EC2 instance to the container.
-	DeviceMounts []string `tfask:"device_mounts"`
+	DeviceMounts []string
 
 	// Indicates all GPUs should be passed through to the container.
 	//
 	// This is the equivalent of the '--gpus all' command-line flag.
-	MountAllGPUs bool `tfsdk:"mount_all_gpus"`
+	MountAllGPUs bool
 
 	// runID holds a unique identifier generated for this run.
 	runID string

--- a/internal/drivers/ec2/driver_setup.go
+++ b/internal/drivers/ec2/driver_setup.go
@@ -3,6 +3,7 @@ package ec2
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"github.com/chainguard-dev/clog"
 )
@@ -16,6 +17,15 @@ func (d *Driver) Setup(ctx context.Context) error {
 		"driver", "ec2",
 		"run_id", d.runID,
 	)
+
+	// Check if we've been told to skip resource creation.
+	//
+	// Scenarios like a user providing the 'instance_ip' input will set this.
+	if d.SkipCreate {
+		return nil
+	}
+	os.Exit(1)
+
 	if err := d.init(ctx); err != nil {
 		return err
 	} else if err := d.postInit(ctx); err != nil {

--- a/internal/drivers/ec2/driver_setup_init.go
+++ b/internal/drivers/ec2/driver_setup_init.go
@@ -19,21 +19,21 @@ func (d *Driver) init(ctx context.Context) (err error) {
 	// TODO: In the future it'd be great to be able to bring-your-own VPC subnet
 	// ID and just attach the EC2 instance to that.
 	log.Info("bootstrapping virtual network")
-	d.net, err = d.deployNetwork(ctx)
+	d.Network, err = d.deployNetwork(ctx)
 	if err != nil {
 		return err
 	}
 	log.Info("virtual network setup complete")
 
 	// Deploy the EC2 instance.
-	d.instance, err = d.deployInstance(ctx, d.net)
+	d.Instance, err = d.deployInstance(ctx, d.Network)
 	if err != nil {
 		return err
 	}
 	log.Info("EC2 instance deployment complete")
 
 	// Prepare the EC2 instance.
-	err = d.prepareInstance(ctx, d.instance, d.net)
+	err = d.prepareInstance(ctx, d.Instance, d.Network)
 	if err != nil {
 		return err
 	}

--- a/internal/drivers/ec2/driver_setup_post_init.go
+++ b/internal/drivers/ec2/driver_setup_post_init.go
@@ -28,7 +28,7 @@ func (d *Driver) postInit(ctx context.Context) error {
 	)
 
 	// Convert the ED25519 private key to an 'ssh.Signer'.
-	signer, err := d.instance.Keys.Private.ToSSH()
+	signer, err := d.Instance.Keys.Private.ToSSH()
 	if err != nil {
 		return err // No annotation required.
 	}
@@ -38,10 +38,10 @@ func (d *Driver) postInit(ctx context.Context) error {
 	log.Info(
 		"connecting to EC2 instance",
 		"user", d.Exec.User,
-		"host", d.net.ElasticIP,
+		"host", d.Network.ElasticIP,
 		"port", portSSH,
 	)
-	client, err := ssh.Connect(d.net.ElasticIP, portSSH, d.Exec.User, signer)
+	client, err := ssh.Connect(d.Network.ElasticIP, portSSH, d.Exec.User, signer)
 	if err != nil {
 		return fmt.Errorf("failed to connect to instance via SSH: %w", err)
 	}

--- a/internal/drivers/ec2/driver_teardown.go
+++ b/internal/drivers/ec2/driver_teardown.go
@@ -2,7 +2,6 @@ package ec2
 
 import (
 	"context"
-	"os"
 
 	"github.com/chainguard-dev/clog"
 )
@@ -20,10 +19,11 @@ func (d *Driver) Teardown(ctx context.Context) error {
 	// value of 'true' is required to skip teardown. However, implementations
 	// around the codebase simply look for the existence of the variable. The
 	// below aligns with the existing implementations.
-	if _, ok := os.LookupEnv("IMAGETEST_SKIP_TEARDOWN"); ok {
-		log.Info("IMAGETEST_SKIP_TEARDOWN is set, skipping cleanup")
+	if d.SkipTeardown {
+		log.Info("skipping cleanup")
 		return nil
 	}
+
 	log.Info("beginning resource teardown")
 
 	// Destroy it all!


### PR DESCRIPTION
# Overview

This pull request adds input `InstanceIP` to the EC2 driver. `InstanceIP` allows for an arbitrary IP address to be provided. When this input is present, the driver will:
- Skip standard AWS resource construction & destruction.
- Execute tests against the provided IP.

This should speed up local dev feedback loops a great deal and pairs nicely with [cdx (in-progress)](https://git.sr.ht/~illbjorn/cdx).

> [!NOTE]
> When using the `InstanceIP` override, the driver will assume SSH authentication is handled (i.e. `~/.ssh/config`)(`cdx` handles this automatically).
