### PR TITLE
imagetest_tests: plumb through k3s setup timeout and retry

### DIFF
--- a/docs/resources/tests.md
+++ b/docs/resources/tests.md
@@ -66,6 +66,7 @@ Optional:
 - `resource_group` (String) The Azure resource group for the AKS driver
 - `subscription_id` (String) The Azure subscription ID for the AKS driver, defaults to AZURE_SUBSCRIPTION_ID env var
 - `tags` (Map of String) Additional tags to apply to all AKS resources created by the driver. Auto-generated tags (imagetest, imagetest:test-name, imagetest:cluster-name) are always included.
+- `timeouts` (Attributes) Timeout configuration for driver lifecycle phases. (see [below for nested schema](#nestedatt--drivers--aks--timeouts))
 
 <a id="nestedatt--drivers--aks--attached_acrs"></a>
 ### Nested Schema for `drivers.aks.attached_acrs`
@@ -114,6 +115,15 @@ Optional:
 
 
 
+<a id="nestedatt--drivers--aks--timeouts"></a>
+### Nested Schema for `drivers.aks.timeouts`
+
+Optional:
+
+- `setup` (String) Maximum time for driver setup (e.g., cluster creation). If unset, setup is bounded only by the resource-level timeout.
+- `teardown` (String) Maximum time for driver teardown (e.g., cluster deletion). If unset, the driver uses a built-in default.
+
+
 
 <a id="nestedatt--drivers--docker_in_docker"></a>
 ### Nested Schema for `drivers.docker_in_docker`
@@ -122,6 +132,16 @@ Optional:
 
 - `image` (String) The image reference to use for the docker-in-docker driver
 - `mirrors` (List of String)
+- `timeouts` (Attributes) Timeout configuration for driver lifecycle phases. (see [below for nested schema](#nestedatt--drivers--docker_in_docker--timeouts))
+
+<a id="nestedatt--drivers--docker_in_docker--timeouts"></a>
+### Nested Schema for `drivers.docker_in_docker.timeouts`
+
+Optional:
+
+- `setup` (String) Maximum time for driver setup (e.g., cluster creation). If unset, setup is bounded only by the resource-level timeout.
+- `teardown` (String) Maximum time for driver teardown (e.g., cluster deletion). If unset, the driver uses a built-in default.
+
 
 
 <a id="nestedatt--drivers--ec2"></a>
@@ -144,6 +164,7 @@ Optional:
 - `ssh_port` (Number) SSH port for connecting to the instance (default: 22).
 - `ssh_user` (String) SSH user for connecting to the instance (default: ubuntu).
 - `subnet_cidr` (String) The CIDR block for the subnet. If not specified, an available /24 is auto-detected.
+- `timeouts` (Attributes) Timeout configuration for driver lifecycle phases. (see [below for nested schema](#nestedatt--drivers--ec2--timeouts))
 - `user_data` (String) Cloud-init user data (will be base64 encoded).
 - `volume_mounts` (List of String) Volume mounts for the test container (format: src:dst).
 - `vpc_id` (String) The VPC ID to create resources in. Required unless using existing_instance.
@@ -155,6 +176,15 @@ Required:
 
 - `ip` (String) IP address of the existing instance.
 - `ssh_key` (String) Path to the SSH private key file.
+
+
+<a id="nestedatt--drivers--ec2--timeouts"></a>
+### Nested Schema for `drivers.ec2.timeouts`
+
+Optional:
+
+- `setup` (String) Maximum time for driver setup (e.g., cluster creation). If unset, setup is bounded only by the resource-level timeout.
+- `teardown` (String) Maximum time for driver teardown (e.g., cluster deletion). If unset, the driver uses a built-in default.
 
 
 
@@ -171,6 +201,7 @@ Optional:
 - `region` (String) The AWS region to use for the eks_with_eksctl driver (default is us-west-2)
 - `storage` (Attributes) Storage configuration for the eks_with_eksctl driver (see [below for nested schema](#nestedatt--drivers--eks_with_eksctl--storage))
 - `tags` (Map of String) Additional tags to apply to all AWS resources created by the driver. Auto-generated tags (imagetest, imagetest:test-name, imagetest:cluster-name) are always included.
+- `timeouts` (Attributes) Timeout configuration for driver lifecycle phases. (see [below for nested schema](#nestedatt--drivers--eks_with_eksctl--timeouts))
 
 <a id="nestedatt--drivers--eks_with_eksctl--pod_identity_associations"></a>
 ### Nested Schema for `drivers.eks_with_eksctl.pod_identity_associations`
@@ -191,6 +222,15 @@ Optional:
 - `type` (String) The type of storage to use (e.g., 'gp2', 'gp3')
 
 
+<a id="nestedatt--drivers--eks_with_eksctl--timeouts"></a>
+### Nested Schema for `drivers.eks_with_eksctl.timeouts`
+
+Optional:
+
+- `setup` (String) Maximum time for driver setup (e.g., cluster creation). If unset, setup is bounded only by the resource-level timeout.
+- `teardown` (String) Maximum time for driver teardown (e.g., cluster deletion). If unset, the driver uses a built-in default.
+
+
 
 <a id="nestedatt--drivers--k3s_in_docker"></a>
 ### Nested Schema for `drivers.k3s_in_docker`
@@ -204,6 +244,7 @@ Optional:
 - `network_policy` (Boolean) Enable the network policy
 - `registries` (Attributes Map) A map of registries containing configuration for optional auth, tls, and mirror configuration. (see [below for nested schema](#nestedatt--drivers--k3s_in_docker--registries))
 - `snapshotter` (String) The snapshotter to use for the k3s_in_docker driver
+- `timeouts` (Attributes) Timeout configuration for driver lifecycle phases. (see [below for nested schema](#nestedatt--drivers--k3s_in_docker--timeouts))
 - `traefik` (Boolean) Enable the traefik ingress controller
 
 <a id="nestedatt--drivers--k3s_in_docker--hooks"></a>
@@ -228,6 +269,15 @@ Optional:
 
 - `endpoints` (List of String)
 
+
+
+<a id="nestedatt--drivers--k3s_in_docker--timeouts"></a>
+### Nested Schema for `drivers.k3s_in_docker.timeouts`
+
+Optional:
+
+- `setup` (String) Maximum time for driver setup (e.g., cluster creation). If unset, setup is bounded only by the resource-level timeout.
+- `teardown` (String) Maximum time for driver teardown (e.g., cluster deletion). If unset, the driver uses a built-in default.
 
 
 

--- a/internal/drivers/docker_in_docker/driver.go
+++ b/internal/drivers/docker_in_docker/driver.go
@@ -40,6 +40,7 @@ type driver struct {
 	cliCfg    *docker.DockerConfig
 	daemonCfg *daemonConfig
 	ropts     []remote.Option
+	timeouts  drivers.Timeouts
 }
 
 func NewDriver(n string, opts ...DriverOpts) (drivers.Tester, error) {
@@ -101,6 +102,8 @@ func (d *driver) Setup(ctx context.Context) error {
 
 // Teardown implements drivers.TestDriver.
 func (d *driver) Teardown(ctx context.Context) error {
+	ctx, cancel := d.timeouts.TeardownContext(ctx)
+	defer cancel()
 	return d.stack.Teardown(ctx)
 }
 

--- a/internal/drivers/docker_in_docker/opts.go
+++ b/internal/drivers/docker_in_docker/opts.go
@@ -4,6 +4,7 @@ import (
 	"maps"
 
 	"github.com/chainguard-dev/terraform-provider-imagetest/internal/docker"
+	"github.com/chainguard-dev/terraform-provider-imagetest/internal/drivers"
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
@@ -106,6 +107,13 @@ func WithRegistryMirrors(mirrors ...string) DriverOpts {
 		}
 
 		d.daemonCfg.Mirrors = append(d.daemonCfg.Mirrors, mirrors...)
+		return nil
+	}
+}
+
+func WithTimeouts(t drivers.Timeouts) DriverOpts {
+	return func(d *driver) error {
+		d.timeouts = t
 		return nil
 	}
 }

--- a/internal/drivers/drivers.go
+++ b/internal/drivers/drivers.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"fmt"
 	"io"
 	"net/url"
 	"os"
+	"time"
 
 	"github.com/chainguard-dev/clog"
 	"github.com/google/go-containerregistry/pkg/name"
@@ -20,6 +22,55 @@ type Tester interface {
 	Teardown(context.Context) error
 	// Run takes a container and runs it
 	Run(context.Context, name.Reference) (*RunResult, error)
+}
+
+// Timeouts holds parsed driver lifecycle timeouts. Zero means no
+// driver-level deadline for that phase.
+type Timeouts struct {
+	Setup    time.Duration
+	Teardown time.Duration
+}
+
+// ParseTimeouts parses setup and teardown duration strings into a
+// Timeouts value. Empty strings are treated as zero (no deadline).
+func ParseTimeouts(setup, teardown string) (Timeouts, error) {
+	var t Timeouts
+	if setup != "" {
+		d, err := time.ParseDuration(setup)
+		if err != nil {
+			return t, fmt.Errorf("parsing setup timeout %q: %w", setup, err)
+		}
+		t.Setup = d
+	}
+	if teardown != "" {
+		d, err := time.ParseDuration(teardown)
+		if err != nil {
+			return t, fmt.Errorf("parsing teardown timeout %q: %w", teardown, err)
+		}
+		t.Teardown = d
+	}
+	return t, nil
+}
+
+// SetupContext returns ctx with the setup timeout applied. If Setup is
+// zero, the original context is returned unchanged.
+func (t Timeouts) SetupContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	if t.Setup > 0 {
+		return context.WithTimeout(ctx, t.Setup)
+	}
+	return ctx, func() {}
+}
+
+// TeardownContext returns a context for teardown. If Teardown is set,
+// it creates a fresh context from context.Background() with that
+// deadline — detached from the caller's potentially expired context.
+// If Teardown is zero, it detaches from the parent's cancellation
+// without adding a new deadline.
+func (t Timeouts) TeardownContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	if t.Teardown > 0 {
+		return context.WithTimeout(context.Background(), t.Teardown)
+	}
+	return context.WithoutCancel(ctx), func() {}
 }
 
 type RunResult struct {

--- a/internal/drivers/ec2/config.go
+++ b/internal/drivers/ec2/config.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/chainguard-dev/terraform-provider-imagetest/internal/drivers"
 )
 
 // Config configures the EC2 driver.
@@ -36,6 +37,7 @@ type Config struct {
 
 	// Operational
 	SkipTeardown bool
+	Timeouts     drivers.Timeouts
 
 	// Use existing instance (skips resource creation)
 	ExistingInstance *ExistingInstance

--- a/internal/drivers/ec2/driver.go
+++ b/internal/drivers/ec2/driver.go
@@ -235,6 +235,8 @@ func (d *driver) Teardown(ctx context.Context) error {
 	}
 
 	log.Info("starting teardown")
+	ctx, cancel := d.cfg.Timeouts.TeardownContext(ctx)
+	defer cancel()
 	return d.stack.Teardown(ctx)
 }
 

--- a/internal/drivers/eks_with_eksctl/driver.go
+++ b/internal/drivers/eks_with_eksctl/driver.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 	"text/template"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
@@ -35,14 +36,14 @@ const (
 )
 
 type driver struct {
-	name       string
-	nodeAMI    string
-	nodeType   string
-	nodeCount  int
-	storage    *StorageOptions
-	awsProfile string
-	tags       map[string]string
-	timeout    string // Go duration format for eksctl --timeout flag
+	name            string
+	nodeAMI         string
+	nodeType        string
+	nodeCount       int
+	storage         *StorageOptions
+	awsProfile      string
+	tags            map[string]string
+	timeouts drivers.Timeouts
 
 	region           string
 	clusterName      string
@@ -69,7 +70,7 @@ type Options struct {
 	PodIdentityAssociations []*PodIdentityAssociationOptions
 	AWSProfile              string
 	Tags                    map[string]string
-	Timeout                 string // Go duration format (e.g., "30m", "1h") for eksctl --timeout flag
+	Timeouts                drivers.Timeouts
 	Registries              map[string]*RegistryConfig
 }
 
@@ -105,20 +106,22 @@ type podIdentityAssociation struct {
 // NewDriver creates a new EKS driver instance that uses eksctl to provision and manage
 // an Amazon EKS cluster for running tests.
 //
-// When opts.Timeout is set, it overrides eksctl's default timeout of 25 minutes for all
-// long-running operations (cluster creation, node group operations, etc.).
+// When opts.SetupTimeout is set, Setup() enforces it as a context deadline and
+// passes it to eksctl --timeout for individual CloudFormation operations. If
+// unset, eksctl uses its default of 25 minutes and Setup() is bounded only by
+// the caller's context.
 func NewDriver(name string, opts Options) (drivers.Tester, error) {
 	k := &driver{
-		name:       name,
-		region:     opts.Region,
-		nodeAMI:    opts.NodeAMI,
-		nodeType:   opts.NodeType,
-		nodeCount:  opts.NodeCount,
-		namespace:  opts.Namespace,
-		storage:    opts.Storage,
+		name:     name,
+		region:   opts.Region,
+		nodeAMI:  opts.NodeAMI,
+		nodeType: opts.NodeType,
+		nodeCount: opts.NodeCount,
+		namespace: opts.Namespace,
+		storage:   opts.Storage,
 		awsProfile: opts.AWSProfile,
 		tags:       opts.Tags,
-		timeout:    opts.Timeout,
+		timeouts:   opts.Timeouts,
 	}
 	if k.region == "" {
 		k.region = regionDefault
@@ -162,9 +165,9 @@ func (k *driver) eksctl(ctx context.Context, args ...string) error {
 		"--verbose", "4", // Set maximum verbosity level
 	}...)
 
-	// Add timeout flag if configured (empty string = use eksctl default of 25m)
-	if k.timeout != "" {
-		args = append(args, "--timeout", k.timeout)
+	// Add timeout flag if configured (zero = use eksctl default of 25m)
+	if k.timeouts.Setup > 0 {
+		args = append(args, "--timeout", k.timeouts.Setup.String())
 	}
 
 	cmd := exec.CommandContext(ctx, "eksctl", args...)
@@ -428,6 +431,19 @@ func (k *driver) deletePodIdentityAssociation(ctx context.Context) error {
 }
 
 func (k *driver) Setup(ctx context.Context) error {
+	if k.timeouts.Setup > 0 {
+		// Validate: the setup timeout must leave room for test execution
+		// within the caller's deadline.
+		if deadline, ok := ctx.Deadline(); ok {
+			if remaining := time.Until(deadline); k.timeouts.Setup >= remaining {
+				return fmt.Errorf("setup timeout (%s) >= remaining resource timeout (%s); the resource timeout must leave room for test execution after setup completes", k.timeouts.Setup, remaining.Truncate(time.Second))
+			}
+		}
+	}
+
+	ctx, cancel := k.timeouts.SetupContext(ctx)
+	defer cancel()
+
 	log := clog.FromContext(ctx)
 	span := trace.SpanFromContext(ctx)
 
@@ -538,6 +554,9 @@ func (k *driver) Setup(ctx context.Context) error {
 }
 
 func (k *driver) Teardown(ctx context.Context) error {
+	ctx, cancel := k.timeouts.TeardownContext(ctx)
+	defer cancel()
+
 	if v := os.Getenv("IMAGETEST_EKS_SKIP_TEARDOWN"); v == "true" {
 		clog.FromContext(ctx).Info("Skipping EKS teardown due to IMAGETEST_EKS_SKIP_TEARDOWN=true")
 		return nil

--- a/internal/drivers/k3s_in_docker/driver.go
+++ b/internal/drivers/k3s_in_docker/driver.go
@@ -44,10 +44,11 @@ type driver struct {
 
 	kubeconfigWritePath string // When set, the generated kubeconfig will be written to this path on the host
 
-	name  string
-	stack *harness.Stack
-	kcli  kubernetes.Interface
-	kcfg  *rest.Config
+	name     string
+	stack    *harness.Stack
+	kcli     kubernetes.Interface
+	kcfg     *rest.Config
+	timeouts drivers.Timeouts
 }
 
 type K3sRegistryConfig struct {
@@ -326,6 +327,8 @@ configs:
 }
 
 func (k *driver) Teardown(ctx context.Context) error {
+	ctx, cancel := k.timeouts.TeardownContext(ctx)
+	defer cancel()
 	return k.stack.Teardown(ctx)
 }
 

--- a/internal/drivers/k3s_in_docker/driver.go
+++ b/internal/drivers/k3s_in_docker/driver.go
@@ -15,6 +15,7 @@ import (
 	"github.com/chainguard-dev/terraform-provider-imagetest/internal/drivers"
 	"github.com/chainguard-dev/terraform-provider-imagetest/internal/drivers/pod"
 	"github.com/chainguard-dev/terraform-provider-imagetest/internal/harness"
+	"github.com/chainguard-dev/terraform-provider-imagetest/internal/retry"
 	"github.com/docker/docker/api/types/mount"
 	"github.com/docker/go-connections/nat"
 	"github.com/google/go-containerregistry/pkg/name"
@@ -93,6 +94,36 @@ func NewDriver(n string, opts ...DriverOpts) (drivers.Tester, error) {
 }
 
 func (k *driver) Setup(ctx context.Context) error {
+	result := retry.Do(ctx, retry.Config{Attempts: 3, Delay: 5 * time.Second}, func(ctx context.Context, attempt int) error {
+		// Each attempt gets a fresh stack and a scoped timeout
+		k.stack = harness.NewStack()
+
+		timeout := k.timeouts.Setup
+		if timeout == 0 {
+			timeout = 5 * time.Minute
+		}
+		setupCtx, cancel := context.WithTimeout(ctx, timeout)
+		err := k.setup(setupCtx)
+		cancel()
+
+		if err != nil {
+			// Teardown uses the parent context — don't let a setup timeout prevent cleanup
+			if terr := k.stack.Teardown(ctx); terr != nil {
+				clog.WarnContext(ctx, "failed to teardown after setup failure", "error", terr)
+			}
+			return err
+		}
+
+		return nil
+	})
+
+	if result.LastError != nil {
+		return fmt.Errorf("k3s setup failed after %d attempts: %w", result.Attempts, result.LastError)
+	}
+	return nil
+}
+
+func (k *driver) setup(ctx context.Context) error {
 	cli, err := docker.New()
 	if err != nil {
 		return fmt.Errorf("creating docker client: %w", err)

--- a/internal/drivers/k3s_in_docker/opts.go
+++ b/internal/drivers/k3s_in_docker/opts.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"maps"
 
+	"github.com/chainguard-dev/terraform-provider-imagetest/internal/drivers"
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
 )
@@ -143,6 +144,13 @@ func WithSandboxEnvs(envs map[string]string) DriverOpts {
 			d.SandboxEnvs = make(map[string]string)
 		}
 		maps.Copy(d.SandboxEnvs, envs)
+		return nil
+	}
+}
+
+func WithTimeouts(t drivers.Timeouts) DriverOpts {
+	return func(k *driver) error {
+		k.timeouts = t
 		return nil
 	}
 }

--- a/internal/provider/drivers.go
+++ b/internal/provider/drivers.go
@@ -56,6 +56,7 @@ type AKSDriverResourceModel struct {
 	SubscriptionID              types.String                                  `tfsdk:"subscription_id"`
 	KubernetesVersion           types.String                                  `tfsdk:"kubernetes_version"`
 	Tags                        map[string]string                             `tfsdk:"tags"`
+	Timeouts                    *DriverTimeoutsResourceModel                  `tfsdk:"timeouts"`
 	PodIdentityAssociations     []*AKSPodIdentityAssociationResourceModel     `tfsdk:"pod_identity_associations"`
 	ClusterIdentityAssociations []*AKSClusterIdentityAssociationResourceModel `tfsdk:"cluster_identity_associations"`
 	AttachedACRs                []*AKSAttachedACR                             `tfsdk:"attached_acrs"`
@@ -92,6 +93,7 @@ type K3sInDockerDriverResourceModel struct {
 	Registries    map[string]*K3sInDockerDriverRegistriesResourceModel `tfsdk:"registries"`
 	Snapshotter   types.String                                         `tfsdk:"snapshotter"`
 	Hooks         *K3sInDockerDriverHooksModel                         `tfsdk:"hooks"`
+	Timeouts      *DriverTimeoutsResourceModel                         `tfsdk:"timeouts"`
 }
 
 type K3sInDockerDriverRegistriesResourceModel struct {
@@ -107,8 +109,9 @@ type K3sInDockerDriverHooksModel struct {
 }
 
 type DockerInDockerDriverResourceModel struct {
-	Image   types.String `tfsdk:"image"`
-	Mirrors []string     `tfsdk:"mirrors"`
+	Image    types.String                `tfsdk:"image"`
+	Mirrors  []string                    `tfsdk:"mirrors"`
+	Timeouts *DriverTimeoutsResourceModel `tfsdk:"timeouts"`
 }
 
 type EKSWithEksctlDriverResourceModel struct {
@@ -116,10 +119,36 @@ type EKSWithEksctlDriverResourceModel struct {
 	NodeAMI                 types.String                                         `tfsdk:"node_ami"`
 	NodeType                types.String                                         `tfsdk:"node_type"`
 	NodeCount               types.Int64                                          `tfsdk:"node_count"`
+	Timeouts                *DriverTimeoutsResourceModel                  `tfsdk:"timeouts"`
 	Storage                 *EKSWithEksctlStorageResourceModel                   `tfsdk:"storage"`
 	PodIdentityAssociations []*EKSWithEksctlPodIdentityAssociationResourceModule `tfsdk:"pod_identity_associations"`
 	AWSProfile              types.String                                         `tfsdk:"aws_profile"`
 	Tags                    map[string]string                                    `tfsdk:"tags"`
+}
+
+// DriverTimeoutsResourceModel is the shared schema model for driver
+// lifecycle timeouts. All drivers that support the timeouts block
+// should embed this type.
+type DriverTimeoutsResourceModel struct {
+	Setup    types.String `tfsdk:"setup"`
+	Teardown types.String `tfsdk:"teardown"`
+}
+
+func driverTimeoutsSchema() schema.SingleNestedAttribute {
+	return schema.SingleNestedAttribute{
+		Description: "Timeout configuration for driver lifecycle phases.",
+		Optional:    true,
+		Attributes: map[string]schema.Attribute{
+			"setup": schema.StringAttribute{
+				Description: "Maximum time for driver setup (e.g., cluster creation). If unset, setup is bounded only by the resource-level timeout.",
+				Optional:    true,
+			},
+			"teardown": schema.StringAttribute{
+				Description: "Maximum time for driver teardown (e.g., cluster deletion). If unset, the driver uses a built-in default.",
+				Optional:    true,
+			},
+		},
+	}
 }
 
 type EKSWithEksctlStorageResourceModel struct {
@@ -152,11 +181,19 @@ type EC2DriverResourceModel struct {
 	GPUs                types.String                      `tfsdk:"gpus"`
 	MountAllGPUs        types.Bool                        `tfsdk:"mount_all_gpus"` // Deprecated: use gpus = "all" instead
 	ExistingInstance    *EC2ExistingInstanceResourceModel `tfsdk:"existing_instance"`
+	Timeouts            *DriverTimeoutsResourceModel      `tfsdk:"timeouts"`
 }
 
 type EC2ExistingInstanceResourceModel struct {
 	IP     types.String `tfsdk:"ip"`
 	SSHKey types.String `tfsdk:"ssh_key"`
+}
+
+func parseTimeoutsModel(m *DriverTimeoutsResourceModel) (drivers.Timeouts, error) {
+	if m == nil {
+		return drivers.Timeouts{}, nil
+	}
+	return drivers.ParseTimeouts(m.Setup.ValueString(), m.Teardown.ValueString())
 }
 
 // LoadDriver creates and configures a driver instance based on the specified driver type.
@@ -385,6 +422,12 @@ kubectl rollout status deployment/coredns -n kube-system --timeout=60s
 			opts = append(opts, k3sindocker.WithPostStartHook(coreDNSHook))
 		}
 
+		timeouts, err := parseTimeoutsModel(cfg.Timeouts)
+		if err != nil {
+			return nil, fmt.Errorf("k3s_in_docker: %w", err)
+		}
+		opts = append(opts, k3sindocker.WithTimeouts(timeouts))
+
 		return k3sindocker.NewDriver(id, opts...)
 
 	case DriverDockerInDocker:
@@ -422,6 +465,12 @@ kubectl rollout status deployment/coredns -n kube-system --timeout=60s
 				),
 			)
 		}
+
+		timeouts, err := parseTimeoutsModel(cfg.Timeouts)
+		if err != nil {
+			return nil, fmt.Errorf("docker_in_docker: %w", err)
+		}
+		opts = append(opts, dockerindocker.WithTimeouts(timeouts))
 
 		return dockerindocker.NewDriver(id, opts...)
 
@@ -473,6 +522,11 @@ kubectl rollout status deployment/coredns -n kube-system --timeout=60s
 			},
 		}
 
+		timeouts, err := parseTimeoutsModel(cfg.Timeouts)
+		if err != nil {
+			return nil, fmt.Errorf("eks_with_eksctl: %w", err)
+		}
+
 		return ekswitheksctl.NewDriver(id, ekswitheksctl.Options{
 			Region:                  cfg.Region.ValueString(),
 			NodeAMI:                 cfg.NodeAMI.ValueString(),
@@ -482,7 +536,7 @@ kubectl rollout status deployment/coredns -n kube-system --timeout=60s
 			Storage:                 storageOpts,
 			AWSProfile:              cfg.AWSProfile.ValueString(),
 			Tags:                    cfg.Tags,
-			Timeout:                 timeout,
+			Timeouts:                timeouts,
 			Registries:              registries,
 		})
 
@@ -558,6 +612,12 @@ kubectl rollout status deployment/coredns -n kube-system --timeout=60s
 		if driverCfg.UserData != "" {
 			driverCfg.UserData = base64.StdEncoding.EncodeToString([]byte(driverCfg.UserData))
 		}
+
+		timeouts, err := parseTimeoutsModel(driversCfg.EC2.Timeouts)
+		if err != nil {
+			return nil, fmt.Errorf("ec2: %w", err)
+		}
+		driverCfg.Timeouts = timeouts
 
 		// Init AWS config and clients
 		awsCfg, err := config.LoadDefaultConfig(ctx)
@@ -712,6 +772,7 @@ func DriverResourceSchema(ctx context.Context) schema.SingleNestedAttribute {
 							},
 						},
 					},
+					"timeouts": driverTimeoutsSchema(),
 				},
 			},
 			"k3s_in_docker": schema.SingleNestedAttribute{
@@ -770,6 +831,7 @@ func DriverResourceSchema(ctx context.Context) schema.SingleNestedAttribute {
 							},
 						},
 					},
+					"timeouts": driverTimeoutsSchema(),
 				},
 			},
 			"docker_in_docker": schema.SingleNestedAttribute{
@@ -784,6 +846,7 @@ func DriverResourceSchema(ctx context.Context) schema.SingleNestedAttribute {
 						ElementType: types.StringType,
 						Optional:    true,
 					},
+					"timeouts": driverTimeoutsSchema(),
 				},
 			},
 			"eks_with_eksctl": schema.SingleNestedAttribute{
@@ -806,6 +869,7 @@ func DriverResourceSchema(ctx context.Context) schema.SingleNestedAttribute {
 						Description: "The instance type to use for the eks_with_eksctl driver (default is m5.large)",
 						Optional:    true,
 					},
+					"timeouts": driverTimeoutsSchema(),
 					"storage": schema.SingleNestedAttribute{
 						Description: "Storage configuration for the eks_with_eksctl driver",
 						Optional:    true,
@@ -947,6 +1011,7 @@ var driverResourceSchemaEC2 = schema.SingleNestedAttribute{
 				},
 			},
 		},
+		"timeouts": driverTimeoutsSchema(),
 	},
 }
 

--- a/internal/provider/tests_resource.go
+++ b/internal/provider/tests_resource.go
@@ -518,12 +518,21 @@ func (t *TestsResource) doAttempt(ctx context.Context, data *TestsResourceModel,
 	}
 
 	defer func() {
-		ctx, teardownSpan := tracer.Start(ctx, "imagetest.teardown",
+		// Detach teardown from the resource-level deadline. By this
+		// point the deadline may already be expired, but drivers still
+		// need a live context to clean up resources (delete clusters,
+		// remove containers/networks, etc.). Drivers that need their
+		// own deadline (EKS, AKS) set one internally.
+		teardownCtx := clog.WithLogger(
+			trace.ContextWithSpan(context.Background(), trace.SpanFromContext(ctx)),
+			clog.FromContext(ctx),
+		)
+		teardownCtx, teardownSpan := tracer.Start(teardownCtx, "imagetest.teardown",
 			trace.WithAttributes(
 				attribute.String(o11y.AttrDriver, string(data.Driver)),
 			),
 		)
-		if d := t.maybeTeardown(ctx, dr, ds.HasError()); d != nil {
+		if d := t.maybeTeardown(teardownCtx, dr, ds.HasError()); d != nil {
 			teardownSpan.RecordError(fmt.Errorf("%s", d.Detail()))
 			teardownSpan.SetStatus(codes.Error, d.Detail())
 			ds = append(ds, d)


### PR DESCRIPTION
right now the k3s `Setup()` just inherits the callers context timeout (30m 😱). there's no need to wait 30m, if the health check isn't popped in 2m then we should know something is wrong and we should try retrying.