### PR TITLE
feat(imagetest): add cross-account AWS support to eks_with_eksctl driver

### DIFF
--- a/docs/resources/tests.md
+++ b/docs/resources/tests.md
@@ -85,6 +85,7 @@ Optional:
 
 Optional:
 
+- `aws_profile` (String) The AWS CLI profile to use for eksctl and AWS CLI commands
 - `node_ami` (String) The AMI to use for the eks_with_eksctl driver (default is the latest EKS optimized AMI)
 - `node_count` (Number) The number of nodes to use for the eks_with_eksctl driver (default is 1)
 - `node_type` (String) The instance type to use for the eks_with_eksctl driver (default is m5.large)

--- a/internal/provider/drivers.go
+++ b/internal/provider/drivers.go
@@ -75,6 +75,7 @@ type EKSWithEksctlDriverResourceModel struct {
 	NodeCount               types.Int64                                          `tfsdk:"node_count"`
 	Storage                 *EKSWithEksctlStorageResourceModel                   `tfsdk:"storage"`
 	PodIdentityAssociations []*EKSWithEksctlPodIdentityAssociationResourceModule `tfsdk:"pod_identity_associations"`
+	AWSProfile              types.String                                         `tfsdk:"aws_profile"`
 }
 
 type EKSWithEksctlStorageResourceModel struct {
@@ -295,6 +296,7 @@ kubectl rollout status deployment/coredns -n kube-system --timeout=60s
 			NodeCount:               int(cfg.NodeCount.ValueInt64()),
 			PodIdentityAssociations: podIdentityAssociations,
 			Storage:                 storageOpts,
+			AWSProfile:              cfg.AWSProfile.ValueString(),
 		})
 
 	case DriverEC2:
@@ -527,6 +529,10 @@ func DriverResourceSchema(ctx context.Context) schema.SingleNestedAttribute {
 								},
 							},
 						},
+					},
+					"aws_profile": schema.StringAttribute{
+						Description: "The AWS CLI profile to use for eksctl and AWS CLI commands",
+						Optional:    true,
 					},
 				},
 			},


### PR DESCRIPTION
The eks_with_eksctl driver currently uses default AWS credentials for all operations. This works when tests run in the same AWS account, but fails for cross-account scenarios where tests need to access resources in a different account.

This change adds an optional aws_profile parameter to the driver that enables cross-account access. The parameter is added to the Terraform schema and wired through the provider layer to the driver instance.

When the parameter is set, the driver passes the AWS_PROFILE environment variable to eksctl commands and configures the AWS SDK to use the specified profile. Both eksctl and the EC2 client now respect the profile setting, enabling complete cross-account support throughout the driver.

With this change, tests can specify which AWS CLI profile to use. When a profile is configured with role assumption settings, the driver will automatically assume the cross-account role before executing commands.

Example usage:

  module "test" {
    source = "./tests"

    drivers = {
      eks_with_eksctl = {
        aws_profile = "imgtest-infra"
      }
    }
  }