### PR TITLE
tee logs to configurable directory

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -49,6 +49,7 @@ provider "imagetest" {
 
 - `extra_repos` (List of String) An optional list of extra oci registries to wire in auth credentials for.
 - `harnesses` (Attributes) (see [below for nested schema](#nestedatt--harnesses))
+- `logs` (Attributes) Configuration for test log output to files. (see [below for nested schema](#nestedatt--logs))
 - `repo` (String) The target repository the provider will use for pushing/pulling dynamically built images.
 - `sandbox` (Attributes) The optional configuration for all test sandboxes. (see [below for nested schema](#nestedatt--sandbox))
 - `test_execution` (Attributes) (see [below for nested schema](#nestedatt--test_execution))
@@ -171,6 +172,14 @@ Optional:
 
 
 
+
+
+<a id="nestedatt--logs"></a>
+### Nested Schema for `logs`
+
+Optional:
+
+- `directory` (String) Base directory where test logs will be written. Each test resource creates its own subdirectory. Can be overridden by IMAGETEST_LOGS environment variable.
 
 
 <a id="nestedatt--sandbox"></a>

--- a/go.mod
+++ b/go.mod
@@ -97,6 +97,8 @@ require (
 	github.com/googleapis/enterprise-certificate-proxy v0.3.6 // indirect
 	github.com/googleapis/gax-go/v2 v2.15.0 // indirect
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 // indirect
+	github.com/gosimple/slug v1.15.0 // indirect
+	github.com/gosimple/unidecode v1.0.1 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.1-0.20210315223345-82c243799c99 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.1 // indirect
@@ -131,6 +133,9 @@ require (
 	github.com/prometheus/common v0.63.0 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
+	github.com/samber/lo v1.51.0 // indirect
+	github.com/samber/slog-common v0.19.0 // indirect
+	github.com/samber/slog-multi v1.4.1 // indirect
 	github.com/sergi/go-diff v1.4.0 // indirect
 	github.com/sirupsen/logrus v1.9.4-0.20230606125235-dd1b4c2e81af // indirect
 	github.com/skeema/knownhosts v1.3.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -235,6 +235,10 @@ github.com/googleapis/gax-go/v2 v2.15.0 h1:SyjDc1mGgZU5LncH8gimWo9lW1DtIfPibOG81
 github.com/googleapis/gax-go/v2 v2.15.0/go.mod h1:zVVkkxAQHa1RQpg9z2AUCMnKhi0Qld9rcmyfL1OZhoc=
 github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 h1:JeSE6pjso5THxAzdVpqr6/geYxZytqFMBCOtn/ujyeo=
 github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674/go.mod h1:r4w70xmWCQKmi1ONH4KIaBptdivuRPyosB9RmPlGEwA=
+github.com/gosimple/slug v1.15.0 h1:wRZHsRrRcs6b0XnxMUBM6WK1U1Vg5B0R7VkIf1Xzobo=
+github.com/gosimple/slug v1.15.0/go.mod h1:UiRaFH+GEilHstLUmcBgWcI42viBN7mAb818JrYOeFQ=
+github.com/gosimple/unidecode v1.0.1 h1:hZzFTMMqSswvf0LBJZCZgThIZrpDHFXux9KeGmn6T/o=
+github.com/gosimple/unidecode v1.0.1/go.mod h1:CP0Cr1Y1kogOtx0bJblKzsVWrqYaqfNOnHzpgWw4Awc=
 github.com/grpc-ecosystem/go-grpc-middleware v1.4.0 h1:UH//fgunKIs4JdUbpDl1VZCDaL56wXCB/5+wF6uHfaI=
 github.com/grpc-ecosystem/go-grpc-middleware v1.4.0/go.mod h1:g5qyo/la0ALbONm6Vbp88Yd8NsDy6rZz+RcrMPxvld8=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.1-0.20210315223345-82c243799c99 h1:JYghRBlGCZyCF2wNUJ8W0cwaQdtpcssJ4CgC406g+WU=
@@ -423,6 +427,12 @@ github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUc
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/samber/lo v1.51.0 h1:kysRYLbHy/MB7kQZf5DSN50JHmMsNEdeY24VzJFu7wI=
+github.com/samber/lo v1.51.0/go.mod h1:4+MXEGsJzbKGaUEQFKBq2xtfuznW9oz/WrgyzMzRoM0=
+github.com/samber/slog-common v0.19.0 h1:fNcZb8B2uOLooeYwFpAlKjkQTUafdjfqKcwcC89G9YI=
+github.com/samber/slog-common v0.19.0/go.mod h1:dTz+YOU76aH007YUU0DffsXNsGFQRQllPQh9XyNoA3M=
+github.com/samber/slog-multi v1.4.1 h1:OVBxOKcorBcGQVKjwlraA41JKWwHQyB/3KfzL3IJAYg=
+github.com/samber/slog-multi v1.4.1/go.mod h1:im2Zi3mH/ivSY5XDj6LFcKToRIWPw1OcjSVSdXt+2d0=
 github.com/sergi/go-diff v1.4.0 h1:n/SP9D5ad1fORl+llWyN+D6qoUETXNZARKjyY2/KVCw=
 github.com/sergi/go-diff v1.4.0/go.mod h1:A0bzQcvG0E7Rwjx0REVgAGH58e96+X0MeOfepqsbeW4=
 github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=

--- a/internal/log/testlog.go
+++ b/internal/log/testlog.go
@@ -1,0 +1,97 @@
+package log
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+
+	"github.com/chainguard-dev/clog"
+	"github.com/chainguard-dev/terraform-provider-imagetest/internal/drivers"
+	"github.com/gosimple/slug"
+	slogmulti "github.com/samber/slog-multi"
+)
+
+// SetupTestsLogging configures logging with optional file output for a specific test.
+func SetupTestsLogging(ctx context.Context, logsDirectory, testID, testName string) (context.Context, func()) {
+	if logsDirectory == "" {
+		return ctx, func() {}
+	}
+
+	// Create subdirectory for this test resource
+	testDir := filepath.Join(logsDirectory, testID)
+	if err := os.MkdirAll(testDir, 0o755); err != nil {
+		clog.WarnContext(ctx, "failed to create test directory", "path", testDir, "error", err.Error())
+		return ctx, func() {}
+	}
+
+	// Create a safe filename for this test
+	safeTestName := slug.Make(testName)
+	logPath := filepath.Join(testDir, fmt.Sprintf("%s.log", safeTestName))
+
+	logFile, err := os.Create(logPath)
+	if err != nil {
+		clog.WarnContext(ctx, "failed to create test log file", "path", logPath, "error", err.Error())
+		return ctx, func() {}
+	}
+
+	// Create a custom handler that only writes driver_log content
+	fileHandler := &testsHandler{
+		w: logFile,
+	}
+
+	// Use slog-multi to tee to both handlers
+	handler := clog.FromContext(ctx).Handler()
+	handler = slogmulti.Fanout(handler, fileHandler)
+
+	// Update the context with the new handler
+	clog.InfoContext(ctx, "logging test output to file", "path", logPath)
+	ctx = clog.WithLogger(ctx, clog.New(handler))
+
+	return ctx, func() {
+		if err := logFile.Close(); err != nil {
+			clog.WarnContext(ctx, "failed to close log file", "path", logPath, "error", err.Error())
+		}
+	}
+}
+
+// testsHandler is an internal slog handler that only writes driver_log attribute values to a file.
+type testsHandler struct {
+	w io.WriteCloser
+}
+
+func (d *testsHandler) Enabled(_ context.Context, _ slog.Level) bool {
+	return true
+}
+
+func (d *testsHandler) Handle(_ context.Context, record slog.Record) error {
+	// Look for the driver_log attribute
+	var driverLog string
+	record.Attrs(func(a slog.Attr) bool {
+		if a.Key == drivers.LogAttributeKey {
+			driverLog = a.Value.String()
+			return false // stop iteration
+		}
+		return true
+	})
+
+	// Only write if we found a driver_log attribute
+	if driverLog != "" {
+		_, err := fmt.Fprintln(d.w, driverLog)
+		return err
+	}
+
+	return nil
+}
+
+func (d *testsHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	// Return the same handler - we don't need to track attrs
+	return d
+}
+
+func (d *testsHandler) WithGroup(name string) slog.Handler {
+	// Return the same handler - we don't need to track groups
+	return d
+}

--- a/internal/provider/store.go
+++ b/internal/provider/store.go
@@ -41,6 +41,7 @@ type ProviderStore struct {
 	extraRepos           []name.Repository
 	ropts                []remote.Option
 	entrypointLayers     map[string][]v1.Layer
+	logsDirectory        string // Base directory for test logs
 }
 
 func NewProviderStore(repo name.Repository) (*ProviderStore, error) {


### PR DESCRIPTION
plumb through an opt in `log_directory` via a slog tee which when set (either at the provider level config or via `IMAGETEST_LOGS`) will write the `driver_log` logs to a file per test case:

```
lr imagetest
drwxr-xr-x    - wolf 29 Aug 18:26 -N imagetest
drwxr-xr-x    - wolf 29 Aug 18:26 -N ├── argo-cd-2.12-k3s_in_docker-2451
.rw-r--r--    0 wolf 29 Aug 18:26 -N │   └── helm-install.log
drwxr-xr-x    - wolf 29 Aug 18:15 -N ├── argo-cd-2.12-k3s_in_docker-ee93
.rw-r--r--  23k wolf 29 Aug 18:15 -N │   ├── argocd-functionality-test.log
.rw-r--r--  10k wolf 29 Aug 18:16 -N │   ├── argocd-ui-playwright-test.log
.rw-r--r-- 1.7M wolf 29 Aug 18:14 -N │   └── helm-install.log
...
```

the contents will only have the actual log lines produced by the imagetest pod, effectively the test logs.

this'll use the same internal deconfliction that the `imagetest_tests` already uses to distinguish between tests (an optional `name` with a fallback random suffix) to name things.

the existing slog tfhandler is untouched, and still produces logs with `TF_LOG=info`:

```
2025-08-29T18:28:44.278Z [INFO]  provider.terraform-provider-imagetest: received container log line: @module=imagetest.imagetest driver=docker_in_docker driver_log="2025/08/29 18:28:44 INFO finished bundling artifacts target=/mnt/imagetest/artifacts.tar.gz dir=/mnt/imagetest/artifacts size=1612 hash=3e950bce1568606a9bb8e8f4e778c04beac10c619603d6011e8facc8b1c4ca59" test_id=crane-docker_in_docker-8cbb @caller=/Users/wolf/go/pkg/mod/github.com/samber/slog-multi@v1.4.1/multi.go:41 test_name=smoke test_ref=us-central1-docker.pkg.dev/wolf-chainguard/work/imagetest/imagetest@sha256:547687c2440b21e8d4a5a7d5b0b6a71a43b3d1a55e7330d23826600c90e915c4 timestamp=2025-08-29T18:28:44.278Z
```