### PR TITLE
DRAFT: feat: add gke driver

### DIFF
--- a/cmd/entrypoint/kodata/entrypoint-wrapper.sh
+++ b/cmd/entrypoint/kodata/entrypoint-wrapper.sh
@@ -17,7 +17,7 @@ error() {
 usage() {
   error "Usage: $0 <test-script-path>"
   error "Environment variables:"
-  error "  IMAGETEST_DRIVER: Type of test environment (docker_in_docker, k3s_in_docker, eks_with_eksctl, ec2)"
+  error "  IMAGETEST_DRIVER: Type of test environment (docker_in_docker, k3s_in_docker, eks_with_eksctl, aks, gke, ec2)"
   exit 1
 }
 
@@ -40,6 +40,35 @@ validate_cmd() {
 # Arguments:
 #   $1: Path to the test script (already validated)
 init_aks() {
+  cmd="$1"
+
+  if which kubectl; then
+    # Set a default context to better mimic a local setup
+    kubectl config set-context default --cluster=kubernetes --user=default --namespace=default
+    kubectl config use-context default
+
+    # Ensure required environment variables are set
+    if [ -z "${POD_NAME-}" ] || [ -z "${POD_NAMESPACE-}" ]; then
+      error "POD_NAME and POD_NAMESPACE environment variables must be set"
+      exit 1
+    fi
+
+    info "Waiting for pod ${POD_NAME} to be ready..."
+    if ! kubectl wait --for=condition=Ready=true pod/"${POD_NAME}" -n "${POD_NAMESPACE}" --timeout=60s; then
+      error "Pod ${POD_NAME} failed to become ready"
+      exit 1
+    fi
+  else
+    echo "kubectl missing, skipping..."
+  fi
+
+  eval "$cmd"
+}
+
+# Initialize and manage a GKE environment.
+# Arguments:
+#   $1: Path to the test script (already validated)
+init_gke() {
   cmd="$1"
 
   if which kubectl; then
@@ -170,6 +199,9 @@ validate_cmd "$cmd"
 case "$IMAGETEST_DRIVER" in
 aks)
   init_aks "$cmd"
+  ;;
+gke)
+  init_gke "$cmd"
   ;;
 docker_in_docker)
   init_docker_in_docker "$cmd"

