### PR TITLE
fix(release): use an Immutable release-friendly pattern

### DIFF
--- a/.github/chainguard/release.sts.yaml
+++ b/.github/chainguard/release.sts.yaml
@@ -1,0 +1,8 @@
+issuer: https://token.actions.githubusercontent.com
+subject: repo:chainguard-dev/terraform-provider-imagetest:ref:refs/heads/main
+claim_pattern:
+  job_workflow_ref: chainguard-dev/terraform-provider-imagetest/.github/workflows/release.yml@refs/heads/main
+
+permissions:
+  contents: write
+  packages: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,23 +1,23 @@
-name: release
+name: Release
+
 on:
-  push:
-    tags:
-      - "v*"
+  schedule:
+    - cron: "0 0 * * 1" # every Monday at 00:00 UTC
+  workflow_dispatch:
 
 permissions: {}
 
 jobs:
-  goreleaser:
+  release:
+    name: Release
     permissions:
-      contents: write # To publish the release.
-      id-token: write # To federate for the GPG key.
-      packages: write # To publish the entrypoint image
+      id-token: write # For OctoSTS and GCP WIF.
 
     runs-on: ubuntu-latest
 
     steps:
       - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
+        uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176 # v2.17.0
         with:
           egress-policy: audit
           allowed-endpoints: >
@@ -46,54 +46,110 @@ jobs:
             uploads.github.com:443
             _pgpkey-http._tcp.keys.openpgp.org:443
             metadata.google.internal:443
+            octo-sts.dev:443
+
+      - uses: octo-sts/action@f603d3be9d8dd9871a265776e625a27b00effe05 # v1.1.1
+        id: octo-sts
+        with:
+          scope: ${{ github.repository }}
+          identity: release
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
-      - run: git fetch --prune --unshallow
+      - name: Check if any changes since last release
+        id: check
+        env:
+          GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
+        run: |
+          git fetch --tags
+          TAG=$(git tag --points-at HEAD)
+          if [ -z "$TAG" ]; then
+            echo "No tag points at HEAD, so we need a new tag and then a new release."
+            echo "need_release=yes" >> "$GITHUB_OUTPUT"
+          else
+            RELEASE=$(gh release view "$TAG" --json tagName --jq '.tagName' || echo "none")
+            if [ "$RELEASE" == "$TAG" ]; then
+              echo "A release exists for tag $TAG, which has the latest changes, so no need for a new tag or release."
+              echo "need_release=no" >> "$GITHUB_OUTPUT"
+            else
+              echo "Tag $TAG exists, but no release is associated. Need a new release."
+              echo "need_release=yes" >> "$GITHUB_OUTPUT"
+              echo "existing_tag=$TAG" >> "$GITHUB_OUTPUT"
+            fi
+          fi
+
+      - name: Bump version and push tag
+        id: create_tag
+        uses: mathieudutour/github-tag-action@a22cf08638b34d5badda920f9daf6e72c477b07b # v6.2
+        if: steps.check.outputs.need_release == 'yes' && steps.check.outputs.existing_tag == ''
+        with:
+          github_token: ${{ steps.octo-sts.outputs.token }}
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        if: steps.check.outputs.need_release == 'yes'
+        with:
+          ref: ${{ steps.check.outputs.existing_tag || steps.create_tag.outputs.new_tag }}
+          fetch-depth: 0
+          persist-credentials: false
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        if: steps.check.outputs.need_release == 'yes'
         with:
           go-version-file: "go.mod"
           check-latest: true
           cache: false
 
       - uses: step-security/setup-ko@3b4d97844e4277c74a9d77ac00052d8ce96580d3 # v0.9.0
+        if: steps.check.outputs.need_release == 'yes'
 
       - id: entrypoint-build
+        if: steps.check.outputs.need_release == 'yes'
+        env:
+          GITHUB_TOKEN: ${{ steps.octo-sts.outputs.token }}
         run: |
           ref=$(ko build --base-import-paths ./cmd/entrypoint)
-          echo "entrypoint_ref=${ref}" >> $GITHUB_OUTPUT
+          echo "entrypoint_ref=${ref}" >> "$GITHUB_OUTPUT"
 
       # This is provisioned here: https://github.com/chainguard-dev/secrets/blob/main/terraform-provider-imagetest.tf
       - uses: step-security/google-github-auth@57c51210cb4d85d8a5d39dc4c576c79bd693f914 # v3.0.1
+        if: steps.check.outputs.need_release == 'yes'
         id: auth
         with:
           workload_identity_provider: "projects/12758742386/locations/global/workloadIdentityPools/github-pool/providers/github-provider"
           service_account: "terraform-provider-imagetest@chainguard-github-secrets.iam.gserviceaccount.com"
 
       - uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
+        if: steps.check.outputs.need_release == 'yes'
         with:
           project_id: "chainguard-github-secrets"
 
       - uses: google-github-actions/get-secretmanager-secrets@bc9c54b29fdffb8a47776820a7d26e77b379d262 # v3.0.0
+        if: steps.check.outputs.need_release == 'yes'
         id: secrets
         with:
           secrets: |-
             token:chainguard-github-secrets/terraform-provider-imagetest-signing-key
 
       - id: import_gpg
+        if: steps.check.outputs.need_release == 'yes'
         uses: step-security/ghaction-import-gpg@69c854a83c7f79463f8bdf46772ab09826c560cd # v6.3.1
         with:
           gpg_private_key: ${{ steps.secrets.outputs.token }}
 
-      - run: |
-          gpg --keyserver keys.openpgp.org --send-keys ${{ steps.import_gpg.outputs.fingerprint }}
+      - if: steps.check.outputs.need_release == 'yes'
+        env:
+          GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
+        run: |
+          gpg --keyserver keys.openpgp.org --send-keys "$GPG_FINGERPRINT"
 
       - uses: goreleaser/goreleaser-action@ec59f474b9834571250b370d4735c50f8e2d1e29 # v7.0.0
+        if: steps.check.outputs.need_release == 'yes'
         with:
           version: latest
           args: release --clean
         env:
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.octo-sts.outputs.token }}
           IMAGETEST_ENTRYPOINT_REF: ${{ steps.entrypoint-build.outputs.entrypoint_ref }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,5 +1,9 @@
 version: 2
 
+before:
+  hooks:
+    - go mod download
+
 builds:
   - env:
       - CGO_ENABLED=0
@@ -41,7 +45,13 @@ signs:
       - "--detach-sign"
       - "${artifact}"
 
+snapshot:
+  name_template: "{{ .Tag }}-next"
+
 release:
+  draft: false
+  prerelease: auto
+  name_template: "Release {{ .Tag }}"
   extra_files:
     - glob: "terraform-registry-manifest.json"
       name_template: "{{ .ProjectName }}_{{ .Version }}_manifest.json"


### PR DESCRIPTION
We need to make our release Workflows compatible with Immutable Releases. This PR moves to the pattern we use in Apko/Melange that handles tag creation automatically and uploads assets before the Release is fully published.