### PR TITLE
fix(release): use default token for entrypoints

### DIFF
--- a/.github/chainguard/release.sts.yaml
+++ b/.github/chainguard/release.sts.yaml
@@ -5,4 +5,3 @@ claim_pattern:
 
 permissions:
   contents: write
-  packages: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ jobs:
     name: Release
     permissions:
       id-token: write # For OctoSTS and GCP WIF.
+      packages: write # To publish the entrypoint image.
 
     runs-on: ubuntu-latest
 
@@ -106,8 +107,6 @@ jobs:
 
       - id: entrypoint-build
         if: steps.check.outputs.need_release == 'yes'
-        env:
-          GITHUB_TOKEN: ${{ steps.octo-sts.outputs.token }}
         run: |
           ref=$(ko build --base-import-paths ./cmd/entrypoint)
           echo "entrypoint_ref=${ref}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
These are scoped to the org-level so octo-sts doesn't have the correct scope for this particular step.