--- a/docs/gke-driver-design.md
+++ b/docs/gke-driver-design.md
@@ -1,0 +1,1168 @@
+# GKE Driver Design Document
+
+## Overview
+
+This document outlines the design and implementation plan for adding a Google Kubernetes Engine (GKE) driver to terraform-provider-imagetest. The GKE driver will enable running container image tests on GKE clusters, following the same patterns established by the existing AKS and EKS drivers.
+
+## Motivation
+
+The terraform-provider-imagetest currently supports testing on AKS and EKS, but lacks GCP/GKE support. Adding a GKE driver provides:
+
+- **Multi-cloud parity**: Support all three major cloud Kubernetes platforms (AWS EKS, Azure AKS, GCP GKE)
+- **GCP-specific testing**: Enable testing of GCP-specific features (Workload Identity, GKE Autopilot, custom GKE node images)
+- **Customer demand**: GCP users need to test images in their target deployment environment
+
+## Architecture
+
+### High-Level Design
+
+The GKE driver follows the same architectural pattern as the AKS driver:
+
+1. **Native SDK approach**: Use Google Cloud Go SDK directly (not `gcloud` CLI)
+2. **Stack-based cleanup**: Use `harness.Stack` for reliable LIFO resource teardown
+3. **Shared pod execution**: Reuse `pod.Run()` from `internal/drivers/pod/`
+4. **Single-phase provisioning**: Create cluster with node pool in one API call
+5. **Ambient authentication**: Use Application Default Credentials (ADC)
+
+### Comparison with Existing Drivers
+
+| Aspect | EKS | AKS | **GKE** (proposed) |
+|--------|-----|-----|-------------------|
+| Provisioning | eksctl CLI | Azure SDK | **Google Cloud SDK** |
+| Cleanup | Manual LIFO | Stack pattern | **Stack pattern** |
+| Node creation | 2-phase (cluster → nodegroup) | Single-phase | **Single-phase** |
+| Kubeconfig | eksctl command | API call | **Extract from cluster** |
+| Location model | Region only | Location (region) | **Region OR zone** |
+| Tags | `map[string]string` | `map[string]*string` | **`map[string]string`** |
+| Workload Identity | Pod Identity addon | UAI + Federated Creds | **GSA + IAM binding** |
+| Registry integration | Static auth | ACR attachment | **GAR attachment** |
+
+**Decision**: Follow the **AKS pattern** (native SDK + Stack) rather than EKS (CLI-based).
+
+**Rationale**:
+- GKE SDK is comprehensive and well-maintained
+- Stack-based cleanup is more robust for partial failures
+- Single-phase cluster creation is simpler
+- Aligns with how GCP users interact with GKE (SDK/Terraform, not CLI)
+
+## Implementation
+
+### File Structure
+
+```
+internal/drivers/gke/
+└── driver.go           # ~800-1000 lines (all in one file, like AKS)
+```
+
+Single-file approach maintains consistency with AKS driver.
+
+### Core Types
+
+```go
+package gke
+
+import (
+    container "cloud.google.com/go/container/apiv1"
+    "cloud.google.com/go/container/apiv1/containerpb"
+    "github.com/chainguard-dev/terraform-provider-imagetest/internal/drivers"
+    "github.com/chainguard-dev/terraform-provider-imagetest/internal/harness"
+    "k8s.io/client-go/kubernetes"
+    "k8s.io/client-go/rest"
+)
+
+type driver struct {
+    name  string
+    stack *harness.Stack
+
+    // Configuration
+    projectID         string
+    region            string  // Regional cluster (preferred)
+    zone              string  // Zonal cluster (alternative)
+    clusterName       string
+    nodeCount         int32
+    machineType       string
+    diskSizeGB        int32
+    diskType          string
+    kubernetesVersion string
+    tags              map[string]string
+
+    // Runtime state
+    kubeconfig string
+    kcli       kubernetes.Interface
+    kcfg       *rest.Config
+
+    // GCP SDK clients
+    clusterClient *container.ClusterManagerClient
+
+    // Features
+    workloadIdentityAssociations []*WorkloadIdentityAssociationOptions
+    attachedGARs                 []*AttachedGAR
+    registries                   map[string]*RegistryConfig
+}
+
+type Options struct {
+    ProjectID         string
+    Region            string  // Regional cluster (e.g., "us-central1")
+    Zone              string  // Zonal cluster (e.g., "us-central1-a")
+    ClusterName       string  // Optional, auto-generated if empty
+    NodeCount         int32
+    MachineType       string
+    DiskSizeGB        int32
+    DiskType          string  // "pd-standard", "pd-ssd", "pd-balanced"
+    KubernetesVersion string
+    Tags              map[string]string
+    Timeout           string
+
+    WorkloadIdentityAssociations []*WorkloadIdentityAssociationOptions
+    AttachedGARs                 []*AttachedGAR
+    Registries                   map[string]*RegistryConfig
+}
+
+// Workload Identity: binds GCP Service Account to K8s Service Account
+type WorkloadIdentityAssociationOptions struct {
+    ServiceAccountName string  // K8s SA name
+    Namespace          string  // K8s namespace
+    GSAEmail           string  // GCP service account email
+    IAMRoles           []string // IAM roles to grant (e.g., "roles/storage.objectViewer")
+}
+
+// Artifact Registry attachment
+type AttachedGAR struct {
+    Repository      string  // Format: "projects/PROJECT/locations/LOCATION/repositories/REPO"
+    CreateIfMissing bool
+}
+
+type RegistryConfig struct {
+    Auth *RegistryAuthConfig
+}
+
+type RegistryAuthConfig struct {
+    Username string
+    Password string
+    Auth     string
+}
+```
+
+### Key Methods
+
+```go
+// NewDriver creates a new GKE driver instance
+func NewDriver(name string, opts Options) (drivers.Tester, error)
+
+// Setup creates the GKE cluster and configures access
+func (k *driver) Setup(ctx context.Context) error
+
+// Run executes a test container using the shared pod.Run() function
+func (k *driver) Run(ctx context.Context, ref name.Reference) (*drivers.RunResult, error)
+
+// Teardown destroys all created resources using the stack
+func (k *driver) Teardown(ctx context.Context) error
+
+// Internal methods
+func (k *driver) setupCommonClients(ctx context.Context) error
+func (k *driver) createCluster(ctx context.Context) error
+func (k *driver) deleteCluster(ctx context.Context) error
+func (k *driver) getKubeConfig(ctx context.Context) error
+func (k *driver) createWorkloadIdentity(ctx context.Context) error
+func (k *driver) attachGARs(ctx context.Context) error
+func (k *driver) buildLabels() map[string]string
+```
+
+### Setup Flow
+
+```go
+func (k *driver) Setup(ctx context.Context) error {
+    log := clog.FromContext(ctx)
+    span := trace.SpanFromContext(ctx)
+
+    // 1. Initialize GCP clients (Application Default Credentials)
+    if err := k.setupCommonClients(ctx); err != nil {
+        return err
+    }
+
+    // 2. Determine cluster name (env var or generate)
+    existingCluster := false
+    if n, ok := os.LookupEnv("IMAGETEST_GKE_CLUSTER"); ok {
+        log.Infof("Using cluster name from IMAGETEST_GKE_CLUSTER: %s", n)
+        k.clusterName = n
+        existingCluster = true
+    } else {
+        k.clusterName = "imagetest-" + uuid.New().String()[:8]
+        log.Infof("Using random cluster name: %s", k.clusterName)
+    }
+
+    // 3. Create temp kubeconfig file
+    cfg, err := os.Create(filepath.Join(os.TempDir(), k.clusterName))
+    if err != nil {
+        return fmt.Errorf("creating temp kubeconfig: %w", err)
+    }
+    k.kubeconfig = cfg.Name()
+
+    // 4. Create cluster (or skip if existing)
+    if !existingCluster {
+        if err = k.createCluster(ctx); err != nil {
+            return err
+        }
+        span.AddEvent("gke.cluster.created")
+    }
+
+    // 5. Configure Workload Identity
+    if err = k.createWorkloadIdentity(ctx); err != nil {
+        return err
+    }
+    span.AddEvent("gke.identity.configured")
+
+    // 6. Attach Artifact Registries
+    if err = k.attachGARs(ctx); err != nil {
+        return err
+    }
+    span.AddEvent("gke.gar.attached")
+
+    // 7. Get kubeconfig and create Kubernetes client
+    if err = k.getKubeConfig(ctx); err != nil {
+        return err
+    }
+
+    config, err := clientcmd.BuildConfigFromFlags("", k.kubeconfig)
+    if err != nil {
+        return fmt.Errorf("building kubeconfig: %w", err)
+    }
+    k.kcfg = config
+
+    kcli, err := kubernetes.NewForConfig(config)
+    if err != nil {
+        return fmt.Errorf("creating kubernetes client: %w", err)
+    }
+    k.kcli = kcli
+
+    return nil
+}
+```
+
+### Cluster Creation
+
+```go
+func (k *driver) createCluster(ctx context.Context) error {
+    log := clog.FromContext(ctx)
+
+    // Determine parent (regional or zonal)
+    var parent string
+    if k.region != "" {
+        parent = fmt.Sprintf("projects/%s/locations/%s", k.projectID, k.region)
+        log.Infof("Creating regional cluster in %s", k.region)
+    } else if k.zone != "" {
+        parent = fmt.Sprintf("projects/%s/locations/%s", k.projectID, k.zone)
+        log.Infof("Creating zonal cluster in %s", k.zone)
+    } else {
+        return fmt.Errorf("either region or zone must be specified")
+    }
+
+    // Build cluster request
+    req := &containerpb.CreateClusterRequest{
+        Parent: parent,
+        Cluster: &containerpb.Cluster{
+            Name:             k.clusterName,
+            InitialNodeCount: k.nodeCount,
+            NodeConfig: &containerpb.NodeConfig{
+                MachineType: k.machineType,
+                DiskSizeGb:  k.diskSizeGB,
+                DiskType:    k.diskType,
+                OauthScopes: []string{
+                    "https://www.googleapis.com/auth/cloud-platform",
+                },
+            },
+            WorkloadIdentityConfig: &containerpb.WorkloadIdentityConfig{
+                WorkloadPool: fmt.Sprintf("%s.svc.id.goog", k.projectID),
+            },
+            ResourceLabels: k.buildLabels(),
+        },
+    }
+
+    // Set Kubernetes version if specified
+    if k.kubernetesVersion != "" {
+        req.Cluster.InitialClusterVersion = k.kubernetesVersion
+    }
+
+    log.Info("Creating GKE cluster",
+        "name", k.clusterName,
+        "project", k.projectID,
+        "node_count", k.nodeCount,
+        "machine_type", k.machineType,
+        "disk_size_gb", k.diskSizeGB,
+    )
+
+    // Start cluster creation (async operation)
+    op, err := k.clusterClient.CreateCluster(ctx, req)
+    if err != nil {
+        return fmt.Errorf("failed to initiate GKE cluster creation: %w", err)
+    }
+
+    // Register cleanup IMMEDIATELY
+    if err := k.stack.Add(func(ctx context.Context) error {
+        return k.deleteCluster(ctx)
+    }); err != nil {
+        return err
+    }
+
+    // Wait for operation to complete
+    log.Info("Waiting for GKE cluster provisioning...")
+    for {
+        opResp, err := k.clusterClient.GetOperation(ctx, &containerpb.GetOperationRequest{
+            Name: op.Name,
+        })
+        if err != nil {
+            return fmt.Errorf("failed to check operation status: %w", err)
+        }
+
+        if opResp.Status == containerpb.Operation_DONE {
+            if opResp.Error != nil {
+                return fmt.Errorf("cluster creation failed: %s", opResp.Error.Message)
+            }
+            log.Infof("Created GKE cluster: %s", k.clusterName)
+            return nil
+        }
+
+        time.Sleep(pollFrequency)
+    }
+}
+```
+
+### Kubeconfig Retrieval
+
+Unlike AKS (separate API call) or EKS (CLI command), GKE requires extracting credentials from the cluster object and constructing the kubeconfig:
+
+```go
+func (k *driver) getKubeConfig(ctx context.Context) error {
+    // Get cluster details
+    parent := fmt.Sprintf("projects/%s/locations/%s", k.projectID, k.getLocation())
+    clusterName := fmt.Sprintf("%s/clusters/%s", parent, k.clusterName)
+    
+    cluster, err := k.clusterClient.GetCluster(ctx, &containerpb.GetClusterRequest{
+        Name: clusterName,
+    })
+    if err != nil {
+        return fmt.Errorf("failed to get cluster: %w", err)
+    }
+
+    // Construct kubeconfig
+    kubeconfig := clientcmdapi.Config{
+        APIVersion: "v1",
+        Kind:       "Config",
+        Clusters: map[string]*clientcmdapi.Cluster{
+            k.clusterName: {
+                Server:                   fmt.Sprintf("https://%s", cluster.Endpoint),
+                CertificateAuthorityData: []byte(cluster.MasterAuth.ClusterCaCertificate),
+            },
+        },
+        Contexts: map[string]*clientcmdapi.Context{
+            k.clusterName: {
+                Cluster:  k.clusterName,
+                AuthInfo: k.clusterName,
+            },
+        },
+        CurrentContext: k.clusterName,
+        AuthInfos: map[string]*clientcmdapi.AuthInfo{
+            k.clusterName: {
+                Exec: &clientcmdapi.ExecConfig{
+                    APIVersion: "client.authentication.k8s.io/v1beta1",
+                    Command:    "gke-gcloud-auth-plugin",
+                    InstallHint: "Install gke-gcloud-auth-plugin for kubectl authentication",
+                },
+            },
+        },
+    }
+
+    // Write kubeconfig to file
+    data, err := clientcmd.Write(kubeconfig)
+    if err != nil {
+        return fmt.Errorf("failed to marshal kubeconfig: %w", err)
+    }
+
+    if err := os.WriteFile(k.kubeconfig, data, 0644); err != nil {
+        return fmt.Errorf("failed to write kubeconfig: %w", err)
+    }
+
+    return nil
+}
+
+func (k *driver) getLocation() string {
+    if k.region != "" {
+        return k.region
+    }
+    return k.zone
+}
+```
+
+### Run Implementation
+
+Identical to AKS and EKS:
+
+```go
+func (k *driver) Run(ctx context.Context, ref name.Reference) (*drivers.RunResult, error) {
+    // Build docker config from registries for pod authentication
+    dcfg := &docker.DockerConfig{
+        Auths: make(map[string]docker.DockerAuthConfig, len(k.registries)),
+    }
+    for reg, cfg := range k.registries {
+        if cfg.Auth == nil {
+            continue
+        }
+        dcfg.Auths[reg] = docker.DockerAuthConfig{
+            Username: cfg.Auth.Username,
+            Password: cfg.Auth.Password,
+            Auth:     cfg.Auth.Auth,
+        }
+    }
+
+    // Delegate to shared pod.Run()
+    return pod.Run(ctx, k.kcfg,
+        pod.WithImageRef(ref),
+        pod.WithExtraEnvs(map[string]string{
+            "IMAGETEST_DRIVER": "gke",
+        }),
+        pod.WithRegistryStaticAuth(dcfg),
+    )
+}
+```
+
+### Teardown Implementation
+
+Identical to AKS:
+
+```go
+func (k *driver) Teardown(ctx context.Context) error {
+    log := clog.FromContext(ctx)
+    
+    // Check skip teardown flags
+    if os.Getenv("IMAGETEST_GKE_SKIP_TEARDOWN") == "true" ||
+       os.Getenv("IMAGETEST_SKIP_TEARDOWN") == "true" {
+        log.Info("Skipping GKE teardown")
+        return nil
+    }
+
+    // Skip if using existing cluster
+    if _, ok := os.LookupEnv("IMAGETEST_GKE_CLUSTER"); ok {
+        log.Info("Skipping teardown for existing cluster")
+        return nil
+    }
+
+    log.Info("Initiating resource teardown")
+
+    // Create fresh context with timeout (original may be cancelled)
+    teardownCtx, cancel := context.WithTimeout(context.Background(), k.timeout)
+    defer cancel()
+
+    // Use stack for LIFO cleanup
+    return k.stack.Teardown(teardownCtx)
+}
+```
+
+## Provider Integration
+
+### Constants and Models
+
+In `internal/provider/drivers.go`:
+
+```go
+const (
+    // ...
+    DriverGKE DriverResourceModel = "gke"
+)
+
+type TestsDriversResourceModel struct {
+    // ...
+    GKE *GKEDriverResourceModel `tfsdk:"gke"`
+}
+
+type GKEDriverResourceModel struct {
+    ProjectID         types.String  `tfsdk:"project_id"`
+    Region            types.String  `tfsdk:"region"`
+    Zone              types.String  `tfsdk:"zone"`
+    ClusterName       types.String  `tfsdk:"cluster_name"`
+    NodeCount         types.Int32   `tfsdk:"node_count"`
+    MachineType       types.String  `tfsdk:"machine_type"`
+    DiskSizeGB        types.Int32   `tfsdk:"disk_size_gb"`
+    DiskType          types.String  `tfsdk:"disk_type"`
+    KubernetesVersion types.String  `tfsdk:"kubernetes_version"`
+    Tags              map[string]string `tfsdk:"tags"`
+    
+    WorkloadIdentityAssociations []*GKEWorkloadIdentityAssociationResourceModel `tfsdk:"workload_identity_associations"`
+    AttachedGARs                 []*GKEAttachedGAR `tfsdk:"attached_gars"`
+}
+
+type GKEWorkloadIdentityAssociationResourceModel struct {
+    ServiceAccountName types.String   `tfsdk:"service_account_name"`
+    Namespace          types.String   `tfsdk:"namespace"`
+    GSAEmail           types.String   `tfsdk:"gsa_email"`
+    IAMRoles           []types.String `tfsdk:"iam_roles"`
+}
+
+type GKEAttachedGAR struct {
+    Repository      types.String `tfsdk:"repository"`
+    CreateIfMissing types.Bool   `tfsdk:"create_if_missing"`
+}
+```
+
+### LoadDriver Case
+
+```go
+case DriverGKE:
+    cfg := driversCfg.GKE
+    if cfg == nil {
+        cfg = &GKEDriverResourceModel{}
+    }
+
+    // Build registry auth (same pattern as AKS/EKS)
+    registries := make(map[string]*gke.RegistryConfig)
+    r, err := name.NewRegistry(repo.RegistryStr())
+    if err != nil {
+        return nil, fmt.Errorf("invalid registry name %s: %w", repo.RegistryStr(), err)
+    }
+    a, err := authn.DefaultKeychain.Resolve(r)
+    if err != nil {
+        return nil, fmt.Errorf("resolving keychain for registry %s: %w", r.String(), err)
+    }
+    acfg, err := a.Authorization()
+    if err != nil {
+        return nil, fmt.Errorf("getting authorization for registry %s: %w", r.String(), err)
+    }
+    registries[repo.RegistryStr()] = &gke.RegistryConfig{
+        Auth: &gke.RegistryAuthConfig{
+            Username: acfg.Username,
+            Password: acfg.Password,
+            Auth:     acfg.Auth,
+        },
+    }
+
+    // Convert workload identity associations
+    workloadIdentityAssociations := []*gke.WorkloadIdentityAssociationOptions{}
+    if cfg.WorkloadIdentityAssociations != nil {
+        for _, v := range cfg.WorkloadIdentityAssociations {
+            association := &gke.WorkloadIdentityAssociationOptions{
+                ServiceAccountName: v.ServiceAccountName.ValueString(),
+                Namespace:          v.Namespace.ValueString(),
+                GSAEmail:           v.GSAEmail.ValueString(),
+            }
+            for _, role := range v.IAMRoles {
+                association.IAMRoles = append(association.IAMRoles, role.ValueString())
+            }
+            workloadIdentityAssociations = append(workloadIdentityAssociations, association)
+        }
+    }
+
+    // Convert attached GARs
+    attachedGARs := []*gke.AttachedGAR{}
+    if cfg.AttachedGARs != nil {
+        for _, v := range cfg.AttachedGARs {
+            attachedGARs = append(attachedGARs, &gke.AttachedGAR{
+                Repository:      v.Repository.ValueString(),
+                CreateIfMissing: v.CreateIfMissing.ValueBool(),
+            })
+        }
+    }
+
+    return gke.NewDriver(id, gke.Options{
+        ProjectID:                    cfg.ProjectID.ValueString(),
+        Region:                       cfg.Region.ValueString(),
+        Zone:                         cfg.Zone.ValueString(),
+        ClusterName:                  cfg.ClusterName.ValueString(),
+        NodeCount:                    cfg.NodeCount.ValueInt32(),
+        MachineType:                  cfg.MachineType.ValueString(),
+        DiskSizeGB:                   cfg.DiskSizeGB.ValueInt32(),
+        DiskType:                     cfg.DiskType.ValueString(),
+        KubernetesVersion:            cfg.KubernetesVersion.ValueString(),
+        Tags:                         cfg.Tags,
+        Timeout:                      timeout,
+        Registries:                   registries,
+        WorkloadIdentityAssociations: workloadIdentityAssociations,
+        AttachedGARs:                 attachedGARs,
+    })
+```
+
+### Terraform Schema
+
+```go
+"gke": schema.SingleNestedAttribute{
+    Description: "The GKE driver",
+    Optional:    true,
+    Attributes: map[string]schema.Attribute{
+        "project_id": schema.StringAttribute{
+            Description: "The GCP project ID. Defaults to GOOGLE_PROJECT_ID environment variable.",
+            Optional:    true,
+        },
+        "region": schema.StringAttribute{
+            Description: "The GCP region for a regional cluster (e.g., 'us-central1'). Mutually exclusive with zone.",
+            Optional:    true,
+        },
+        "zone": schema.StringAttribute{
+            Description: "The GCP zone for a zonal cluster (e.g., 'us-central1-a'). Mutually exclusive with region.",
+            Optional:    true,
+        },
+        "cluster_name": schema.StringAttribute{
+            Description: "The GKE cluster name. Auto-generated if not specified.",
+            Optional:    true,
+        },
+        "node_count": schema.Int32Attribute{
+            Description: "The number of nodes (default: 1)",
+            Optional:    true,
+        },
+        "machine_type": schema.StringAttribute{
+            Description: "The GCE machine type (default: 'e2-standard-4')",
+            Optional:    true,
+        },
+        "disk_size_gb": schema.Int32Attribute{
+            Description: "Boot disk size in GB (default: 100)",
+            Optional:    true,
+        },
+        "disk_type": schema.StringAttribute{
+            Description: "Boot disk type: 'pd-standard', 'pd-ssd', or 'pd-balanced' (default: 'pd-standard')",
+            Optional:    true,
+        },
+        "kubernetes_version": schema.StringAttribute{
+            Description: "Kubernetes version. Uses GKE default if unspecified.",
+            Optional:    true,
+        },
+        "tags": schema.MapAttribute{
+            Description: "Resource labels to apply to the cluster.",
+            ElementType: types.StringType,
+            Optional:    true,
+        },
+        "workload_identity_associations": schema.ListNestedAttribute{
+            Description: "Workload Identity bindings (GSA → KSA)",
+            Optional:    true,
+            NestedObject: schema.NestedAttributeObject{
+                Attributes: map[string]schema.Attribute{
+                    "service_account_name": schema.StringAttribute{
+                        Description: "Kubernetes service account name",
+                        Required:    true,
+                    },
+                    "namespace": schema.StringAttribute{
+                        Description: "Kubernetes namespace",
+                        Required:    true,
+                    },
+                    "gsa_email": schema.StringAttribute{
+                        Description: "GCP service account email (e.g., 'sa@PROJECT.iam.gserviceaccount.com')",
+                        Required:    true,
+                    },
+                    "iam_roles": schema.ListAttribute{
+                        Description: "IAM roles to grant to the GSA (e.g., 'roles/storage.objectViewer')",
+                        ElementType: types.StringType,
+                        Optional:    true,
+                    },
+                },
+            },
+        },
+        "attached_gars": schema.ListNestedAttribute{
+            Description: "Artifact Registry repositories to grant pull access",
+            Optional:    true,
+            NestedObject: schema.NestedAttributeObject{
+                Attributes: map[string]schema.Attribute{
+                    "repository": schema.StringAttribute{
+                        Description: "Repository path: 'projects/PROJECT/locations/LOCATION/repositories/REPO'",
+                        Required:    true,
+                    },
+                    "create_if_missing": schema.BoolAttribute{
+                        Description: "Create the repository if it doesn't exist",
+                        Optional:    true,
+                    },
+                },
+            },
+        },
+    },
+},
+```
+
+## Entrypoint Integration
+
+Add to `cmd/entrypoint/kodata/entrypoint-wrapper.sh`:
+
+```bash
+gke)
+  init_gke "$cmd"
+  ;;
+
+# Initialize and manage a GKE environment.
+# Arguments:
+#   $1: Path to the test script (already validated)
+init_gke() {
+  cmd="$1"
+
+  if which kubectl; then
+    # Set a default context to better mimic a local setup
+    kubectl config set-context default --cluster=kubernetes --user=default --namespace=default
+    kubectl config use-context default
+
+    # Ensure required environment variables are set
+    if [ -z "${POD_NAME-}" ] || [ -z "${POD_NAMESPACE-}" ]; then
+      error "POD_NAME and POD_NAMESPACE environment variables must be set"
+      exit 1
+    fi
+
+    info "Waiting for pod ${POD_NAME} to be ready..."
+    if ! kubectl wait --for=condition=Ready=true pod/"${POD_NAME}" -n "${POD_NAMESPACE}" --timeout=60s; then
+      error "Pod ${POD_NAME} failed to become ready"
+      exit 1
+    fi
+  else
+    warn "kubectl missing, skipping readiness check"
+  fi
+
+  exec "$cmd"
+}
+```
+
+## Testing
+
+### Unit Tests
+
+Location: `internal/drivers/gke/driver_test.go`
+
+```go
+package gke
+
+import (
+    "testing"
+)
+
+func TestNewDriver(t *testing.T) {
+    tests := []struct {
+        name    string
+        opts    Options
+        wantErr bool
+    }{
+        {
+            name: "valid minimal config",
+            opts: Options{
+                ProjectID: "test-project",
+                Region:    "us-central1",
+            },
+            wantErr: false,
+        },
+        {
+            name: "missing project ID",
+            opts: Options{
+                Region: "us-central1",
+            },
+            wantErr: true,
+        },
+        {
+            name: "both region and zone specified",
+            opts: Options{
+                ProjectID: "test-project",
+                Region:    "us-central1",
+                Zone:      "us-central1-a",
+            },
+            wantErr: true,
+        },
+        {
+            name: "neither region nor zone specified",
+            opts: Options{
+                ProjectID: "test-project",
+            },
+            wantErr: true,
+        },
+    }
+
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            _, err := NewDriver("test", tt.opts)
+            if (err != nil) != tt.wantErr {
+                t.Errorf("NewDriver() error = %v, wantErr %v", err, tt.wantErr)
+            }
+        })
+    }
+}
+```
+
+### Acceptance Tests
+
+Location: `internal/provider/tests_resource_gke_test.go`
+
+```go
+//go:build gke
+
+package provider
+
+import (
+    "fmt"
+    "os"
+    "testing"
+
+    "github.com/hashicorp/terraform-plugin-framework/providerserver"
+    "github.com/hashicorp/terraform-plugin-go/tfprotov6"
+    "github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccTestsResource_GKE(t *testing.T) {
+    projectID := os.Getenv("IMAGETEST_GKE_PROJECT_ID")
+    region := os.Getenv("IMAGETEST_GKE_REGION")
+    if region == "" {
+        region = "us-central1"
+    }
+
+    repo := "ttl.sh/imagetest"
+
+    // Test 1: Basic cluster creation
+    tf := fmt.Sprintf(`
+resource "imagetest_tests" "foo" {
+  name   = "foo"
+  driver = "gke"
+
+  drivers = {
+    gke = {
+      project_id = %q
+      region     = %q
+    }
+  }
+
+  images = {
+    foo = "cgr.dev/chainguard/busybox:latest@sha256:c546e746013d75c1fc9bf01b7a645ce7caa1ec46c45cb618c6e28d7b57bccc85"
+  }
+
+  tests = [
+    {
+      name    = "basic"
+      image   = "cgr.dev/chainguard/busybox:latest@sha256:ecc152fe3dece44e60d1aa0fbbefb624902b4af0e2ed8c2c84dfbce653ff064f"
+      cmd     = "echo success"
+    }
+  ]
+
+  timeout = "30m"
+}
+`, projectID, region)
+
+    // Test 2: Custom node configuration
+    tfWithCustomNodes := fmt.Sprintf(`
+resource "imagetest_tests" "foo_custom" {
+  name   = "foo-custom"
+  driver = "gke"
+
+  drivers = {
+    gke = {
+      project_id   = %q
+      region       = %q
+      node_count   = 2
+      machine_type = "n1-standard-4"
+      disk_size_gb = 150
+      disk_type    = "pd-ssd"
+      tags = {
+        "team"        = "platform"
+        "environment" = "test"
+      }
+    }
+  }
+
+  images = {
+    foo = "cgr.dev/chainguard/busybox:latest@sha256:c546e746013d75c1fc9bf01b7a645ce7caa1ec46c45cb618c6e28d7b57bccc85"
+  }
+
+  tests = [
+    {
+      name    = "basic"
+      image   = "cgr.dev/chainguard/busybox:latest@sha256:ecc152fe3dece44e60d1aa0fbbefb624902b4af0e2ed8c2c84dfbce653ff064f"
+      cmd     = "echo success"
+    }
+  ]
+
+  timeout = "30m"
+}
+`, projectID, region)
+
+    // Test 3: Workload Identity
+    gsaEmail := fmt.Sprintf("test-sa@%s.iam.gserviceaccount.com", projectID)
+    tfWithWorkloadIdentity := fmt.Sprintf(`
+resource "imagetest_tests" "foo_wi" {
+  name   = "foo-wi"
+  driver = "gke"
+
+  drivers = {
+    gke = {
+      project_id = %q
+      region     = %q
+      
+      workload_identity_associations = [
+        {
+          service_account_name = "default"
+          namespace            = "default"
+          gsa_email            = %q
+          iam_roles = [
+            "roles/storage.objectViewer"
+          ]
+        }
+      ]
+    }
+  }
+
+  images = {
+    foo = "cgr.dev/chainguard/busybox:latest@sha256:c546e746013d75c1fc9bf01b7a645ce7caa1ec46c45cb618c6e28d7b57bccc85"
+  }
+
+  tests = [
+    {
+      name    = "basic"
+      image   = "cgr.dev/chainguard/kubectl:latest-dev"
+      cmd     = "kubectl get sa default -o yaml"
+    }
+  ]
+
+  timeout = "30m"
+}
+`, projectID, region, gsaEmail)
+
+    resource.Test(t, resource.TestCase{
+        PreCheck: func() {
+            testAccPreCheck(t)
+            if projectID == "" {
+                t.Fatal("IMAGETEST_GKE_PROJECT_ID must be set for acceptance tests")
+            }
+        },
+        ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
+            "imagetest": providerserver.NewProtocol6WithError(&ImageTestProvider{
+                repo: repo,
+            }),
+        },
+        Steps: []resource.TestStep{
+            {Config: tf},
+            {Config: tfWithCustomNodes},
+            {Config: tfWithWorkloadIdentity},
+        },
+    })
+}
+```
+
+### Running Tests
+
+```bash
+# Unit tests
+go test ./internal/drivers/gke/... -v
+
+# Acceptance tests (requires GCP credentials)
+export IMAGETEST_GKE_PROJECT_ID="my-test-project"
+export IMAGETEST_GKE_REGION="us-central1"
+export TF_ACC=1
+go test ./internal/provider/... -v -tags=gke -timeout=60m
+
+# Or use make target
+make testacc TESTARGS="-tags=gke -run=TestAccTestsResource_GKE"
+```
+
+## Environment Variables
+
+| Variable | Purpose | Example |
+|----------|---------|---------|
+| `IMAGETEST_GKE_CLUSTER` | Use existing cluster (skip creation) | `my-test-cluster` |
+| `IMAGETEST_GKE_SKIP_TEARDOWN` | Keep GKE resources after test | `true` |
+| `IMAGETEST_SKIP_TEARDOWN` | Global skip teardown (all drivers) | `true` |
+| `GOOGLE_PROJECT_ID` | Default GCP project ID | `my-project-123` |
+| `GOOGLE_APPLICATION_CREDENTIALS` | Path to service account key | `/path/to/sa.json` |
+
+**Authentication priority**:
+1. `GOOGLE_APPLICATION_CREDENTIALS` (service account key file)
+2. `gcloud` CLI credentials (`gcloud auth application-default login`)
+3. GCE metadata server (when running in GCP)
+
+## Configuration Examples
+
+### Minimal Configuration
+
+```hcl
+resource "imagetest_tests" "basic" {
+  name   = "basic-test"
+  driver = "gke"
+
+  drivers = {
+    gke = {
+      project_id = "my-project"
+      region     = "us-central1"
+    }
+  }
+
+  images = {
+    nginx = "cgr.dev/chainguard/nginx:latest"
+  }
+
+  tests = [{
+    name  = "smoke-test"
+    image = "cgr.dev/chainguard/kubectl:latest-dev"
+    cmd   = "kubectl run nginx --image=$IMAGES[\"nginx\"] --dry-run=client -o yaml"
+  }]
+}
+```
+
+### Advanced Configuration
+
+```hcl
+resource "imagetest_tests" "advanced" {
+  name   = "advanced-gke"
+  driver = "gke"
+
+  drivers = {
+    gke = {
+      project_id         = "my-project"
+      region             = "us-central1"
+      node_count         = 3
+      machine_type       = "n2-standard-8"
+      disk_size_gb       = 200
+      disk_type          = "pd-ssd"
+      kubernetes_version = "1.28"
+
+      tags = {
+        team        = "platform"
+        environment = "ci"
+        cost-center = "engineering"
+      }
+
+      # Workload Identity: bind K8s SA to GCP SA
+      workload_identity_associations = [{
+        service_account_name = "test-runner"
+        namespace            = "default"
+        gsa_email            = "test-runner@my-project.iam.gserviceaccount.com"
+        iam_roles = [
+          "roles/storage.objectViewer",
+          "roles/secretmanager.secretAccessor"
+        ]
+      }]
+
+      # Grant pull access to private Artifact Registry
+      attached_gars = [{
+        repository      = "projects/my-project/locations/us-central1/repositories/my-repo"
+        create_if_missing = false
+      }]
+    }
+  }
+
+  images = {
+    app = "us-central1-docker.pkg.dev/my-project/my-repo/my-app:latest"
+  }
+
+  tests = [{
+    name  = "integration-test"
+    image = "cgr.dev/chainguard/kubectl:latest-dev"
+    content = [{
+      source = "./tests/integration"
+    }]
+    cmd = "/imagetest/run-integration-tests.sh"
+  }]
+
+  timeout = "45m"
+}
+```
+
+## Implementation Phases
+
+### Phase 1: MVP (Core Functionality)
+**Goal**: Basic GKE cluster creation and test execution
+
+- [ ] Create `internal/drivers/gke/driver.go`
+- [ ] Implement `NewDriver()` with validation
+- [ ] Implement `setupCommonClients()`
+- [ ] Implement `Setup()` flow
+- [ ] Implement `createCluster()` with stack registration
+- [ ] Implement `getKubeConfig()`
+- [ ] Implement `Run()` (delegate to `pod.Run()`)
+- [ ] Implement `Teardown()` (use stack)
+- [ ] Add entrypoint wrapper case
+- [ ] Provider integration (constants, models, LoadDriver, schema)
+- [ ] Basic unit tests
+- [ ] Basic acceptance test
+
+**Estimated effort**: 2-3 days
+
+### Phase 2: Advanced Features
+**Goal**: Feature parity with AKS driver
+
+- [ ] Workload Identity support
+  - [ ] Bind GSA to KSA
+  - [ ] Grant IAM roles
+  - [ ] Annotate K8s SA with GSA email
+- [ ] Artifact Registry attachment
+  - [ ] Grant `artifactregistry.reader` role to node SA
+  - [ ] Optional: Create repository if missing
+- [ ] Enhanced error handling
+  - [ ] Detect quota errors
+  - [ ] Handle rate limiting
+  - [ ] Better operation polling
+- [ ] Comprehensive tests
+  - [ ] Workload Identity test
+  - [ ] GAR attachment test
+  - [ ] Zonal cluster test
+
+**Estimated effort**: 2-3 days
+
+### Phase 3: Polish & Documentation
+**Goal**: Production-ready
+
+- [ ] Comprehensive documentation
+  - [ ] User guide in docs/
+  - [ ] Example Terraform configs
+  - [ ] Troubleshooting guide
+- [ ] CI/CD integration
+  - [ ] Add GKE tests to GitHub Actions
+  - [ ] Set up test project
+  - [ ] Manage service account credentials
+- [ ] Performance optimization
+  - [ ] Parallel resource creation where possible
+  - [ ] Optimize polling intervals
+- [ ] Edge case handling
+  - [ ] Cluster already exists
+  - [ ] Partial cleanup on failure
+  - [ ] Network connectivity issues
+
+**Estimated effort**: 1-2 days
+
+## Open Questions & Future Work
+
+### Open Questions
+
+1. **Authentication strategy**: Should we support `gke-gcloud-auth-plugin` in the kubeconfig, or use token-based auth directly in the SDK?
+   - **Recommendation**: Use `gke-gcloud-auth-plugin` for better compatibility with existing kubectl tooling
+
+2. **Regional vs Zonal**: Should we default to regional (HA) or zonal (cheaper)?
+   - **Recommendation**: Default to regional for reliability, allow zonal as opt-in
+
+3. **Autopilot support**: Should we support GKE Autopilot mode?
+   - **Recommendation**: Phase 4 - separate feature after standard mode is stable
+
+4. **Node image**: Should we support custom node images (similar to EKS nodeAMI)?
+   - **Recommendation**: Yes, add `node_image` option for testing COS variants
+
+### Future Enhancements
+
+- **GKE Autopilot mode**: Fully managed nodes, no node configuration needed
+- **Multi-cluster testing**: Support creating multiple clusters in one test
+- **Private clusters**: VPC-native clusters with private endpoints
+- **Shielded nodes**: Security hardening features
+- **Binary Authorization**: Image signature verification
+- **Custom node pools**: Multiple node pools with different machine types
+- **Preemptible nodes**: Cost optimization for CI workloads
+- **Release channels**: Follow GKE's Rapid/Regular/Stable channels
+
+## Risk Mitigation
+
+| Risk | Mitigation |
+|------|------------|
+| Cluster creation timeout (>15 min) | Increase default timeout to 30m, make configurable |
+| Quota exhaustion in test project | Document quota requirements, implement exponential backoff |
+| Authentication failures in CI | Provide clear error messages, document workload identity federation setup |
+| Incomplete cleanup on failure | Use stack pattern, add automated cleanup job for orphaned resources |
+| SDK breaking changes | Pin SDK version, test upgrades in separate branch |
+| GKE API rate limiting | Implement retry logic with exponential backoff |
+
+## Success Criteria
+
+- [ ] MVP can create GKE cluster, run test, and clean up successfully
+- [ ] Acceptance tests pass consistently (>95% success rate)
+- [ ] Workload Identity feature works with GCS/Secret Manager
+- [ ] Documentation is clear and includes working examples
+- [ ] Code review approved by maintainers
+- [ ] CI/CD pipeline includes GKE tests
+
+## References
+
+- [GKE Go SDK Documentation](https://pkg.go.dev/cloud.google.com/go/container/apiv1)
+- [GKE REST API Reference](https://cloud.google.com/kubernetes-engine/docs/reference/rest)
+- [GKE Workload Identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity)
+- [Artifact Registry IAM](https://cloud.google.com/artifact-registry/docs/access-control)
+- [Application Default Credentials](https://cloud.google.com/docs/authentication/application-default-credentials)
+- AKS driver implementation: `internal/drivers/aks/driver.go`
+- EKS driver implementation: `internal/drivers/eks_with_eksctl/driver.go`

--- a/docs/gke-driver-design.md
+++ b/docs/gke-driver-design.md
@@ -101,7 +101,7 @@ type driver struct {
 }
 
 type Options struct {
-    ProjectID         string
+    Project           string
     Region            string  // Regional cluster (e.g., "us-central1")
     Zone              string  // Zonal cluster (e.g., "us-central1-a")
     ClusterName       string  // Optional, auto-generated if empty
@@ -475,7 +475,7 @@ type TestsDriversResourceModel struct {
 }
 
 type GKEDriverResourceModel struct {
-    ProjectID         types.String  `tfsdk:"project_id"`
+    Project           types.String  `tfsdk:"project"`
     Region            types.String  `tfsdk:"region"`
     Zone              types.String  `tfsdk:"zone"`
     ClusterName       types.String  `tfsdk:"cluster_name"`
@@ -562,7 +562,7 @@ case DriverGKE:
     }
 
     return gke.NewDriver(id, gke.Options{
-        ProjectID:                    cfg.ProjectID.ValueString(),
+        Project:                      cfg.Project.ValueString(),
         Region:                       cfg.Region.ValueString(),
         Zone:                         cfg.Zone.ValueString(),
         ClusterName:                  cfg.ClusterName.ValueString(),
@@ -586,8 +586,8 @@ case DriverGKE:
     Description: "The GKE driver",
     Optional:    true,
     Attributes: map[string]schema.Attribute{
-        "project_id": schema.StringAttribute{
-            Description: "The GCP project ID. Defaults to GOOGLE_PROJECT_ID environment variable.",
+        "project": schema.StringAttribute{
+            Description: "The GCP project ID. Falls back to the GOOGLE_CLOUD_PROJECT environment variable, then the deprecated GOOGLE_PROJECT_ID env var.",
             Optional:    true,
         },
         "region": schema.StringAttribute{
@@ -733,7 +733,7 @@ func TestNewDriver(t *testing.T) {
         {
             name: "valid minimal config",
             opts: Options{
-                ProjectID: "test-project",
+                Project: "test-project",
                 Region:    "us-central1",
             },
             wantErr: false,
@@ -748,7 +748,7 @@ func TestNewDriver(t *testing.T) {
         {
             name: "both region and zone specified",
             opts: Options{
-                ProjectID: "test-project",
+                Project: "test-project",
                 Region:    "us-central1",
                 Zone:      "us-central1-a",
             },
@@ -757,7 +757,7 @@ func TestNewDriver(t *testing.T) {
         {
             name: "neither region nor zone specified",
             opts: Options{
-                ProjectID: "test-project",
+                Project: "test-project",
             },
             wantErr: true,
         },
@@ -794,7 +794,7 @@ import (
 )
 
 func TestAccTestsResource_GKE(t *testing.T) {
-    projectID := os.Getenv("IMAGETEST_GKE_PROJECT_ID")
+    projectID := os.Getenv("IMAGETEST_GKE_PROJECT")
     region := os.Getenv("IMAGETEST_GKE_REGION")
     if region == "" {
         region = "us-central1"
@@ -810,7 +810,7 @@ resource "imagetest_tests" "foo" {
 
   drivers = {
     gke = {
-      project_id = %q
+      project = %q
       region     = %q
     }
   }
@@ -839,7 +839,7 @@ resource "imagetest_tests" "foo_custom" {
 
   drivers = {
     gke = {
-      project_id   = %q
+      project      = %q
       region       = %q
       node_count   = 2
       machine_type = "n1-standard-4"
@@ -877,7 +877,7 @@ resource "imagetest_tests" "foo_wi" {
 
   drivers = {
     gke = {
-      project_id = %q
+      project = %q
       region     = %q
       
       workload_identity_associations = [
@@ -913,7 +913,7 @@ resource "imagetest_tests" "foo_wi" {
         PreCheck: func() {
             testAccPreCheck(t)
             if projectID == "" {
-                t.Fatal("IMAGETEST_GKE_PROJECT_ID must be set for acceptance tests")
+                t.Fatal("IMAGETEST_GKE_PROJECT must be set for acceptance tests")
             }
         },
         ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
@@ -937,7 +937,7 @@ resource "imagetest_tests" "foo_wi" {
 go test ./internal/drivers/gke/... -v
 
 # Acceptance tests (requires GCP credentials)
-export IMAGETEST_GKE_PROJECT_ID="my-test-project"
+export IMAGETEST_GKE_PROJECT="my-test-project"
 export IMAGETEST_GKE_REGION="us-central1"
 export TF_ACC=1
 go test ./internal/provider/... -v -tags=gke -timeout=60m
@@ -953,7 +953,8 @@ make testacc TESTARGS="-tags=gke -run=TestAccTestsResource_GKE"
 | `IMAGETEST_GKE_CLUSTER` | Use existing cluster (skip creation) | `my-test-cluster` |
 | `IMAGETEST_GKE_SKIP_TEARDOWN` | Keep GKE resources after test | `true` |
 | `IMAGETEST_SKIP_TEARDOWN` | Global skip teardown (all drivers) | `true` |
-| `GOOGLE_PROJECT_ID` | Default GCP project ID | `my-project-123` |
+| `GOOGLE_CLOUD_PROJECT` | Default GCP project ID (canonical; checked by the official Go client libraries) | `my-project-123` |
+| `GOOGLE_PROJECT_ID` | Default GCP project ID (**deprecated** — use `GOOGLE_CLOUD_PROJECT`) | `my-project-123` |
 | `GOOGLE_APPLICATION_CREDENTIALS` | Path to service account key | `/path/to/sa.json` |
 
 **Authentication priority**:
@@ -972,7 +973,7 @@ resource "imagetest_tests" "basic" {
 
   drivers = {
     gke = {
-      project_id = "my-project"
+      project = "my-project"
       region     = "us-central1"
     }
   }
@@ -998,7 +999,7 @@ resource "imagetest_tests" "advanced" {
 
   drivers = {
     gke = {
-      project_id         = "my-project"
+      project            = "my-project"
       region             = "us-central1"
       node_count         = 3
       machine_type       = "n2-standard-8"

--- a/docs/resources/tests.md
+++ b/docs/resources/tests.md
@@ -44,6 +44,7 @@ Optional:
 - `docker_in_docker` (Attributes) The docker_in_docker driver (see [below for nested schema](#nestedatt--drivers--docker_in_docker))
 - `ec2` (Attributes) The AWS EC2 driver. (see [below for nested schema](#nestedatt--drivers--ec2))
 - `eks_with_eksctl` (Attributes) The eks_with_eksctl driver (see [below for nested schema](#nestedatt--drivers--eks_with_eksctl))
+- `gke` (Attributes) The GKE driver (see [below for nested schema](#nestedatt--drivers--gke))
 - `k3s_in_docker` (Attributes) The k3s_in_docker driver (see [below for nested schema](#nestedatt--drivers--k3s_in_docker))
 
 <a id="nestedatt--drivers--aks"></a>
@@ -230,6 +231,23 @@ Optional:
 - `setup` (String) Maximum time for driver setup (e.g., cluster creation). If unset, setup is bounded only by the resource-level timeout.
 - `teardown` (String) Maximum time for driver teardown (e.g., cluster deletion). If unset, the driver uses a built-in default.
 
+
+
+<a id="nestedatt--drivers--gke"></a>
+### Nested Schema for `drivers.gke`
+
+Optional:
+
+- `cluster_name` (String) The GKE cluster name. Auto-generated if not specified.
+- `disk_size_gb` (Number) Boot disk size in GB (default: 100)
+- `disk_type` (String) Boot disk type: 'pd-standard', 'pd-ssd', or 'pd-balanced' (default: 'pd-standard')
+- `kubernetes_version` (String) Kubernetes version. Uses GKE default if unspecified.
+- `machine_type` (String) The GCE machine type (default: 'e2-standard-4')
+- `node_count` (Number) The number of nodes (default: 1)
+- `project` (String) The GCP project ID. Falls back to the GOOGLE_CLOUD_PROJECT environment variable, then the deprecated GOOGLE_PROJECT_ID env var.
+- `region` (String) The GCP region for a regional cluster (e.g., 'us-central1'). Mutually exclusive with zone. Defaults to 'us-central1'.
+- `tags` (Map of String) Resource labels to apply to the cluster. Auto-generated labels (imagetest, imagetest-test-name, imagetest-cluster-name) are always included.
+- `zone` (String) The GCP zone for a zonal cluster (e.g., 'us-central1-a'). Mutually exclusive with region.
 
 
 <a id="nestedatt--drivers--k3s_in_docker"></a>

--- a/examples/gke-test/QUICKSTART.md
+++ b/examples/gke-test/QUICKSTART.md
@@ -108,7 +108,7 @@ Edit `main.tf`:
 ```hcl
 drivers = {
   gke = {
-    project_id = "your-project"
+    project = "your-project"
     zone       = "us-central1-a"  # Instead of region
   }
 }
@@ -240,7 +240,7 @@ Once this works, you can:
 
 3. **Run acceptance tests**:
    ```bash
-   export IMAGETEST_GKE_PROJECT_ID="your-project"
+   export IMAGETEST_GKE_PROJECT="your-project"
    export TF_ACC=1
    go test -v -tags=gke ./internal/provider/tests_resource_gke_test.go -timeout=120m
    ```

--- a/examples/gke-test/QUICKSTART.md
+++ b/examples/gke-test/QUICKSTART.md
@@ -1,0 +1,254 @@
+# GKE Driver Quick Start Guide
+
+## 🚀 5-Minute Setup
+
+### 1. Install Prerequisites
+
+```bash
+# Install gke-gcloud-auth-plugin
+gcloud components install gke-gcloud-auth-plugin
+
+# Verify
+gke-gcloud-auth-plugin --version
+```
+
+### 2. Authenticate
+
+```bash
+# Login to GCP
+gcloud auth application-default login
+
+# Set your project (replace with your project ID)
+gcloud config set project YOUR_PROJECT_ID
+
+# Authenticate to Chainguard registry
+chainctl auth login
+chainctl auth configure-docker
+```
+
+### 3. Configure Terraform Dev Override
+
+```bash
+# This tells Terraform to use your locally built provider
+cat > ~/.terraformrc <<'EOF'
+provider_installation {
+  dev_overrides {
+    "chainguard-dev/imagetest" = "<YOUR_PATH_TO>/terraform-provider-imagetest"
+  }
+  direct {}
+}
+EOF
+```
+
+### 4. Update Configuration
+
+```bash
+cd <YOUR_PATH_TO>/terraform-provider-imagetest/examples/gke-test
+
+# Edit main.tf and replace:
+# 1. YOUR_GCP_PROJECT_ID with your GCP project
+# 2. YOUR_ORG with your Chainguard organization name
+
+# You can use sed:
+sed -i '' 's/YOUR_GCP_PROJECT_ID/my-gcp-project/g' main.tf
+sed -i '' 's/YOUR_ORG/chainguard-private/g' main.tf
+```
+
+### 5. Run the Test
+
+```bash
+# Initialize (you'll see a warning about dev overrides - that's expected!)
+terraform init
+
+# See the plan
+terraform plan
+
+# Create cluster and run test (takes ~15 minutes)
+terraform apply -auto-approve
+
+# Clean up
+terraform destroy -auto-approve
+```
+
+**Note**: The test uses cgr.dev (Chainguard registry). Make sure you're authenticated with `chainctl auth login` and have push access to the repository specified in `main.tf`.
+
+## 💡 Expected Output
+
+### During `terraform apply`:
+
+```
+imagetest_tests.gke_basic: Creating...
+imagetest_tests.gke_basic: Still creating... [10s elapsed]
+imagetest_tests.gke_basic: Still creating... [8m30s elapsed]
+...
+imagetest_tests.gke_basic: Still creating... [14m45s elapsed]
+imagetest_tests.gke_basic: Creation complete after 15m2s [id=gke-basic-test]
+
+Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
+
+Outputs:
+
+test_results = {
+  "driver" = "gke"
+  "id" = "gke-basic-test"
+  "name" = "gke-basic-test"
+  ...
+}
+```
+
+### In GCP Console:
+
+You'll see a cluster named `imagetest-XXXXXXXX` being created in us-central1.
+
+## ⚡ Faster Testing Options
+
+### Option 1: Use a Zonal Cluster (Cheaper, Faster)
+
+Edit `main.tf`:
+```hcl
+drivers = {
+  gke = {
+    project_id = "your-project"
+    zone       = "us-central1-a"  # Instead of region
+  }
+}
+```
+
+### Option 2: Use an Existing Cluster
+
+```bash
+# If you already have a GKE cluster
+export IMAGETEST_GKE_CLUSTER="my-existing-cluster"
+terraform apply
+```
+
+### Option 3: Keep Cluster for Multiple Tests
+
+```bash
+# First run - creates cluster
+export IMAGETEST_GKE_SKIP_TEARDOWN=true
+terraform apply
+
+# Make changes to tests in main.tf, then:
+export IMAGETEST_GKE_CLUSTER="imagetest-XXXXX"  # Use the cluster name from first run
+terraform apply
+
+# Clean up manually when done
+gcloud container clusters delete imagetest-XXXXX --region=us-central1
+```
+
+## 🔍 Verify It's Working
+
+Check the logs during terraform apply:
+
+```
+# You should see:
+INFO Creating GKE cluster name=imagetest-abc123 project=your-project
+INFO Waiting for GKE cluster provisioning...
+INFO Created GKE cluster: imagetest-abc123
+INFO Running test with image: cgr.dev/chainguard/kubectl:latest-dev
+INFO kubectl version --client
+INFO kubectl get nodes
+INFO ✓ GKE cluster is working!
+```
+
+## 🐛 Quick Troubleshooting
+
+### Error: "tag references are not supported"
+
+The imagetest provider requires digest references, not tags:
+
+```bash
+# ❌ Wrong - using tag
+images = {
+  nginx = "cgr.dev/chainguard/nginx:latest"
+}
+
+# ✅ Correct - using digest
+images = {
+  nginx = "cgr.dev/chainguard/nginx:latest@sha256:abc123..."
+}
+```
+
+To get the digest for an image:
+```bash
+# Install crane if needed
+go install github.com/google/go-containerregistry/cmd/crane@latest
+
+# Get digest
+crane digest cgr.dev/chainguard/nginx:latest
+```
+
+### Error: "gke-gcloud-auth-plugin: command not found"
+```bash
+gcloud components install gke-gcloud-auth-plugin
+```
+
+### Error: "Permission denied" or "IAM policy"
+```bash
+# Grant yourself container admin role
+gcloud projects add-iam-policy-binding YOUR_PROJECT_ID \
+  --member="user:$(gcloud config get-value account)" \
+  --role="roles/container.admin"
+```
+
+### Error: "Quota exceeded"
+Your project has hit resource limits. Either:
+- Delete unused resources in the GCP console
+- Request quota increase: https://console.cloud.google.com/iam-admin/quotas
+- Use a different region
+
+### Warning: "Provider development overrides are in effect"
+This is **expected**! It means Terraform is using your local binary.
+
+## 💰 Cost Estimate
+
+- **Test duration**: ~20 minutes
+- **Cluster cost**: Regional clusters have a $0.10/hour management fee
+- **Node cost**: e2-standard-4 is ~$0.13/hour
+- **Total**: ~$0.10 per test run
+
+To minimize costs:
+- Use zonal clusters (no management fee)
+- Use smaller machines (e2-standard-2)
+- Clean up immediately after testing
+- Use `IMAGETEST_GKE_CLUSTER` to reuse clusters
+
+## 🎯 What's Next?
+
+Once this works, you can:
+
+1. **Test with real images** from images-private:
+   ```hcl
+   images = {
+     gcp-csi = "cgr.dev/chainguard/gcp-compute-persistent-disk-csi-driver:latest"
+   }
+   ```
+
+2. **Add more complex tests**:
+   ```hcl
+   tests = [{
+     name  = "persistent-volume-test"
+     image = "cgr.dev/chainguard/kubectl:latest-dev"
+     cmd   = <<-EOF
+       kubectl apply -f storageclass.yaml
+       kubectl apply -f pvc.yaml
+       kubectl wait --for=condition=Bound pvc/test-pvc
+     EOF
+   }]
+   ```
+
+3. **Run acceptance tests**:
+   ```bash
+   export IMAGETEST_GKE_PROJECT_ID="your-project"
+   export TF_ACC=1
+   go test -v -tags=gke ./internal/provider/tests_resource_gke_test.go -timeout=120m
+   ```
+
+## 📚 Full Documentation
+
+See `README.md` for complete documentation including:
+- All configuration options
+- Debugging tips
+- GCP permissions
+- Resource cleanup

--- a/examples/gke-test/README.md
+++ b/examples/gke-test/README.md
@@ -1,0 +1,243 @@
+# GKE Driver Local Testing
+
+This directory contains a test configuration for locally testing the GKE driver.
+
+## Prerequisites
+
+1. **GCP Project**: You need a GCP project with billing enabled
+2. **GCP Credentials**: Authenticated with GCP
+3. **gke-gcloud-auth-plugin**: Required for kubectl authentication
+
+### Install gke-gcloud-auth-plugin
+
+```bash
+# macOS
+gcloud components install gke-gcloud-auth-plugin
+
+# Or via Homebrew
+brew install gke-gcloud-auth-plugin
+
+# Verify installation
+gke-gcloud-auth-plugin --version
+```
+
+### Authenticate with GCP
+
+```bash
+# Option 1: User credentials (recommended for testing)
+gcloud auth application-default login
+
+# Option 2: Service account key (for CI/CD)
+export GOOGLE_APPLICATION_CREDENTIALS="/path/to/service-account-key.json"
+
+# Verify authentication
+gcloud auth list
+```
+
+### Container Registry & Authentication
+
+The imagetest provider needs a container registry to push modified test images. This example uses **cgr.dev** (Chainguard registry).
+
+**Authenticate to cgr.dev**:
+
+```bash
+# Option 1: Using chainctl (recommended)
+chainctl auth login
+chainctl auth configure-docker
+
+# Option 2: Using OIDC token
+export CHAINGUARD_IDENTITY_TOKEN=$(chainctl auth token)
+
+# Option 3: Using pull token (for automation)
+# Create a pull token in the Chainguard console, then:
+docker login cgr.dev -u <token-id> -p <token-secret>
+```
+
+**Configure the repository**:
+
+In `main.tf`, update the `repo` parameter:
+```hcl
+provider "imagetest" {
+  repo = "cgr.dev/YOUR_ORG/imagetest"
+}
+```
+
+Replace `YOUR_ORG` with your Chainguard organization name (e.g., `chainguard-private`).
+
+### Set GCP Project
+
+```bash
+# Set your default project
+gcloud config set project YOUR_PROJECT_ID
+
+# Or export for this session
+export GOOGLE_PROJECT_ID="YOUR_PROJECT_ID"
+```
+
+## Setup
+
+1. **Build the provider**:
+```bash
+cd <YOUR_PATH_TO>/terraform-provider-imagetest
+make terraform-provider-imagetest
+# Or directly: go build -o terraform-provider-imagetest .
+```
+
+2. **Update main.tf**:
+   - Open `main.tf`
+   - Replace `YOUR_GCP_PROJECT_ID` with your actual GCP project ID
+
+3. **Create dev override** (tells Terraform to use local binary):
+```bash
+cd examples/gke-test
+
+cat > ~/.terraformrc <<EOF
+provider_installation {
+  dev_overrides {
+    "chainguard-dev/imagetest" = "<YOUR_PATH_TO>/terraform-provider-imagetest"
+  }
+  direct {}
+}
+EOF
+```
+
+## Run the Test
+
+```bash
+cd examples/gke-test
+
+# Initialize Terraform
+terraform init
+
+# See what will be created (doesn't create anything)
+terraform plan
+
+# Create the cluster and run tests (takes ~15 minutes)
+terraform apply
+
+# View the results
+terraform output
+
+# Clean up (deletes the cluster)
+terraform destroy
+```
+
+## Test Options
+
+### Quick Test (Use Existing Cluster)
+
+If you already have a GKE cluster:
+
+```bash
+export IMAGETEST_GKE_CLUSTER="your-existing-cluster-name"
+terraform apply
+```
+
+This will skip cluster creation and use your existing cluster.
+
+### Debug Mode (Keep Resources)
+
+To keep the cluster after testing (for debugging):
+
+```bash
+export IMAGETEST_GKE_SKIP_TEARDOWN=true
+terraform apply
+```
+
+Then manually delete when done:
+```bash
+gcloud container clusters delete imagetest-XXXXX --region=us-central1
+```
+
+### Minimal Test (Fastest)
+
+Modify `main.tf` to use a zonal cluster with 1 node:
+
+```hcl
+drivers = {
+  gke = {
+    project_id = "your-project"
+    zone       = "us-central1-a"  # Zonal is faster
+    node_count = 1
+    machine_type = "e2-standard-2"  # Smaller machine
+  }
+}
+```
+
+## Cost Considerations
+
+- **Regional cluster**: ~$0.10/hour (per cluster) + node costs
+- **Zonal cluster**: $0 cluster fee + node costs
+- **e2-standard-4**: ~$0.13/hour per node
+- **Typical test run**: ~20 minutes = ~$0.05
+
+**Recommendation**: Use zonal clusters with `e2-standard-2` for testing to minimize costs.
+
+## Troubleshooting
+
+### "Permission denied" errors
+
+Ensure your GCP account has these IAM roles:
+- `roles/container.admin` (create/delete clusters)
+- `roles/compute.networkAdmin` (create VPCs/subnets)
+- `roles/iam.serviceAccountUser` (use service accounts)
+
+```bash
+# Grant roles to your user
+gcloud projects add-iam-policy-binding YOUR_PROJECT_ID \
+  --member="user:your-email@example.com" \
+  --role="roles/container.admin"
+```
+
+### "gke-gcloud-auth-plugin not found"
+
+Install the plugin:
+```bash
+gcloud components install gke-gcloud-auth-plugin
+```
+
+### "Quota exceeded" errors
+
+Check your project quotas:
+```bash
+gcloud compute project-info describe --project=YOUR_PROJECT_ID
+```
+
+Request quota increases if needed: https://console.cloud.google.com/iam-admin/quotas
+
+### Cluster creation timeout
+
+Increase the timeout in `main.tf`:
+```hcl
+timeout = "60m"  # Increase from 45m
+```
+
+## What Gets Created
+
+When you run `terraform apply`, the following GCP resources are created:
+
+1. **GKE Cluster** (`imagetest-XXXXXXXX`)
+   - Location: us-central1 (regional) or us-central1-a (zonal)
+   - Initial node count: 1 (default)
+
+2. **Managed Resources** (auto-created by GKE):
+   - VPC network and subnet
+   - Firewall rules
+   - VM instances (nodes)
+   - Service accounts
+   - Load balancers (if needed)
+
+3. **Kubernetes Resources** (created by imagetest):
+   - Namespace: `imagetest`
+   - Service account with cluster-admin role
+   - Test pods
+
+All resources are automatically deleted when you run `terraform destroy`.
+
+## Next Steps
+
+Once this basic test works, try:
+- Custom node configurations
+- Multiple node pools
+- Workload Identity (future feature)
+- Integration with actual image tests from images-private repo

--- a/examples/gke-test/README.md
+++ b/examples/gke-test/README.md
@@ -71,7 +71,7 @@ Replace `YOUR_ORG` with your Chainguard organization name (e.g., `chainguard-pri
 gcloud config set project YOUR_PROJECT_ID
 
 # Or export for this session
-export GOOGLE_PROJECT_ID="YOUR_PROJECT_ID"
+export GOOGLE_CLOUD_PROJECT="YOUR_PROJECT_ID"
 ```
 
 ## Setup
@@ -156,7 +156,7 @@ Modify `main.tf` to use a zonal cluster with 1 node:
 ```hcl
 drivers = {
   gke = {
-    project_id = "your-project"
+    project = "your-project"
     zone       = "us-central1-a"  # Zonal is faster
     node_count = 1
     machine_type = "e2-standard-2"  # Smaller machine

--- a/examples/gke-test/cleanup-old-clusters.sh
+++ b/examples/gke-test/cleanup-old-clusters.sh
@@ -3,7 +3,7 @@
 
 set -e
 
-PROJECT_ID="${GOOGLE_PROJECT_ID:?GOOGLE_PROJECT_ID must be set}"
+PROJECT_ID="${GOOGLE_CLOUD_PROJECT:?GOOGLE_CLOUD_PROJECT must be set}"
 REGION="${GKE_REGION:-us-central1}"
 MAX_AGE_HOURS="${MAX_AGE_HOURS:-2}"  # Delete clusters older than 2 hours
 

--- a/examples/gke-test/cleanup-old-clusters.sh
+++ b/examples/gke-test/cleanup-old-clusters.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+# Cleanup orphaned imagetest clusters older than a certain time
+
+set -e
+
+PROJECT_ID="${GOOGLE_PROJECT_ID:?GOOGLE_PROJECT_ID must be set}"
+REGION="${GKE_REGION:-us-central1}"
+MAX_AGE_HOURS="${MAX_AGE_HOURS:-2}"  # Delete clusters older than 2 hours
+
+echo "🔍 Looking for orphaned imagetest clusters in project: $PROJECT_ID"
+echo "   Will delete clusters older than $MAX_AGE_HOURS hours"
+echo ""
+
+# Get current timestamp
+CURRENT_TIME=$(date +%s)
+CUTOFF_TIME=$((CURRENT_TIME - (MAX_AGE_HOURS * 3600)))
+
+# List all imagetest clusters
+gcloud container clusters list \
+  --project="$PROJECT_ID" \
+  --filter="name:imagetest" \
+  --format="value(name,location,createTime)" | \
+while IFS=$'\t' read -r name location createTime; do
+  # Convert createTime to epoch seconds
+  # Format: 2026-03-06T10:30:00+00:00
+  createEpoch=$(date -j -f "%Y-%m-%dT%H:%M:%S%z" "${createTime}" "+%s" 2>/dev/null || echo "0")
+  
+  if [ "$createEpoch" -lt "$CUTOFF_TIME" ]; then
+    age_hours=$(( (CURRENT_TIME - createEpoch) / 3600 ))
+    echo "🗑️  Deleting old cluster: $name (age: ${age_hours}h)"
+    echo "   Location: $location"
+    echo "   Created: $createTime"
+    
+    gcloud container clusters delete "$name" \
+      --location="$location" \
+      --project="$PROJECT_ID" \
+      --quiet \
+      --async
+    
+    echo "   ✓ Deletion initiated"
+    echo ""
+  else
+    age_hours=$(( (CURRENT_TIME - createEpoch) / 3600 ))
+    echo "✓ Keeping recent cluster: $name (age: ${age_hours}h)"
+  fi
+done
+
+echo ""
+echo "✅ Cleanup complete!"
+echo ""
+echo "💡 Tip: Set MAX_AGE_HOURS=1 to delete clusters older than 1 hour"
+echo "   Example: MAX_AGE_HOURS=1 ./cleanup-old-clusters.sh"

--- a/examples/gke-test/get-digest.sh
+++ b/examples/gke-test/get-digest.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# Helper script to get image digests for use in imagetest configurations
+
+set -e
+
+# Check if crane is installed
+if ! command -v crane &> /dev/null; then
+    echo "Installing crane..."
+    go install github.com/google/go-containerregistry/cmd/crane@latest
+fi
+
+# Default images if no arguments provided
+if [ $# -eq 0 ]; then
+    IMAGES=(
+        "cgr.dev/chainguard/nginx:latest-dev"
+        "cgr.dev/chainguard/kubectl:latest-dev"
+        "cgr.dev/chainguard/busybox:latest"
+    )
+else
+    IMAGES=("$@")
+fi
+
+echo "Getting digests for images..."
+echo ""
+
+for img in "${IMAGES[@]}"; do
+    # Extract the image without tag
+    base_img="${img%:*}"
+    tag="${img##*:}"
+    
+    # Get the digest
+    digest=$(crane digest "$img" 2>/dev/null || echo "ERROR")
+    
+    if [ "$digest" = "ERROR" ]; then
+        echo "❌ Failed to get digest for: $img"
+    else
+        full_ref="${img}@${digest}"
+        echo "✓ $full_ref"
+    fi
+done
+
+echo ""
+echo "Use these full references in your Terraform configuration:"
+echo ""
+
+for img in "${IMAGES[@]}"; do
+    digest=$(crane digest "$img" 2>/dev/null || echo "")
+    if [ -n "$digest" ]; then
+        echo "  ${img}@${digest}"
+    fi
+done

--- a/examples/gke-test/main.tf
+++ b/examples/gke-test/main.tf
@@ -19,18 +19,18 @@ resource "imagetest_tests" "gke_basic" {
 
   drivers = {
     gke = {
-      project    = "<YOUR_GCP_PROJECT_ID>"
-      region     = "us-central1"
-      
+      project = "<YOUR_GCP_PROJECT_ID>"
+      region  = "us-central1"
+
       # Use a unique cluster name to avoid conflicts
       # cluster_name = "imagetest-gke-test-final"  # Let GKE auto-generate
-      
+
       # Optional: customize cluster
       # node_count    = 2
       # machine_type  = "n1-standard-4"
       # disk_size_gb  = 150
       # disk_type     = "pd-ssd"
-      
+
       # Optional: add custom labels
       # tags = {
       #   environment = "test"
@@ -49,7 +49,7 @@ resource "imagetest_tests" "gke_basic" {
 
   tests = [
     {
-      name  = "smoke-test"
+      name = "smoke-test"
       # Test sandbox image - provides kubectl and other tools
       image = "cgr.dev/chainguard/kubectl:latest-dev@sha256:9d3f6aa5c7741d84ca6a82935df987162f7c53692f98c48624c1871f03c40f8b"
       cmd   = <<-EOF
@@ -74,7 +74,7 @@ resource "imagetest_tests" "gke_basic" {
       ]
     }
   ]
-  
+
   # GKE cluster creation takes ~10-15 minutes
   timeout = "45m"
 }

--- a/examples/gke-test/main.tf
+++ b/examples/gke-test/main.tf
@@ -1,0 +1,84 @@
+terraform {
+  required_providers {
+    imagetest = {
+      source = "chainguard-dev/imagetest"
+    }
+  }
+}
+
+# Configure the provider to use a public registry
+# ttl.sh is a public registry with 24hr retention (no auth required)
+# This matches AKS/EKS test pattern
+provider "imagetest" {
+  repo = "ttl.sh/imagetest-gke"
+}
+
+resource "imagetest_tests" "gke_basic" {
+  name   = "gke-basic-test"
+  driver = "gke"
+
+  drivers = {
+    gke = {
+      project_id = "<YOUR_GCP_PROJECT_ID>"
+      region     = "us-central1"
+      
+      # Use a unique cluster name to avoid conflicts
+      # cluster_name = "imagetest-gke-test-final"  # Let GKE auto-generate
+      
+      # Optional: customize cluster
+      # node_count    = 2
+      # machine_type  = "n1-standard-4"
+      # disk_size_gb  = 150
+      # disk_type     = "pd-ssd"
+      
+      # Optional: add custom labels
+      # tags = {
+      #   environment = "test"
+      #   team        = "platform"
+      # }
+    }
+  }
+
+  # NOTE: imagetest requires digest references (@sha256:...), not tags (:latest)
+  # To get the current digest:
+  #   crane digest cgr.dev/chainguard/nginx:latest
+  # Using public images - provider will modify and push to your repo
+  images = {
+    nginx = "cgr.dev/chainguard/nginx:latest@sha256:25f70f9f4d82518a547ec16a02d7cbd81a8bb0cc3278259789b750f834803798"
+  }
+
+  tests = [
+    {
+      name  = "smoke-test"
+      # Test sandbox image - provides kubectl and other tools
+      image = "cgr.dev/chainguard/kubectl:latest-dev@sha256:9d3f6aa5c7741d84ca6a82935df987162f7c53692f98c48624c1871f03c40f8b"
+      cmd   = <<-EOF
+        set -ex
+
+        apk add jq
+
+        # Verify kubectl works
+        kubectl version --client
+        kubectl get nodes
+
+        # Test deploying the image
+        kubectl run nginx-test --image=$(echo "$IMAGES" | jq -r '.nginx.ref') --dry-run=client -o yaml
+
+        echo "✓ GKE cluster is working!"
+      EOF
+      on_failure = [
+        "kubectl describe pod $POD_NAME -n $POD_NAMESPACE",
+        "kubectl get events -n $POD_NAMESPACE --sort-by='.lastTimestamp'",
+        "kubectl get pods -n $POD_NAMESPACE -o wide",
+        "kubectl get nodes -o wide",
+      ]
+    }
+  ]
+  
+  # GKE cluster creation takes ~10-15 minutes
+  timeout = "45m"
+}
+
+output "test_results" {
+  value = imagetest_tests.gke_basic
+}

--- a/examples/gke-test/main.tf
+++ b/examples/gke-test/main.tf
@@ -19,7 +19,7 @@ resource "imagetest_tests" "gke_basic" {
 
   drivers = {
     gke = {
-      project_id = "<YOUR_GCP_PROJECT_ID>"
+      project    = "<YOUR_GCP_PROJECT_ID>"
       region     = "us-central1"
       
       # Use a unique cluster name to avoid conflicts

--- a/examples/gke-test/setup.sh
+++ b/examples/gke-test/setup.sh
@@ -1,0 +1,183 @@
+#!/bin/bash
+set -e
+
+echo "🚀 GKE Driver Test Setup"
+echo "========================"
+echo ""
+
+# Colors
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+NC='\033[0m' # No Color
+
+# Check if running from correct directory
+if [ ! -f "main.tf" ]; then
+    echo -e "${RED}❌ Error: main.tf not found${NC}"
+    echo "Please run this script from the examples/gke-test directory"
+    exit 1
+fi
+
+# Check prerequisites
+echo "📋 Checking prerequisites..."
+echo ""
+
+# Check gcloud
+if ! command -v gcloud &> /dev/null; then
+    echo -e "${RED}❌ gcloud CLI not found${NC}"
+    echo "Install from: https://cloud.google.com/sdk/docs/install"
+    exit 1
+fi
+echo -e "${GREEN}✓ gcloud CLI installed${NC}"
+
+# Check gke-gcloud-auth-plugin
+if ! command -v gke-gcloud-auth-plugin &> /dev/null; then
+    echo -e "${YELLOW}⚠️  gke-gcloud-auth-plugin not found${NC}"
+    echo ""
+    echo "Installing gke-gcloud-auth-plugin..."
+    gcloud components install gke-gcloud-auth-plugin --quiet
+    echo -e "${GREEN}✓ gke-gcloud-auth-plugin installed${NC}"
+else
+    echo -e "${GREEN}✓ gke-gcloud-auth-plugin installed${NC}"
+fi
+
+# Check terraform
+if ! command -v terraform &> /dev/null; then
+    echo -e "${RED}❌ Terraform not found${NC}"
+    echo "Install from: https://www.terraform.io/downloads"
+    exit 1
+fi
+echo -e "${GREEN}✓ Terraform installed ($(terraform version -json | jq -r .terraform_version))${NC}"
+
+# Check GCP authentication
+echo ""
+echo "🔐 Checking GCP authentication..."
+if ! gcloud auth application-default print-access-token &> /dev/null; then
+    echo -e "${YELLOW}⚠️  Not authenticated with GCP${NC}"
+    echo ""
+    echo "Authenticating..."
+    gcloud auth application-default login
+fi
+echo -e "${GREEN}✓ Authenticated with GCP${NC}"
+
+# Check Chainguard authentication
+echo ""
+echo "🔐 Checking Chainguard registry authentication..."
+if ! command -v chainctl &> /dev/null; then
+    echo -e "${YELLOW}⚠️  chainctl not found${NC}"
+    echo "Install from: https://edu.chainguard.dev/chainguard/chainctl/"
+    echo ""
+    read -p "Press enter to continue without chainctl authentication..."
+else
+    if ! chainctl auth status &> /dev/null; then
+        echo -e "${YELLOW}⚠️  Not authenticated to Chainguard${NC}"
+        echo ""
+        echo "Authenticating..."
+        chainctl auth login
+        chainctl auth configure-docker
+    fi
+    echo -e "${GREEN}✓ Authenticated with Chainguard${NC}"
+fi
+
+# Get current project
+CURRENT_PROJECT=$(gcloud config get-value project 2>/dev/null || echo "")
+if [ -z "$CURRENT_PROJECT" ]; then
+    echo ""
+    echo -e "${YELLOW}⚠️  No default project set${NC}"
+    echo "Please enter your GCP project ID:"
+    read -r GCP_PROJECT
+    gcloud config set project "$GCP_PROJECT"
+    CURRENT_PROJECT="$GCP_PROJECT"
+fi
+echo -e "${GREEN}✓ Using GCP project: ${CURRENT_PROJECT}${NC}"
+
+# Check if provider binary exists
+PROVIDER_PATH="<YOUR_PATH_TO>/terraform-provider-imagetest/terraform-provider-imagetest"
+if [ ! -f "$PROVIDER_PATH" ]; then
+    echo ""
+    echo -e "${YELLOW}⚠️  Provider binary not found${NC}"
+    echo "Building provider..."
+    cd <YOUR_PATH_TO>/terraform-provider-imagetest
+    CGO_ENABLED=0 go build -ldflags "-s -w -X main.version=devel" -o terraform-provider-imagetest .
+    cd - > /dev/null
+    echo -e "${GREEN}✓ Provider built${NC}"
+else
+    echo -e "${GREEN}✓ Provider binary exists${NC}"
+fi
+
+# Update main.tf with project ID
+echo ""
+echo "📝 Updating configuration..."
+if grep -q "YOUR_GCP_PROJECT_ID" main.tf; then
+    sed -i '' "s/YOUR_GCP_PROJECT_ID/${CURRENT_PROJECT}/g" main.tf
+    echo -e "${GREEN}✓ Updated main.tf with GCP project ID${NC}"
+else
+    echo -e "${GREEN}✓ GCP project ID already configured${NC}"
+fi
+
+# Prompt for Chainguard org if needed
+if grep -q "YOUR_ORG" main.tf; then
+    echo ""
+    echo "Please enter your Chainguard organization name (e.g., 'chainguard-private'):"
+    read -r CGR_ORG
+    if [ -n "$CGR_ORG" ]; then
+        sed -i '' "s/YOUR_ORG/${CGR_ORG}/g" main.tf
+        echo -e "${GREEN}✓ Updated main.tf with Chainguard org: ${CGR_ORG}${NC}"
+    else
+        echo -e "${YELLOW}⚠️  Skipped Chainguard org update - you'll need to edit main.tf manually${NC}"
+    fi
+else
+    echo -e "${GREEN}✓ Chainguard org already configured${NC}"
+fi
+
+# Create Terraform dev override
+echo ""
+echo "🔧 Configuring Terraform..."
+TERRAFORMRC="$HOME/.terraformrc"
+if grep -q "chainguard-dev/imagetest" "$TERRAFORMRC" 2>/dev/null; then
+    echo -e "${GREEN}✓ Terraform dev override already configured${NC}"
+else
+    cat > "$TERRAFORMRC" <<EOF
+provider_installation {
+  dev_overrides {
+    "chainguard-dev/imagetest" = "<YOUR_PATH_TO>/terraform-provider-imagetest"
+  }
+  direct {}
+}
+EOF
+    echo -e "${GREEN}✓ Created Terraform dev override${NC}"
+fi
+
+# Initialize Terraform
+echo ""
+echo "🎯 Initializing Terraform..."
+terraform init -upgrade
+
+echo ""
+echo -e "${GREEN}✅ Setup complete!${NC}"
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo ""
+echo "📌 Next steps:"
+echo ""
+echo "  1. Review the configuration:"
+echo "     ${YELLOW}cat main.tf${NC}"
+echo ""
+echo "  2. See what will be created:"
+echo "     ${YELLOW}terraform plan${NC}"
+echo ""
+echo "  3. Create cluster and run test (~15 min):"
+echo "     ${YELLOW}terraform apply${NC}"
+echo ""
+echo "  4. Clean up when done:"
+echo "     ${YELLOW}terraform destroy${NC}"
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo ""
+echo "💡 Tips:"
+echo "  • First run takes ~15 minutes (GKE cluster creation)"
+echo "  • Estimated cost: ~$0.10 per test run"
+echo "  • Use 'terraform destroy' to clean up and avoid charges"
+echo ""
+echo "📚 For more info, see README.md or QUICKSTART.md"
+echo ""

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.25.7
 
 require (
 	chainguard.dev/apko v1.2.9
+	cloud.google.com/go/container v1.49.0
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.0
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.1
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v2 v2.2.0

--- a/go.sum
+++ b/go.sum
@@ -4,12 +4,16 @@ chainguard.dev/go-grpc-kit v0.17.17 h1:Jwhc0zyUwQbC2hNcsi+YMeUX/JUnM+dXVCkTw6wtP
 chainguard.dev/go-grpc-kit v0.17.17/go.mod h1:qn0meP6RtrbLicE1bgBZnnVU9dvX95eLs0x0T6kZ+b4=
 chainguard.dev/sdk v0.1.54 h1:xXNB9G0dnMyAjhQ8+vQORa7ns1AlclkhImgCUS7+c7I=
 chainguard.dev/sdk v0.1.54/go.mod h1:WeUO5MQTgLtK8ZDcguIymeIO0UuVAyie8aOvM6ulth8=
+cloud.google.com/go v0.123.0 h1:2NAUJwPR47q+E35uaJeYoNhuNEM9kM8SjgRgdeOJUSE=
+cloud.google.com/go v0.123.0/go.mod h1:xBoMV08QcqUGuPW65Qfm1o9Y4zKZBpGS+7bImXLTAZU=
 cloud.google.com/go/auth v0.20.0 h1:kXTssoVb4azsVDoUiF8KvxAqrsQcQtB53DcSgta74CA=
 cloud.google.com/go/auth v0.20.0/go.mod h1:942/yi/itH1SsmpyrbnTMDgGfdy2BUqIKyd0cyYLc5Q=
 cloud.google.com/go/auth/oauth2adapt v0.2.8 h1:keo8NaayQZ6wimpNSmW5OPc283g65QNIiLpZnkHRbnc=
 cloud.google.com/go/auth/oauth2adapt v0.2.8/go.mod h1:XQ9y31RkqZCcwJWNSx2Xvric3RrU88hAYYbjDWYDL+c=
 cloud.google.com/go/compute/metadata v0.9.0 h1:pDUj4QMoPejqq20dK0Pg2N4yG9zIkYGdBtwLoEkH9Zs=
 cloud.google.com/go/compute/metadata v0.9.0/go.mod h1:E0bWwX5wTnLPedCKqk3pJmVgCBSM6qQI1yTBdEb3C10=
+cloud.google.com/go/container v1.49.0 h1:K4nmtmJezHOzsIyedAOv1Ok36krw1apFmo4zXBaRL1A=
+cloud.google.com/go/container v1.49.0/go.mod h1:EvqoT2eXfxLweXXUlhAMGR0sOAB00XPzEjoL01esSDs=
 dario.cat/mergo v1.0.1 h1:Ra4+bf83h2ztPIQYNP99R6m+Y7KfnARDfID+a+vLl4s=
 dario.cat/mergo v1.0.1/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
 filippo.io/edwards25519 v1.2.0 h1:crnVqOiS4jqYleHd9vaKZ+HKtHfllngJIiOpNpoJsjo=
@@ -138,6 +142,8 @@ github.com/clipperhouse/uax29/v2 v2.6.0 h1:z0cDbUV+aPASdFb2/ndFnS9ts/WNXgTNNGFoK
 github.com/clipperhouse/uax29/v2 v2.6.0/go.mod h1:Wn1g7MK6OoeDT0vL+Q0SQLDz/KpfsVRgg6W7ihQeh4g=
 github.com/cloudflare/circl v1.6.3 h1:9GPOhQGF9MCYUeXyMYlqTR6a5gTrgR/fBLXvUgtVcg8=
 github.com/cloudflare/circl v1.6.3/go.mod h1:2eXP6Qfat4O/Yhh8BznvKnJ+uzEoTQ6jVKJRn81BiS4=
+github.com/cncf/xds/go v0.0.0-20251210132809-ee656c7534f5 h1:6xNmx7iTtyBRev0+D/Tv1FZd4SCg8axKApyNyRsAt/w=
+github.com/cncf/xds/go v0.0.0-20251210132809-ee656c7534f5/go.mod h1:KdCmV+x/BuvyMxRnYBlmVaq4OLiKW6iRQfvC62cvdkI=
 github.com/containerd/errdefs v1.0.0 h1:tg5yIfIlQIrxYtu9ajqY42W3lpS19XqdxRQeEwYG8PI=
 github.com/containerd/errdefs v1.0.0/go.mod h1:+YBYIdtsnF4Iw6nWZhJcqGSg/dwvV7tyJ/kCkyJ2k+M=
 github.com/containerd/errdefs/pkg v0.3.0 h1:9IKJ06FvyNlexW690DXuQNx2KA2cUJXx151Xdx3ZPPE=
@@ -171,6 +177,11 @@ github.com/emicklei/go-restful/v3 v3.12.2 h1:DhwDP0vY3k8ZzE0RunuJy8GhNpPL6zqLkDf
 github.com/emicklei/go-restful/v3 v3.12.2/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
 github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc=
 github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=
+github.com/envoyproxy/go-control-plane v0.14.0 h1:hbG2kr4RuFj222B6+7T83thSPqLjwBIfQawTkC++2HA=
+github.com/envoyproxy/go-control-plane/envoy v1.36.0 h1:yg/JjO5E7ubRyKX3m07GF3reDNEnfOboJ0QySbH736g=
+github.com/envoyproxy/go-control-plane/envoy v1.36.0/go.mod h1:ty89S1YCCVruQAm9OtKeEkQLTb+Lkz0k8v9W0Oxsv98=
+github.com/envoyproxy/protoc-gen-validate v1.3.0 h1:TvGH1wof4H33rezVKWSpqKz5NXWg5VPuZ0uONDT6eb4=
+github.com/envoyproxy/protoc-gen-validate v1.3.0/go.mod h1:HvYl7zwPa5mffgyeTUHA9zHIH36nmrm7oCbo4YKoSWA=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
 github.com/fatih/color v1.18.0 h1:S8gINlzdQ840/4pfAwic/ZE0djQEH3wM94VfqLTZcOM=
 github.com/fatih/color v1.18.0/go.mod h1:4FelSpRwEGDpQ12mAdzqdOukCy4u8WUtOY6lkT/6HfU=
@@ -416,6 +427,8 @@ github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmd
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c/go.mod h1:7rwL4CYBLnjLxUqIJNnCWiEdr3bn6IUYi15bNlnbCCU=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 h1:GFCKgmp0tecUJ0sJuv4pzYCqS9+RGSn52M3FUwPs+uo=
+github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10/go.mod h1:t/avpk3KcrXxUnYOhZhMXJlSEyie6gQbtLq5NM3loB8=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/internal/drivers/gke/driver.go
+++ b/internal/drivers/gke/driver.go
@@ -26,13 +26,13 @@ import (
 )
 
 const (
-	regionDefault     = "us-central1"
-	nodeCountDefault  = 1
+	regionDefault      = "us-central1"
+	nodeCountDefault   = 1
 	machineTypeDefault = "e2-standard-4"
-	diskSizeGBDefault = 100
-	diskTypeDefault   = "pd-standard"
-	timeoutDefault    = 30 * time.Minute
-	pollFrequency     = 30 * time.Second
+	diskSizeGBDefault  = 100
+	diskTypeDefault    = "pd-standard"
+	timeoutDefault     = 30 * time.Minute
+	pollFrequency      = 30 * time.Second
 )
 
 type driver struct {
@@ -296,10 +296,10 @@ func (k *driver) createCluster(ctx context.Context) error {
 
 	// Wait for operation to complete
 	log.Info("Waiting for GKE cluster provisioning...")
-	
+
 	// The operation name should be in format: projects/{project}/locations/{location}/operations/{operation}
 	opName := op.GetName()
-	
+
 	// If the operation name doesn't include the full path, construct it
 	if !strings.Contains(opName, "projects/") {
 		opName = fmt.Sprintf("%s/operations/%s", parent, opName)
@@ -347,13 +347,13 @@ func (k *driver) createCluster(ctx context.Context) error {
 
 		switch opResp.Status {
 		case containerpb.Operation_DONE:
-			if opResp.StatusMessage != "" && opResp.StatusMessage != "Done" {
-				return fmt.Errorf("cluster creation failed: %s", opResp.StatusMessage)
+			if e := opResp.GetError(); e != nil {
+				return fmt.Errorf("cluster creation failed: %s", e.GetMessage())
 			}
 			log.Infof("Created GKE cluster: %s", k.clusterName)
 			return nil
 		case containerpb.Operation_ABORTING:
-			return fmt.Errorf("cluster creation aborting: %s", opResp.StatusMessage)
+			return fmt.Errorf("cluster creation aborting: %s", opResp.GetError().GetMessage())
 		case containerpb.Operation_PENDING, containerpb.Operation_RUNNING:
 			log.Debugf("Cluster creation in progress, status: %s", opResp.Status)
 		default:
@@ -381,10 +381,10 @@ func (k *driver) deleteCluster(ctx context.Context) error {
 
 	// Wait for deletion to complete
 	log.Info("Waiting for cluster deletion...")
-	
+
 	// The operation name should be in format: projects/{project}/locations/{location}/operations/{operation}
 	opName := op.GetName()
-	
+
 	// If the operation name doesn't include the full path, construct it
 	if !strings.Contains(opName, "projects/") {
 		opName = fmt.Sprintf("%s/operations/%s", parent, opName)
@@ -436,7 +436,7 @@ func (k *driver) deleteCluster(ctx context.Context) error {
 			log.Info("Cluster deleted successfully")
 			return nil
 		case containerpb.Operation_ABORTING:
-			return fmt.Errorf("cluster deletion aborting: %s", opResp.StatusMessage)
+			return fmt.Errorf("cluster deletion aborting: %s", opResp.GetError().GetMessage())
 		case containerpb.Operation_PENDING, containerpb.Operation_RUNNING:
 			log.Debugf("Cluster deletion in progress, status: %s", opResp.Status)
 		default:
@@ -493,8 +493,8 @@ func (k *driver) getKubeConfig(ctx context.Context) error {
 		AuthInfos: map[string]*clientcmdapi.AuthInfo{
 			k.clusterName: {
 				Exec: &clientcmdapi.ExecConfig{
-					APIVersion: "client.authentication.k8s.io/v1beta1",
-					Command:    "gke-gcloud-auth-plugin",
+					APIVersion:  "client.authentication.k8s.io/v1beta1",
+					Command:     "gke-gcloud-auth-plugin",
 					InstallHint: "Install gke-gcloud-auth-plugin for use with kubectl by following https://cloud.google.com/kubernetes-engine/docs/how-to/cluster-access-for-kubectl#install_plugin",
 				},
 			},
@@ -507,7 +507,7 @@ func (k *driver) getKubeConfig(ctx context.Context) error {
 		return fmt.Errorf("failed to marshal kubeconfig: %w", err)
 	}
 
-	if err := os.WriteFile(k.kubeconfig, data, 0644); err != nil {
+	if err := os.WriteFile(k.kubeconfig, data, 0o644); err != nil {
 		return fmt.Errorf("failed to write kubeconfig: %w", err)
 	}
 

--- a/internal/drivers/gke/driver.go
+++ b/internal/drivers/gke/driver.go
@@ -32,7 +32,7 @@ const (
 	diskSizeGBDefault = 100
 	diskTypeDefault   = "pd-standard"
 	timeoutDefault    = 30 * time.Minute
-	pollFrequency     = 10 * time.Second
+	pollFrequency     = 30 * time.Second
 )
 
 type driver struct {
@@ -305,19 +305,32 @@ func (k *driver) createCluster(ctx context.Context) error {
 		opName = fmt.Sprintf("%s/operations/%s", parent, opName)
 	}
 
-	deadline := time.Now().Add(k.timeout)
-	for time.Now().Before(deadline) {
+	// Bound the polling loop by k.timeout. The select on ctx.Done() lets
+	// callers cancel the wait immediately rather than waiting up to a full
+	// pollFrequency tick.
+	ctx, cancel := context.WithTimeout(ctx, k.timeout)
+	defer cancel()
+
+	for {
+		select {
+		case <-ctx.Done():
+			if ctx.Err() == context.DeadlineExceeded {
+				return fmt.Errorf("cluster creation timed out after %v", k.timeout)
+			}
+			return fmt.Errorf("cluster creation: %w", ctx.Err())
+		case <-time.After(pollFrequency):
+		}
+
 		opReq := &containerpb.GetOperationRequest{
 			Name: opName,
 		}
 		opResp, err := k.clusterClient.GetOperation(ctx, opReq)
 		if err != nil {
 			// If operation not found, check if cluster was created successfully
-			// (operation might have completed and been cleaned up)
+			// (operation might have completed and been cleaned up).
 			if strings.Contains(err.Error(), "not found") || strings.Contains(err.Error(), "NotFound") {
 				log.Info("Operation not found, checking if cluster was created successfully...")
-				
-				// Try to get the cluster
+
 				clusterReq := &containerpb.GetClusterRequest{
 					Name: fmt.Sprintf("%s/clusters/%s", parent, k.clusterName),
 				}
@@ -326,26 +339,27 @@ func (k *driver) createCluster(ctx context.Context) error {
 					log.Infof("Created GKE cluster: %s (operation completed)", k.clusterName)
 					return nil
 				}
-				
-				// If cluster doesn't exist either, return the original error
+
 				return fmt.Errorf("failed to check operation status: %w", err)
 			}
 			return fmt.Errorf("failed to check operation status: %w", err)
 		}
 
-		if opResp.Status == containerpb.Operation_DONE {
+		switch opResp.Status {
+		case containerpb.Operation_DONE:
 			if opResp.StatusMessage != "" && opResp.StatusMessage != "Done" {
 				return fmt.Errorf("cluster creation failed: %s", opResp.StatusMessage)
 			}
 			log.Infof("Created GKE cluster: %s", k.clusterName)
 			return nil
+		case containerpb.Operation_ABORTING:
+			return fmt.Errorf("cluster creation aborting: %s", opResp.StatusMessage)
+		case containerpb.Operation_PENDING, containerpb.Operation_RUNNING:
+			log.Debugf("Cluster creation in progress, status: %s", opResp.Status)
+		default:
+			return fmt.Errorf("unexpected operation status: %v", opResp.Status)
 		}
-
-		log.Debugf("Cluster creation in progress, status: %s", opResp.Status)
-		time.Sleep(pollFrequency)
 	}
-
-	return fmt.Errorf("cluster creation timed out after %v", k.timeout)
 }
 
 func (k *driver) deleteCluster(ctx context.Context) error {
@@ -376,18 +390,31 @@ func (k *driver) deleteCluster(ctx context.Context) error {
 		opName = fmt.Sprintf("%s/operations/%s", parent, opName)
 	}
 
-	deadline := time.Now().Add(k.timeout)
-	for time.Now().Before(deadline) {
+	// Bound the polling loop by k.timeout. The select on ctx.Done() lets
+	// callers cancel the wait immediately rather than waiting up to a full
+	// pollFrequency tick.
+	ctx, cancel := context.WithTimeout(ctx, k.timeout)
+	defer cancel()
+
+	for {
+		select {
+		case <-ctx.Done():
+			if ctx.Err() == context.DeadlineExceeded {
+				return fmt.Errorf("cluster deletion timed out after %v", k.timeout)
+			}
+			return fmt.Errorf("cluster deletion: %w", ctx.Err())
+		case <-time.After(pollFrequency):
+		}
+
 		opReq := &containerpb.GetOperationRequest{
 			Name: opName,
 		}
 		opResp, err := k.clusterClient.GetOperation(ctx, opReq)
 		if err != nil {
-			// If operation not found, check if cluster is really deleted
+			// If operation not found, verify cluster is really deleted.
 			if strings.Contains(err.Error(), "not found") || strings.Contains(err.Error(), "NotFound") {
 				log.Info("Operation not found, verifying cluster deletion...")
-				
-				// Try to get the cluster - if it doesn't exist, deletion succeeded
+
 				clusterReq := &containerpb.GetClusterRequest{
 					Name: fmt.Sprintf("%s/clusters/%s", parent, k.clusterName),
 				}
@@ -396,21 +423,26 @@ func (k *driver) deleteCluster(ctx context.Context) error {
 					log.Info("Cluster deleted successfully (verified)")
 					return nil
 				}
-				
-				// If we can still see the cluster, keep waiting
+
+				// Cluster still exists; loop back and poll again.
 				log.Debug("Cluster still exists, continuing to wait...")
-			} else {
-				return fmt.Errorf("failed to check deletion status: %w", err)
+				continue
 			}
-		} else if opResp.Status == containerpb.Operation_DONE {
-			log.Info("Cluster deleted successfully")
-			return nil
+			return fmt.Errorf("failed to check deletion status: %w", err)
 		}
 
-		time.Sleep(pollFrequency)
+		switch opResp.Status {
+		case containerpb.Operation_DONE:
+			log.Info("Cluster deleted successfully")
+			return nil
+		case containerpb.Operation_ABORTING:
+			return fmt.Errorf("cluster deletion aborting: %s", opResp.StatusMessage)
+		case containerpb.Operation_PENDING, containerpb.Operation_RUNNING:
+			log.Debugf("Cluster deletion in progress, status: %s", opResp.Status)
+		default:
+			return fmt.Errorf("unexpected operation status: %v", opResp.Status)
+		}
 	}
-
-	return fmt.Errorf("cluster deletion timed out after %v", k.timeout)
 }
 
 func (k *driver) getKubeConfig(ctx context.Context) error {

--- a/internal/drivers/gke/driver.go
+++ b/internal/drivers/gke/driver.go
@@ -1,0 +1,564 @@
+package gke
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	container "cloud.google.com/go/container/apiv1"
+	"cloud.google.com/go/container/apiv1/containerpb"
+	"github.com/chainguard-dev/clog"
+	"github.com/chainguard-dev/terraform-provider-imagetest/internal/docker"
+	"github.com/chainguard-dev/terraform-provider-imagetest/internal/drivers"
+	"github.com/chainguard-dev/terraform-provider-imagetest/internal/drivers/pod"
+	"github.com/chainguard-dev/terraform-provider-imagetest/internal/harness"
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/uuid"
+	"go.opentelemetry.io/otel/trace"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+)
+
+const (
+	regionDefault     = "us-central1"
+	nodeCountDefault  = 1
+	machineTypeDefault = "e2-standard-4"
+	diskSizeGBDefault = 100
+	diskTypeDefault   = "pd-standard"
+	timeoutDefault    = 30 * time.Minute
+	pollFrequency     = 10 * time.Second
+)
+
+type driver struct {
+	name  string
+	stack *harness.Stack
+
+	// Configuration
+	projectID         string
+	region            string // Regional cluster (preferred)
+	zone              string // Zonal cluster (alternative)
+	clusterName       string
+	nodeCount         int32
+	machineType       string
+	diskSizeGB        int32
+	diskType          string
+	kubernetesVersion string
+	timeout           time.Duration
+	tags              map[string]string
+
+	// Runtime state
+	kubeconfig string
+	kcli       kubernetes.Interface
+	kcfg       *rest.Config
+
+	// GCP SDK clients
+	clusterClient *container.ClusterManagerClient
+
+	// Features
+	registries map[string]*RegistryConfig
+}
+
+type Options struct {
+	// REQUIRED. GCP project ID.
+	ProjectID string
+	// Regional cluster location (e.g., "us-central1"). Mutually exclusive with Zone.
+	Region string
+	// Zonal cluster location (e.g., "us-central1-a"). Mutually exclusive with Region.
+	Zone string
+	// The GKE cluster name. Auto-generated if not specified.
+	ClusterName string
+	// The number of nodes (default: 1).
+	NodeCount int32
+	// The GCE machine type (default: "e2-standard-4").
+	MachineType string
+	// Boot disk size in GB (default: 100).
+	DiskSizeGB int32
+	// Boot disk type: "pd-standard", "pd-ssd", or "pd-balanced" (default: "pd-standard").
+	DiskType string
+	// Kubernetes version. Uses GKE default if unspecified.
+	KubernetesVersion string
+	// Go duration format for long running operations.
+	// Default: "30m".
+	Timeout string
+	// Resource labels to apply to the cluster.
+	Tags       map[string]string
+	Registries map[string]*RegistryConfig
+}
+
+// RegistryConfig holds authentication configuration for a container registry.
+type RegistryConfig struct {
+	Auth *RegistryAuthConfig
+}
+
+// RegistryAuthConfig holds the credentials for authenticating to a container registry.
+type RegistryAuthConfig struct {
+	Username string
+	Password string
+	Auth     string
+}
+
+// NewDriver creates a new GKE driver instance that uses the Google Cloud SDK
+// to provision and manage a GKE cluster for running tests.
+func NewDriver(name string, opts Options) (drivers.Tester, error) {
+	k := &driver{
+		name:              name,
+		stack:             harness.NewStack(),
+		projectID:         opts.ProjectID,
+		region:            opts.Region,
+		zone:              opts.Zone,
+		clusterName:       opts.ClusterName,
+		nodeCount:         opts.NodeCount,
+		machineType:       opts.MachineType,
+		diskSizeGB:        opts.DiskSizeGB,
+		diskType:          opts.DiskType,
+		kubernetesVersion: opts.KubernetesVersion,
+		tags:              opts.Tags,
+	}
+
+	// Validate project ID
+	if k.projectID == "" {
+		if v, ok := os.LookupEnv("GOOGLE_PROJECT_ID"); ok {
+			k.projectID = v
+		} else {
+			return nil, fmt.Errorf("no GCP project ID specified (set project_id or GOOGLE_PROJECT_ID)")
+		}
+	}
+
+	// Validate location (must specify either region or zone, not both)
+	if k.region == "" && k.zone == "" {
+		k.region = regionDefault
+	}
+	if k.region != "" && k.zone != "" {
+		return nil, fmt.Errorf("cannot specify both region and zone, choose one")
+	}
+
+	// Set defaults
+	if k.nodeCount <= 0 {
+		k.nodeCount = nodeCountDefault
+	}
+	if k.machineType == "" {
+		k.machineType = machineTypeDefault
+	}
+	if k.diskSizeGB <= 0 {
+		k.diskSizeGB = diskSizeGBDefault
+	}
+	if k.diskType == "" {
+		k.diskType = diskTypeDefault
+	}
+
+	k.timeout = timeoutDefault
+	if opts.Timeout != "" {
+		timeout, err := time.ParseDuration(opts.Timeout)
+		if err != nil {
+			return nil, fmt.Errorf("unable to parse timeout setting: %s %v", opts.Timeout, err)
+		}
+		k.timeout = timeout
+	}
+
+	if opts.Registries != nil {
+		k.registries = opts.Registries
+	}
+
+	return k, nil
+}
+
+func (k *driver) setupCommonClients(ctx context.Context) error {
+	// Create GKE cluster client using Application Default Credentials
+	clusterClient, err := container.NewClusterManagerClient(ctx)
+	if err != nil {
+		return fmt.Errorf("unable to create GKE cluster client: %w", err)
+	}
+	k.clusterClient = clusterClient
+
+	return nil
+}
+
+func (k *driver) Setup(ctx context.Context) error {
+	log := clog.FromContext(ctx)
+	span := trace.SpanFromContext(ctx)
+
+	// Initialize GCP clients
+	if err := k.setupCommonClients(ctx); err != nil {
+		return err
+	}
+
+	// Determine cluster name (env var or generate)
+	existingCluster := false
+	if n, ok := os.LookupEnv("IMAGETEST_GKE_CLUSTER"); ok {
+		log.Infof("Using cluster name from IMAGETEST_GKE_CLUSTER: %s", n)
+		k.clusterName = n
+		existingCluster = true
+	} else {
+		if k.clusterName == "" {
+			k.clusterName = "imagetest-" + uuid.New().String()[:8]
+		}
+		log.Infof("Using cluster name: %s", k.clusterName)
+	}
+
+	// Create temp kubeconfig file
+	cfg, err := os.Create(filepath.Join(os.TempDir(), k.clusterName))
+	if err != nil {
+		return fmt.Errorf("creating temp kubeconfig: %w", err)
+	}
+	log.Infof("Using kubeconfig: %s", cfg.Name())
+	k.kubeconfig = cfg.Name()
+
+	// Create cluster (or skip if existing)
+	if !existingCluster {
+		if err = k.createCluster(ctx); err != nil {
+			return err
+		}
+		span.AddEvent("gke.cluster.created")
+	}
+
+	// Get kubeconfig and create Kubernetes client
+	if err = k.getKubeConfig(ctx); err != nil {
+		return err
+	}
+
+	config, err := clientcmd.BuildConfigFromFlags("", k.kubeconfig)
+	if err != nil {
+		return fmt.Errorf("building kubeconfig: %w", err)
+	}
+	k.kcfg = config
+
+	kcli, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return fmt.Errorf("creating kubernetes client: %w", err)
+	}
+	k.kcli = kcli
+
+	return nil
+}
+
+func (k *driver) createCluster(ctx context.Context) error {
+	log := clog.FromContext(ctx)
+
+	// Determine parent (regional or zonal)
+	var parent string
+	if k.region != "" {
+		parent = fmt.Sprintf("projects/%s/locations/%s", k.projectID, k.region)
+		log.Infof("Creating regional cluster in %s", k.region)
+	} else {
+		parent = fmt.Sprintf("projects/%s/locations/%s", k.projectID, k.zone)
+		log.Infof("Creating zonal cluster in %s", k.zone)
+	}
+
+	// Build cluster request
+	req := &containerpb.CreateClusterRequest{
+		Parent: parent,
+		Cluster: &containerpb.Cluster{
+			Name:             k.clusterName,
+			InitialNodeCount: k.nodeCount,
+			NodeConfig: &containerpb.NodeConfig{
+				MachineType: k.machineType,
+				DiskSizeGb:  k.diskSizeGB,
+				DiskType:    k.diskType,
+				OauthScopes: []string{
+					"https://www.googleapis.com/auth/cloud-platform",
+				},
+			},
+			ResourceLabels: k.buildLabels(),
+		},
+	}
+
+	// Set Kubernetes version if specified
+	if k.kubernetesVersion != "" {
+		req.Cluster.InitialClusterVersion = k.kubernetesVersion
+	}
+
+	log.Info("Creating GKE cluster",
+		"name", k.clusterName,
+		"project", k.projectID,
+		"location", k.getLocation(),
+		"node_count", k.nodeCount,
+		"machine_type", k.machineType,
+		"disk_size_gb", k.diskSizeGB,
+		"disk_type", k.diskType,
+	)
+
+	// Start cluster creation (async operation)
+	op, err := k.clusterClient.CreateCluster(ctx, req)
+	if err != nil {
+		return fmt.Errorf("failed to initiate GKE cluster creation: %w", err)
+	}
+
+	// Register cleanup IMMEDIATELY
+	if err := k.stack.Add(func(ctx context.Context) error {
+		return k.deleteCluster(ctx)
+	}); err != nil {
+		return err
+	}
+
+	// Wait for operation to complete
+	log.Info("Waiting for GKE cluster provisioning...")
+	
+	// The operation name should be in format: projects/{project}/locations/{location}/operations/{operation}
+	opName := op.GetName()
+	
+	// If the operation name doesn't include the full path, construct it
+	if !strings.Contains(opName, "projects/") {
+		opName = fmt.Sprintf("%s/operations/%s", parent, opName)
+	}
+
+	deadline := time.Now().Add(k.timeout)
+	for time.Now().Before(deadline) {
+		opReq := &containerpb.GetOperationRequest{
+			Name: opName,
+		}
+		opResp, err := k.clusterClient.GetOperation(ctx, opReq)
+		if err != nil {
+			// If operation not found, check if cluster was created successfully
+			// (operation might have completed and been cleaned up)
+			if strings.Contains(err.Error(), "not found") || strings.Contains(err.Error(), "NotFound") {
+				log.Info("Operation not found, checking if cluster was created successfully...")
+				
+				// Try to get the cluster
+				clusterReq := &containerpb.GetClusterRequest{
+					Name: fmt.Sprintf("%s/clusters/%s", parent, k.clusterName),
+				}
+				cluster, clusterErr := k.clusterClient.GetCluster(ctx, clusterReq)
+				if clusterErr == nil && cluster.Status == containerpb.Cluster_RUNNING {
+					log.Infof("Created GKE cluster: %s (operation completed)", k.clusterName)
+					return nil
+				}
+				
+				// If cluster doesn't exist either, return the original error
+				return fmt.Errorf("failed to check operation status: %w", err)
+			}
+			return fmt.Errorf("failed to check operation status: %w", err)
+		}
+
+		if opResp.Status == containerpb.Operation_DONE {
+			if opResp.StatusMessage != "" && opResp.StatusMessage != "Done" {
+				return fmt.Errorf("cluster creation failed: %s", opResp.StatusMessage)
+			}
+			log.Infof("Created GKE cluster: %s", k.clusterName)
+			return nil
+		}
+
+		log.Debugf("Cluster creation in progress, status: %s", opResp.Status)
+		time.Sleep(pollFrequency)
+	}
+
+	return fmt.Errorf("cluster creation timed out after %v", k.timeout)
+}
+
+func (k *driver) deleteCluster(ctx context.Context) error {
+	log := clog.FromContext(ctx)
+
+	parent := k.getParent()
+	clusterName := fmt.Sprintf("%s/clusters/%s", parent, k.clusterName)
+
+	log.Info("Initiating GKE cluster deletion", "cluster", clusterName)
+
+	req := &containerpb.DeleteClusterRequest{
+		Name: clusterName,
+	}
+
+	op, err := k.clusterClient.DeleteCluster(ctx, req)
+	if err != nil {
+		return fmt.Errorf("failed to initiate cluster deletion: %w", err)
+	}
+
+	// Wait for deletion to complete
+	log.Info("Waiting for cluster deletion...")
+	
+	// The operation name should be in format: projects/{project}/locations/{location}/operations/{operation}
+	opName := op.GetName()
+	
+	// If the operation name doesn't include the full path, construct it
+	if !strings.Contains(opName, "projects/") {
+		opName = fmt.Sprintf("%s/operations/%s", parent, opName)
+	}
+
+	deadline := time.Now().Add(k.timeout)
+	for time.Now().Before(deadline) {
+		opReq := &containerpb.GetOperationRequest{
+			Name: opName,
+		}
+		opResp, err := k.clusterClient.GetOperation(ctx, opReq)
+		if err != nil {
+			// If operation not found, check if cluster is really deleted
+			if strings.Contains(err.Error(), "not found") || strings.Contains(err.Error(), "NotFound") {
+				log.Info("Operation not found, verifying cluster deletion...")
+				
+				// Try to get the cluster - if it doesn't exist, deletion succeeded
+				clusterReq := &containerpb.GetClusterRequest{
+					Name: fmt.Sprintf("%s/clusters/%s", parent, k.clusterName),
+				}
+				_, clusterErr := k.clusterClient.GetCluster(ctx, clusterReq)
+				if clusterErr != nil && (strings.Contains(clusterErr.Error(), "not found") || strings.Contains(clusterErr.Error(), "NotFound")) {
+					log.Info("Cluster deleted successfully (verified)")
+					return nil
+				}
+				
+				// If we can still see the cluster, keep waiting
+				log.Debug("Cluster still exists, continuing to wait...")
+			} else {
+				return fmt.Errorf("failed to check deletion status: %w", err)
+			}
+		} else if opResp.Status == containerpb.Operation_DONE {
+			log.Info("Cluster deleted successfully")
+			return nil
+		}
+
+		time.Sleep(pollFrequency)
+	}
+
+	return fmt.Errorf("cluster deletion timed out after %v", k.timeout)
+}
+
+func (k *driver) getKubeConfig(ctx context.Context) error {
+	log := clog.FromContext(ctx)
+
+	parent := k.getParent()
+	clusterName := fmt.Sprintf("%s/clusters/%s", parent, k.clusterName)
+
+	log.Infof("Retrieving cluster details: %s", clusterName)
+
+	req := &containerpb.GetClusterRequest{
+		Name: clusterName,
+	}
+
+	cluster, err := k.clusterClient.GetCluster(ctx, req)
+	if err != nil {
+		return fmt.Errorf("failed to get cluster: %w", err)
+	}
+
+	if cluster.Endpoint == "" {
+		return fmt.Errorf("cluster endpoint is empty")
+	}
+
+	// Decode CA certificate
+	caCert, err := base64.StdEncoding.DecodeString(cluster.MasterAuth.ClusterCaCertificate)
+	if err != nil {
+		return fmt.Errorf("failed to decode CA certificate: %w", err)
+	}
+
+	// Construct kubeconfig
+	// Note: This uses gke-gcloud-auth-plugin for authentication
+	kubeconfig := clientcmdapi.Config{
+		APIVersion: "v1",
+		Kind:       "Config",
+		Clusters: map[string]*clientcmdapi.Cluster{
+			k.clusterName: {
+				Server:                   fmt.Sprintf("https://%s", cluster.Endpoint),
+				CertificateAuthorityData: caCert,
+			},
+		},
+		Contexts: map[string]*clientcmdapi.Context{
+			k.clusterName: {
+				Cluster:  k.clusterName,
+				AuthInfo: k.clusterName,
+			},
+		},
+		CurrentContext: k.clusterName,
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			k.clusterName: {
+				Exec: &clientcmdapi.ExecConfig{
+					APIVersion: "client.authentication.k8s.io/v1beta1",
+					Command:    "gke-gcloud-auth-plugin",
+					InstallHint: "Install gke-gcloud-auth-plugin for use with kubectl by following https://cloud.google.com/kubernetes-engine/docs/how-to/cluster-access-for-kubectl#install_plugin",
+				},
+			},
+		},
+	}
+
+	// Write kubeconfig to file
+	data, err := clientcmd.Write(kubeconfig)
+	if err != nil {
+		return fmt.Errorf("failed to marshal kubeconfig: %w", err)
+	}
+
+	if err := os.WriteFile(k.kubeconfig, data, 0644); err != nil {
+		return fmt.Errorf("failed to write kubeconfig: %w", err)
+	}
+
+	log.Infof("Wrote kubeconfig to %s", k.kubeconfig)
+	return nil
+}
+
+func (k *driver) Teardown(ctx context.Context) error {
+	log := clog.FromContext(ctx)
+
+	// Check skip teardown flags
+	if os.Getenv("IMAGETEST_GKE_SKIP_TEARDOWN") == "true" ||
+		os.Getenv("IMAGETEST_SKIP_TEARDOWN") == "true" {
+		log.Info("Skipping GKE teardown")
+		return nil
+	}
+
+	// Skip if using existing cluster
+	if _, ok := os.LookupEnv("IMAGETEST_GKE_CLUSTER"); ok {
+		log.Info("Skipping teardown for existing cluster")
+		return nil
+	}
+
+	log.Info("Initiating resource teardown")
+
+	// Create fresh context with timeout (original may be cancelled)
+	teardownCtx, cancel := context.WithTimeout(context.Background(), k.timeout)
+	defer cancel()
+
+	// Use stack for LIFO cleanup
+	return k.stack.Teardown(teardownCtx)
+}
+
+func (k *driver) Run(ctx context.Context, ref name.Reference) (*drivers.RunResult, error) {
+	log := clog.FromContext(ctx)
+	log.Infof("Running test with image: %s", ref.String())
+
+	// Build docker config from registries for pod authentication
+	dcfg := &docker.DockerConfig{
+		Auths: make(map[string]docker.DockerAuthConfig, len(k.registries)),
+	}
+	for reg, cfg := range k.registries {
+		if cfg.Auth == nil {
+			continue
+		}
+		dcfg.Auths[reg] = docker.DockerAuthConfig{
+			Username: cfg.Auth.Username,
+			Password: cfg.Auth.Password,
+			Auth:     cfg.Auth.Auth,
+		}
+	}
+
+	// Delegate to shared pod.Run()
+	return pod.Run(ctx, k.kcfg,
+		pod.WithImageRef(ref),
+		pod.WithExtraEnvs(map[string]string{
+			"IMAGETEST_DRIVER": "gke",
+		}),
+		pod.WithRegistryStaticAuth(dcfg),
+	)
+}
+
+func (k *driver) getLocation() string {
+	if k.region != "" {
+		return k.region
+	}
+	return k.zone
+}
+
+func (k *driver) getParent() string {
+	return fmt.Sprintf("projects/%s/locations/%s", k.projectID, k.getLocation())
+}
+
+func (k *driver) buildLabels() map[string]string {
+	labels := map[string]string{
+		"imagetest":              "true",
+		"imagetest-test-name":    k.name,
+		"imagetest-cluster-name": k.clusterName,
+	}
+	for k, v := range k.tags {
+		labels[k] = v
+	}
+	return labels
+}

--- a/internal/drivers/gke/driver.go
+++ b/internal/drivers/gke/driver.go
@@ -287,10 +287,10 @@ func (k *driver) createCluster(ctx context.Context) error {
 		return fmt.Errorf("failed to initiate GKE cluster creation: %w", err)
 	}
 
-	// Register cleanup IMMEDIATELY
-	if err := k.stack.Add(func(ctx context.Context) error {
-		return k.deleteCluster(ctx)
-	}); err != nil {
+	// Register cleanup IMMEDIATELY. teardownCluster honors skip-teardown env
+	// vars internally, so non-cluster stack items aren't short-circuited
+	// when cluster teardown is skipped.
+	if err := k.stack.Add(k.teardownCluster); err != nil {
 		return err
 	}
 
@@ -516,29 +516,37 @@ func (k *driver) getKubeConfig(ctx context.Context) error {
 }
 
 func (k *driver) Teardown(ctx context.Context) error {
-	log := clog.FromContext(ctx)
+	clog.FromContext(ctx).Info("Initiating resource teardown")
 
-	// Check skip teardown flags
-	if os.Getenv("IMAGETEST_GKE_SKIP_TEARDOWN") == "true" ||
-		os.Getenv("IMAGETEST_SKIP_TEARDOWN") == "true" {
-		log.Info("Skipping GKE teardown")
-		return nil
-	}
-
-	// Skip if using existing cluster
-	if _, ok := os.LookupEnv("IMAGETEST_GKE_CLUSTER"); ok {
-		log.Info("Skipping teardown for existing cluster")
-		return nil
-	}
-
-	log.Info("Initiating resource teardown")
-
-	// Create fresh context with timeout (original may be cancelled)
+	// Create fresh context with timeout (the original may already be cancelled
+	// by the time the test framework calls Teardown).
 	teardownCtx, cancel := context.WithTimeout(context.Background(), k.timeout)
 	defer cancel()
 
-	// Use stack for LIFO cleanup
+	// Use stack for LIFO cleanup. Each registered teardown function honors its
+	// own skip-teardown logic — see teardownCluster.
 	return k.stack.Teardown(teardownCtx)
+}
+
+// teardownCluster is the stack callback that deletes the GKE cluster. Honors
+// the per-driver and global skip-teardown env vars (and the use-existing-
+// cluster mode) so that non-cluster stack items can still run independently
+// when the user wants to keep the cluster around for debugging.
+func (k *driver) teardownCluster(ctx context.Context) error {
+	log := clog.FromContext(ctx)
+
+	if os.Getenv("IMAGETEST_GKE_SKIP_TEARDOWN") == "true" ||
+		os.Getenv("IMAGETEST_SKIP_TEARDOWN") == "true" {
+		log.Info("Skipping GKE cluster teardown")
+		return nil
+	}
+
+	if _, ok := os.LookupEnv("IMAGETEST_GKE_CLUSTER"); ok {
+		log.Info("Skipping cluster teardown for existing cluster")
+		return nil
+	}
+
+	return k.deleteCluster(ctx)
 }
 
 func (k *driver) Run(ctx context.Context, ref name.Reference) (*drivers.RunResult, error) {

--- a/internal/drivers/gke/driver.go
+++ b/internal/drivers/gke/driver.go
@@ -65,8 +65,10 @@ type driver struct {
 }
 
 type Options struct {
-	// REQUIRED. GCP project ID.
-	ProjectID string
+	// GCP project ID. If empty, falls back to the GOOGLE_CLOUD_PROJECT
+	// environment variable, then the deprecated GOOGLE_PROJECT_ID env var.
+	// Required after the fallback chain.
+	Project string
 	// Regional cluster location (e.g., "us-central1"). Mutually exclusive with Zone.
 	Region string
 	// Zonal cluster location (e.g., "us-central1-a"). Mutually exclusive with Region.
@@ -109,7 +111,6 @@ func NewDriver(name string, opts Options) (drivers.Tester, error) {
 	k := &driver{
 		name:              name,
 		stack:             harness.NewStack(),
-		projectID:         opts.ProjectID,
 		region:            opts.Region,
 		zone:              opts.Zone,
 		clusterName:       opts.ClusterName,
@@ -121,13 +122,10 @@ func NewDriver(name string, opts Options) (drivers.Tester, error) {
 		tags:              opts.Tags,
 	}
 
-	// Validate project ID
+	// Resolve project ID: explicit Terraform value first, then env-var fallbacks.
+	k.projectID = resolveProjectID(context.Background(), opts.Project)
 	if k.projectID == "" {
-		if v, ok := os.LookupEnv("GOOGLE_PROJECT_ID"); ok {
-			k.projectID = v
-		} else {
-			return nil, fmt.Errorf("no GCP project ID specified (set project_id or GOOGLE_PROJECT_ID)")
-		}
+		return nil, fmt.Errorf("no GCP project ID specified: set the `project` field in Terraform, or GOOGLE_CLOUD_PROJECT in the environment")
 	}
 
 	// Validate location (must specify either region or zone, not both)
@@ -561,6 +559,36 @@ func (k *driver) buildLabels() map[string]string {
 		labels[sanitizeGCPLabel(tagK)] = sanitizeGCPLabel(tagV)
 	}
 	return labels
+}
+
+// resolveProjectID returns the GCP project ID, preferring the explicit value
+// from the Terraform configuration, then falling back through the canonical
+// GCP environment variables. Returns the empty string if no source is set;
+// callers should surface a clear error when the result is empty.
+//
+// Resolution order:
+//  1. explicit (the Terraform schema's `project` attribute, if set)
+//  2. GOOGLE_CLOUD_PROJECT — the canonical project-ID env var used by the
+//     official Go client libraries
+//     (cloud.google.com/go/auth/internal/internal.go: projectEnvVar)
+//  3. GOOGLE_PROJECT_ID — historical, non-standard, kept as a deprecated
+//     fallback to avoid breaking existing smoke-test setups; emits a warning
+//     when used
+//
+// Whitespace is trimmed at every source so that values like
+// "$(cat /tmp/proj)" with trailing newlines work correctly.
+func resolveProjectID(ctx context.Context, explicit string) string {
+	if v := strings.TrimSpace(explicit); v != "" {
+		return v
+	}
+	if v := strings.TrimSpace(os.Getenv("GOOGLE_CLOUD_PROJECT")); v != "" {
+		return v
+	}
+	if v := strings.TrimSpace(os.Getenv("GOOGLE_PROJECT_ID")); v != "" {
+		clog.FromContext(ctx).Warn("GOOGLE_PROJECT_ID is deprecated; use GOOGLE_CLOUD_PROJECT instead")
+		return v
+	}
+	return ""
 }
 
 // sanitizeGCPLabel sanitizes a string to be a valid GCP resource label key or

--- a/internal/drivers/gke/driver.go
+++ b/internal/drivers/gke/driver.go
@@ -554,11 +554,40 @@ func (k *driver) getParent() string {
 func (k *driver) buildLabels() map[string]string {
 	labels := map[string]string{
 		"imagetest":              "true",
-		"imagetest-test-name":    k.name,
-		"imagetest-cluster-name": k.clusterName,
+		"imagetest-test-name":    sanitizeGCPLabel(k.name),
+		"imagetest-cluster-name": sanitizeGCPLabel(k.clusterName),
 	}
-	for k, v := range k.tags {
-		labels[k] = v
+	for tagK, tagV := range k.tags {
+		labels[sanitizeGCPLabel(tagK)] = sanitizeGCPLabel(tagV)
 	}
 	return labels
+}
+
+// sanitizeGCPLabel sanitizes a string to be a valid GCP resource label key or
+// value. GCP labels allow lowercase letters, digits, underscores, and dashes;
+// max length is 63 characters. Invalid characters are replaced with a dash so
+// that semantically distinct inputs (e.g. "image:test/foo") don't collapse to
+// the same sanitized output. GCP additionally requires keys to begin with a
+// lowercase letter — that constraint is intentionally not enforced here, since
+// rewriting a user-provided key (e.g. by prefixing a letter) could cause
+// collisions; callers are expected to provide keys that already start with a
+// letter, and GCP will reject keys that don't.
+//
+// Reference: https://cloud.google.com/compute/docs/labeling-resources
+func sanitizeGCPLabel(s string) string {
+	s = strings.ToLower(s)
+	s = strings.Map(func(r rune) rune {
+		if r >= 'a' && r <= 'z' || r >= '0' && r <= '9' {
+			return r
+		}
+		switch r {
+		case '_', '-':
+			return r
+		}
+		return '-'
+	}, s)
+	if len(s) > 63 {
+		s = s[:63]
+	}
+	return s
 }

--- a/internal/drivers/gke/driver_test.go
+++ b/internal/drivers/gke/driver_test.go
@@ -1,0 +1,74 @@
+package gke
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSanitizeGCPLabel(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "valid string unchanged",
+			input: "hello-world",
+			want:  "hello-world",
+		},
+		{
+			name:  "uppercase converted to lowercase",
+			input: "Hello-World",
+			want:  "hello-world",
+		},
+		{
+			name:  "colons replaced with dashes",
+			input: "imagetest:test-name",
+			want:  "imagetest-test-name",
+		},
+		{
+			name:  "spaces replaced with dashes",
+			input: "my test name",
+			want:  "my-test-name",
+		},
+		{
+			name:  "truncated to 63 characters",
+			input: strings.Repeat("a", 100),
+			want:  strings.Repeat("a", 63),
+		},
+		{
+			name:  "special characters replaced with dashes",
+			input: "test[bot].foo@bar",
+			want:  "test-bot--foo-bar",
+		},
+		{
+			name:  "underscores preserved",
+			input: "my_test_name",
+			want:  "my_test_name",
+		},
+		{
+			name:  "digits preserved",
+			input: "test123",
+			want:  "test123",
+		},
+		{
+			name:  "digit leading character allowed (gcp key rule not enforced)",
+			input: "1abc",
+			want:  "1abc",
+		},
+		{
+			name:  "empty string",
+			input: "",
+			want:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := sanitizeGCPLabel(tt.input)
+			if got != tt.want {
+				t.Errorf("sanitizeGCPLabel(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/drivers/gke/driver_test.go
+++ b/internal/drivers/gke/driver_test.go
@@ -1,9 +1,14 @@
 package gke
 
 import (
+	"bytes"
+	"context"
+	"log/slog"
 	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/chainguard-dev/clog"
 )
 
 func TestSanitizeGCPLabel(t *testing.T) {
@@ -181,6 +186,89 @@ func TestBuildLabels(t *testing.T) {
 			got := k.buildLabels()
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("buildLabels() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestResolveProjectID exercises resolveProjectID — the project-ID resolver
+// for the GKE driver. Locks in the precedence between the explicit Terraform
+// value and the canonical GCP env vars, the deprecation warning for
+// GOOGLE_PROJECT_ID, and whitespace trimming. Uses t.Setenv for hermetic
+// env-var manipulation and a clog-bound bytes.Buffer to assert on the warning.
+func TestResolveProjectID(t *testing.T) {
+	const deprecationFragment = "GOOGLE_PROJECT_ID is deprecated"
+
+	tests := []struct {
+		name        string
+		explicit    string
+		envVars     map[string]string
+		want        string
+		wantWarning bool
+	}{
+		{
+			name:     "explicit Terraform value wins over all env vars",
+			explicit: "explicit",
+			envVars: map[string]string{
+				"GOOGLE_CLOUD_PROJECT": "primary",
+				"GOOGLE_PROJECT_ID":    "deprecated",
+			},
+			want: "explicit",
+		},
+		{
+			name:    "primary env var used",
+			envVars: map[string]string{"GOOGLE_CLOUD_PROJECT": "primary"},
+			want:    "primary",
+		},
+		{
+			name:        "deprecated env var fallback fires warning",
+			envVars:     map[string]string{"GOOGLE_PROJECT_ID": "deprecated"},
+			want:        "deprecated",
+			wantWarning: true,
+		},
+		{
+			name: "primary wins when both env vars set, no warning",
+			envVars: map[string]string{
+				"GOOGLE_CLOUD_PROJECT": "primary",
+				"GOOGLE_PROJECT_ID":    "deprecated",
+			},
+			want: "primary",
+		},
+		{
+			name: "all sources unset returns empty",
+			want: "",
+		},
+		{
+			name:     "whitespace trimmed from explicit value",
+			explicit: "  ws-proj  ",
+			want:     "ws-proj",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Clear all three env vars first so leakage from the host environment
+			// or earlier subtests can't influence the result. t.Setenv restores
+			// the original values after the test.
+			for _, k := range []string{"GOOGLE_CLOUD_PROJECT", "GOOGLE_PROJECT_ID"} {
+				t.Setenv(k, "")
+			}
+			for k, v := range tt.envVars {
+				t.Setenv(k, v)
+			}
+
+			// Bind a buffered logger to the context so we can assert on warnings.
+			buf := &bytes.Buffer{}
+			ctx := clog.WithLogger(context.Background(), clog.New(slog.NewTextHandler(buf, nil)))
+
+			got := resolveProjectID(ctx, tt.explicit)
+			if got != tt.want {
+				t.Errorf("resolveProjectID(_, %q) = %q, want %q", tt.explicit, got, tt.want)
+			}
+
+			gotWarning := strings.Contains(buf.String(), deprecationFragment)
+			if gotWarning != tt.wantWarning {
+				t.Errorf("warning fired = %v, want %v\nlog output: %q", gotWarning, tt.wantWarning, buf.String())
 			}
 		})
 	}

--- a/internal/drivers/gke/driver_test.go
+++ b/internal/drivers/gke/driver_test.go
@@ -1,6 +1,7 @@
 package gke
 
 import (
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -68,6 +69,118 @@ func TestSanitizeGCPLabel(t *testing.T) {
 			got := sanitizeGCPLabel(tt.input)
 			if got != tt.want {
 				t.Errorf("sanitizeGCPLabel(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestBuildLabels exercises (*driver).buildLabels, which composes the GKE
+// resource labels by merging reserved imagetest labels with user-provided tags
+// and passing dynamic inputs through sanitizeGCPLabel. This locks in the
+// label-merging semantics — including the collision behavior between a user
+// tag and a reserved key — so future changes to buildLabels can't silently
+// regress them.
+func TestBuildLabels(t *testing.T) {
+	tests := []struct {
+		name        string
+		driverName  string
+		clusterName string
+		tags        map[string]string
+		want        map[string]string
+	}{
+		{
+			name:        "reserved labels only with nil tags",
+			driverName:  "my-test",
+			clusterName: "cluster-1",
+			tags:        nil,
+			want: map[string]string{
+				"imagetest":              "true",
+				"imagetest-test-name":    "my-test",
+				"imagetest-cluster-name": "cluster-1",
+			},
+		},
+		{
+			name:        "reserved labels only with empty tags map",
+			driverName:  "my-test",
+			clusterName: "cluster-1",
+			tags:        map[string]string{},
+			want: map[string]string{
+				"imagetest":              "true",
+				"imagetest-test-name":    "my-test",
+				"imagetest-cluster-name": "cluster-1",
+			},
+		},
+		{
+			name:        "reserved labels merged with clean user tags",
+			driverName:  "my-test",
+			clusterName: "cluster-1",
+			tags: map[string]string{
+				"team": "platform",
+			},
+			want: map[string]string{
+				"imagetest":              "true",
+				"imagetest-test-name":    "my-test",
+				"imagetest-cluster-name": "cluster-1",
+				"team":                   "platform",
+			},
+		},
+		{
+			name:        "user tag key and value sanitized through merge",
+			driverName:  "my-test",
+			clusterName: "cluster-1",
+			tags: map[string]string{
+				"Team Name": "Platform Eng",
+			},
+			want: map[string]string{
+				"imagetest":              "true",
+				"imagetest-test-name":    "my-test",
+				"imagetest-cluster-name": "cluster-1",
+				"team-name":              "platform-eng",
+			},
+		},
+		{
+			// Reserved labels are written into the map first, then user tags
+			// are merged in via the range loop — so a user tag whose sanitized
+			// key collides with a reserved key overwrites the reserved value.
+			// This is documented current behavior, not necessarily desired:
+			// changing it (e.g. to make reserved keys take priority, or to
+			// reject colliding user keys) is a separate decision. This test
+			// pins the behavior so any future change is explicit.
+			name:        "user tag collides with reserved key — user value wins",
+			driverName:  "my-test",
+			clusterName: "cluster-1",
+			tags: map[string]string{
+				"imagetest": "false",
+			},
+			want: map[string]string{
+				"imagetest":              "false",
+				"imagetest-test-name":    "my-test",
+				"imagetest-cluster-name": "cluster-1",
+			},
+		},
+		{
+			name:        "dynamic name and clusterName sanitized",
+			driverName:  "My Test [Bot]",
+			clusterName: "Cluster 1",
+			tags:        nil,
+			want: map[string]string{
+				"imagetest":              "true",
+				"imagetest-test-name":    "my-test--bot-",
+				"imagetest-cluster-name": "cluster-1",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			k := &driver{
+				name:        tt.driverName,
+				clusterName: tt.clusterName,
+				tags:        tt.tags,
+			}
+			got := k.buildLabels()
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("buildLabels() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/internal/drivers/pod/pod.go
+++ b/internal/drivers/pod/pod.go
@@ -411,7 +411,7 @@ func startLogStream(ctx context.Context, cli kubernetes.Interface, pod *corev1.P
 	var logs io.ReadCloser
 	var err error
 	maxRetries := 5
-	for i := 0; i < maxRetries; i++ {
+	for i := range maxRetries {
 		logs, err = lreq.Stream(ctx)
 		if err == nil {
 			break

--- a/internal/drivers/pod/pod.go
+++ b/internal/drivers/pod/pod.go
@@ -627,11 +627,18 @@ func (o *opts) pod() *corev1.Pod {
 
 	// If DockerConfig is provided, create a secret volume and mount it to ~/.docker/config.json
 	if o.DockerConfig != nil {
+		secretName := fmt.Sprintf("%s-docker-config", o.Name)
+
+		// Add imagePullSecret so Kubernetes can pull the pod images
+		pod.Spec.ImagePullSecrets = append(pod.Spec.ImagePullSecrets, corev1.LocalObjectReference{
+			Name: secretName,
+		})
+
 		dockerConfigVolume := corev1.Volume{
 			Name: "docker-config",
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
-					SecretName: fmt.Sprintf("%s-docker-config", o.Name),
+					SecretName: secretName,
 					Items: []corev1.KeyToPath{
 						{
 							Key:  ".dockerconfigjson",

--- a/internal/drivers/pod/pod.go
+++ b/internal/drivers/pod/pod.go
@@ -266,10 +266,22 @@ func monitor(ctx context.Context, cli kubernetes.Interface, pod *corev1.Pod) err
 			}
 
 			if !logStarted && p.Status.Phase == corev1.PodRunning {
-				logStarted = true
-				trace.SpanFromContext(ctx).AddEvent("pod.running")
-				clog.InfoContext(ctx, "starting log stream")
-				logch = startLogStream(ctx, cli, pod)
+				// Wait for at least one container to be ready before streaming logs
+				// to avoid "No agent available" errors when kubelet isn't ready yet
+				containerReady := false
+				for _, cs := range p.Status.ContainerStatuses {
+					if cs.Ready {
+						containerReady = true
+						break
+					}
+				}
+
+				if containerReady {
+					logStarted = true
+					trace.SpanFromContext(ctx).AddEvent("pod.running")
+					clog.InfoContext(ctx, "starting log stream")
+					logch = startLogStream(ctx, cli, pod)
+				}
 			}
 
 			if w.Type == watch.Deleted {
@@ -395,9 +407,34 @@ func startLogStream(ctx context.Context, cli kubernetes.Interface, pod *corev1.P
 		Container: SandboxContainerName,
 	})
 
-	logs, err := lreq.Stream(ctx)
-	if err != nil {
+	// Retry log streaming with exponential backoff to handle GKE kubelet startup delays
+	var logs io.ReadCloser
+	var err error
+	maxRetries := 5
+	for i := 0; i < maxRetries; i++ {
+		logs, err = lreq.Stream(ctx)
+		if err == nil {
+			break
+		}
+
+		// Check if error is about kubelet not being available
+		if strings.Contains(err.Error(), "No agent available") || strings.Contains(err.Error(), "connection refused") {
+			if i < maxRetries-1 {
+				backoff := time.Duration(i+1) * time.Second
+				clog.InfoContext(ctx, "kubelet not ready, retrying log stream", "attempt", i+1, "backoff", backoff)
+				time.Sleep(backoff)
+				continue
+			}
+		}
+
+		// Non-retriable error or max retries reached
 		errch <- fmt.Errorf("failed to initiate pod log stream: %w", err)
+		close(errch)
+		return errch
+	}
+
+	if err != nil {
+		errch <- fmt.Errorf("failed to initiate pod log stream after %d retries: %w", maxRetries, err)
 		close(errch)
 		return errch
 	}

--- a/internal/harness/harness.go
+++ b/internal/harness/harness.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"slices"
 	"strings"
 	"sync"
 )
@@ -116,12 +117,12 @@ func (r *Stack) Teardown(ctx context.Context) error {
 	}
 
 	var errs []error
-	for i := len(r.stack) - 1; i >= 0; i-- {
+	for _, fn := range slices.Backward(r.stack) {
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
 		default:
-			if err := r.stack[i](ctx); err != nil {
+			if err := fn(ctx); err != nil {
 				errs = append(errs, err)
 			}
 		}

--- a/internal/provider/drivers.go
+++ b/internal/provider/drivers.go
@@ -88,7 +88,7 @@ type AKSAttachedACR struct {
 }
 
 type GKEDriverResourceModel struct {
-	ProjectID         types.String      `tfsdk:"project_id"`
+	Project           types.String      `tfsdk:"project"`
 	Region            types.String      `tfsdk:"region"`
 	Zone              types.String      `tfsdk:"zone"`
 	ClusterName       types.String      `tfsdk:"cluster_name"`
@@ -358,7 +358,7 @@ func (t TestsResource) LoadDriver(ctx context.Context, data *TestsResourceModel)
 		}
 
 		return gke.NewDriver(id, gke.Options{
-			ProjectID:         cfg.ProjectID.ValueString(),
+			Project:           cfg.Project.ValueString(),
 			Region:            cfg.Region.ValueString(),
 			Zone:              cfg.Zone.ValueString(),
 			ClusterName:       cfg.ClusterName.ValueString(),
@@ -838,8 +838,8 @@ func DriverResourceSchema(ctx context.Context) schema.SingleNestedAttribute {
 				Description: "The GKE driver",
 				Optional:    true,
 				Attributes: map[string]schema.Attribute{
-					"project_id": schema.StringAttribute{
-						Description: "The GCP project ID. Defaults to GOOGLE_PROJECT_ID environment variable.",
+					"project": schema.StringAttribute{
+						Description: "The GCP project ID. Falls back to the GOOGLE_CLOUD_PROJECT environment variable, then the deprecated GOOGLE_PROJECT_ID env var.",
 						Optional:    true,
 					},
 					"region": schema.StringAttribute{

--- a/internal/provider/drivers.go
+++ b/internal/provider/drivers.go
@@ -18,6 +18,7 @@ import (
 	dockerindocker "github.com/chainguard-dev/terraform-provider-imagetest/internal/drivers/docker_in_docker"
 	mc2 "github.com/chainguard-dev/terraform-provider-imagetest/internal/drivers/ec2"
 	ekswitheksctl "github.com/chainguard-dev/terraform-provider-imagetest/internal/drivers/eks_with_eksctl"
+	"github.com/chainguard-dev/terraform-provider-imagetest/internal/drivers/gke"
 	k3sindocker "github.com/chainguard-dev/terraform-provider-imagetest/internal/drivers/k3s_in_docker"
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
@@ -29,6 +30,7 @@ type DriverResourceModel string
 
 const (
 	DriverAKS            DriverResourceModel = "aks"
+	DriverGKE            DriverResourceModel = "gke"
 	DriverK3sInDocker    DriverResourceModel = "k3s_in_docker"
 	DriverDockerInDocker DriverResourceModel = "docker_in_docker"
 	DriverEKSWithEksctl  DriverResourceModel = "eks_with_eksctl"
@@ -37,6 +39,7 @@ const (
 
 type TestsDriversResourceModel struct {
 	AKS            *AKSDriverResourceModel            `tfsdk:"aks"`
+	GKE            *GKEDriverResourceModel            `tfsdk:"gke"`
 	K3sInDocker    *K3sInDockerDriverResourceModel    `tfsdk:"k3s_in_docker"`
 	DockerInDocker *DockerInDockerDriverResourceModel `tfsdk:"docker_in_docker"`
 	EKSWithEksctl  *EKSWithEksctlDriverResourceModel  `tfsdk:"eks_with_eksctl"`
@@ -82,6 +85,19 @@ type AKSAttachedACR struct {
 	ResourceGroup   types.String `tfsdk:"resource_group"`
 	Name            types.String `tfsdk:"name"`
 	CreateIfMissing types.Bool   `tfsdk:"create_if_missing"`
+}
+
+type GKEDriverResourceModel struct {
+	ProjectID         types.String      `tfsdk:"project_id"`
+	Region            types.String      `tfsdk:"region"`
+	Zone              types.String      `tfsdk:"zone"`
+	ClusterName       types.String      `tfsdk:"cluster_name"`
+	NodeCount         types.Int32       `tfsdk:"node_count"`
+	MachineType       types.String      `tfsdk:"machine_type"`
+	DiskSizeGB        types.Int32       `tfsdk:"disk_size_gb"`
+	DiskType          types.String      `tfsdk:"disk_type"`
+	KubernetesVersion types.String      `tfsdk:"kubernetes_version"`
+	Tags              map[string]string `tfsdk:"tags"`
 }
 
 type K3sInDockerDriverResourceModel struct {
@@ -311,6 +327,49 @@ func (t TestsResource) LoadDriver(ctx context.Context, data *TestsResourceModel)
 			PodIdentityAssociations:     podIdentityAssociations,
 			ClusterIdentityAssociations: clusterIdentityAssociations,
 			AttachedACRs:                attachedACRs,
+		})
+
+	case DriverGKE:
+		cfg := driversCfg.GKE
+		if cfg == nil {
+			cfg = &GKEDriverResourceModel{}
+		}
+
+		// Build registry auth config from the resolved repo
+		registries := make(map[string]*gke.RegistryConfig)
+		r, err := name.NewRegistry(repo.RegistryStr())
+		if err != nil {
+			return nil, fmt.Errorf("invalid registry name %s: %w", repo.RegistryStr(), err)
+		}
+		a, err := authn.DefaultKeychain.Resolve(r)
+		if err != nil {
+			return nil, fmt.Errorf("resolving keychain for registry %s: %w", r.String(), err)
+		}
+		acfg, err := a.Authorization()
+		if err != nil {
+			return nil, fmt.Errorf("getting authorization for registry %s: %w", r.String(), err)
+		}
+		registries[repo.RegistryStr()] = &gke.RegistryConfig{
+			Auth: &gke.RegistryAuthConfig{
+				Username: acfg.Username,
+				Password: acfg.Password,
+				Auth:     acfg.Auth,
+			},
+		}
+
+		return gke.NewDriver(id, gke.Options{
+			ProjectID:         cfg.ProjectID.ValueString(),
+			Region:            cfg.Region.ValueString(),
+			Zone:              cfg.Zone.ValueString(),
+			ClusterName:       cfg.ClusterName.ValueString(),
+			NodeCount:         cfg.NodeCount.ValueInt32(),
+			MachineType:       cfg.MachineType.ValueString(),
+			DiskSizeGB:        cfg.DiskSizeGB.ValueInt32(),
+			DiskType:          cfg.DiskType.ValueString(),
+			KubernetesVersion: cfg.KubernetesVersion.ValueString(),
+			Timeout:           timeout,
+			Tags:              cfg.Tags,
+			Registries:        registries,
 		})
 
 	case DriverK3sInDocker:
@@ -773,6 +832,53 @@ func DriverResourceSchema(ctx context.Context) schema.SingleNestedAttribute {
 						},
 					},
 					"timeouts": driverTimeoutsSchema(),
+				},
+			},
+			"gke": schema.SingleNestedAttribute{
+				Description: "The GKE driver",
+				Optional:    true,
+				Attributes: map[string]schema.Attribute{
+					"project_id": schema.StringAttribute{
+						Description: "The GCP project ID. Defaults to GOOGLE_PROJECT_ID environment variable.",
+						Optional:    true,
+					},
+					"region": schema.StringAttribute{
+						Description: "The GCP region for a regional cluster (e.g., 'us-central1'). Mutually exclusive with zone. Defaults to 'us-central1'.",
+						Optional:    true,
+					},
+					"zone": schema.StringAttribute{
+						Description: "The GCP zone for a zonal cluster (e.g., 'us-central1-a'). Mutually exclusive with region.",
+						Optional:    true,
+					},
+					"cluster_name": schema.StringAttribute{
+						Description: "The GKE cluster name. Auto-generated if not specified.",
+						Optional:    true,
+					},
+					"node_count": schema.Int32Attribute{
+						Description: "The number of nodes (default: 1)",
+						Optional:    true,
+					},
+					"machine_type": schema.StringAttribute{
+						Description: "The GCE machine type (default: 'e2-standard-4')",
+						Optional:    true,
+					},
+					"disk_size_gb": schema.Int32Attribute{
+						Description: "Boot disk size in GB (default: 100)",
+						Optional:    true,
+					},
+					"disk_type": schema.StringAttribute{
+						Description: "Boot disk type: 'pd-standard', 'pd-ssd', or 'pd-balanced' (default: 'pd-standard')",
+						Optional:    true,
+					},
+					"kubernetes_version": schema.StringAttribute{
+						Description: "Kubernetes version. Uses GKE default if unspecified.",
+						Optional:    true,
+					},
+					"tags": schema.MapAttribute{
+						Description: "Resource labels to apply to the cluster. Auto-generated labels (imagetest, imagetest-test-name, imagetest-cluster-name) are always included.",
+						ElementType: types.StringType,
+						Optional:    true,
+					},
 				},
 			},
 			"k3s_in_docker": schema.SingleNestedAttribute{

--- a/internal/provider/tests_resource_gke_test.go
+++ b/internal/provider/tests_resource_gke_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestAccTestsResource_GKE(t *testing.T) {
-	projectID := os.Getenv("IMAGETEST_GKE_PROJECT_ID")
+	projectID := os.Getenv("IMAGETEST_GKE_PROJECT")
 	region := os.Getenv("IMAGETEST_GKE_REGION")
 	if region == "" {
 		region = "us-central1"
@@ -29,7 +29,7 @@ resource "imagetest_tests" "foo" {
 
   drivers = {
     gke = {
-      project_id = %q
+      project    = %q
       region     = %q
     }
   }
@@ -58,7 +58,7 @@ resource "imagetest_tests" "foo_custom" {
 
   drivers = {
     gke = {
-      project_id   = %q
+      project      = %q
       region       = %q
       node_count   = 2
       machine_type = "n1-standard-4"
@@ -96,7 +96,7 @@ resource "imagetest_tests" "foo_zonal" {
 
   drivers = {
     gke = {
-      project_id = %q
+      project    = %q
       zone       = %q
     }
   }
@@ -121,7 +121,7 @@ resource "imagetest_tests" "foo_zonal" {
 		PreCheck: func() {
 			testAccPreCheck(t)
 			if projectID == "" {
-				t.Fatal("IMAGETEST_GKE_PROJECT_ID must be set for acceptance tests")
+				t.Fatal("IMAGETEST_GKE_PROJECT must be set for acceptance tests")
 			}
 		},
 		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){

--- a/internal/provider/tests_resource_gke_test.go
+++ b/internal/provider/tests_resource_gke_test.go
@@ -1,0 +1,138 @@
+//go:build gke
+
+package provider
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/providerserver"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccTestsResource_GKE(t *testing.T) {
+	projectID := os.Getenv("IMAGETEST_GKE_PROJECT_ID")
+	region := os.Getenv("IMAGETEST_GKE_REGION")
+	if region == "" {
+		region = "us-central1"
+	}
+
+	repo := "ttl.sh/imagetest" // TODO: Don't push to ttl.sh
+
+	// Test 1: Basic cluster creation
+	tf := fmt.Sprintf(`
+resource "imagetest_tests" "foo" {
+  name   = "foo"
+  driver = "gke"
+
+  drivers = {
+    gke = {
+      project_id = %q
+      region     = %q
+    }
+  }
+
+  images = {
+    foo = "cgr.dev/chainguard/busybox:latest@sha256:c546e746013d75c1fc9bf01b7a645ce7caa1ec46c45cb618c6e28d7b57bccc85"
+  }
+
+  tests = [
+    {
+      name    = "basic"
+      image   = "cgr.dev/chainguard/busybox:latest@sha256:ecc152fe3dece44e60d1aa0fbbefb624902b4af0e2ed8c2c84dfbce653ff064f"
+      cmd     = "echo success"
+    }
+  ]
+
+  timeout = "45m"
+}
+`, projectID, region)
+
+	// Test 2: Custom node configuration
+	tfWithCustomNodes := fmt.Sprintf(`
+resource "imagetest_tests" "foo_custom" {
+  name   = "foo-custom"
+  driver = "gke"
+
+  drivers = {
+    gke = {
+      project_id   = %q
+      region       = %q
+      node_count   = 2
+      machine_type = "n1-standard-4"
+      disk_size_gb = 150
+      disk_type    = "pd-ssd"
+      tags = {
+        "team"        = "platform"
+        "environment" = "test"
+      }
+    }
+  }
+
+  images = {
+    foo = "cgr.dev/chainguard/busybox:latest@sha256:c546e746013d75c1fc9bf01b7a645ce7caa1ec46c45cb618c6e28d7b57bccc85"
+  }
+
+  tests = [
+    {
+      name    = "basic"
+      image   = "cgr.dev/chainguard/busybox:latest@sha256:ecc152fe3dece44e60d1aa0fbbefb624902b4af0e2ed8c2c84dfbce653ff064f"
+      cmd     = "echo success"
+    }
+  ]
+
+  timeout = "45m"
+}
+`, projectID, region)
+
+	// Test 3: Zonal cluster
+	zone := region + "-a"
+	tfZonal := fmt.Sprintf(`
+resource "imagetest_tests" "foo_zonal" {
+  name   = "foo-zonal"
+  driver = "gke"
+
+  drivers = {
+    gke = {
+      project_id = %q
+      zone       = %q
+    }
+  }
+
+  images = {
+    foo = "cgr.dev/chainguard/busybox:latest@sha256:c546e746013d75c1fc9bf01b7a645ce7caa1ec46c45cb618c6e28d7b57bccc85"
+  }
+
+  tests = [
+    {
+      name    = "basic"
+      image   = "cgr.dev/chainguard/kubectl:latest-dev@sha256:1d8c1f0c437628aafa1bca52c41ff310aea449423cce9b2feae2767ac53c336f"
+      cmd     = "kubectl get nodes"
+    }
+  ]
+
+  timeout = "45m"
+}
+`, projectID, zone)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			if projectID == "" {
+				t.Fatal("IMAGETEST_GKE_PROJECT_ID must be set for acceptance tests")
+			}
+		},
+		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
+			"imagetest": providerserver.NewProtocol6WithError(&ImageTestProvider{
+				repo: repo,
+			}),
+		},
+		Steps: []resource.TestStep{
+			{Config: tf},
+			{Config: tfWithCustomNodes},
+			{Config: tfZonal},
+		},
+	})
+}


### PR DESCRIPTION
## Summary

Collaborative effort: built from @srishtih's original [draft PR](https://github.com/srishtih/terraform-provider-imagetest/pull/1)

Adds a GKE driver (modeled on the AKS driver pattern) that allows provisioning a GKE cluster in a given GCP project, enabling container image testing on GKE alongside the existing  AKS / EKS / k3s / docker drivers.
