### PR TITLE
Bump Go to 1.26 and address new lint findings

### DIFF
--- a/cmd/entrypoint/main.go
+++ b/cmd/entrypoint/main.go
@@ -692,28 +692,28 @@ func (p *proxyServer) Start() error {
 
 	logger := slog.New(slog.NewJSONHandler(lf, nil))
 
-	proxy := httputil.NewSingleHostReverseProxy(&url.URL{
+	target := &url.URL{
 		Scheme: "http",
 		Host:   fmt.Sprintf("host.docker.internal:%d", p.port),
-	})
-
-	// Wrap the director with a simple logger
-	odirector := proxy.Director
-	proxy.Director = func(req *http.Request) {
-		odirector(req)
-		logger.Info("request",
-			"method", req.Method,
-			"url", req.URL.String(),
-			"host", req.Host,
-			"remote", req.RemoteAddr)
 	}
-	proxy.ModifyResponse = func(resp *http.Response) error {
-		logger.Info("response",
-			"method", resp.Request.Method,
-			"url", resp.Request.URL.String(),
-			"status", resp.StatusCode,
-			"size", resp.ContentLength)
-		return nil
+
+	proxy := &httputil.ReverseProxy{
+		Rewrite: func(r *httputil.ProxyRequest) {
+			r.SetURL(target)
+			logger.Info("request",
+				"method", r.Out.Method,
+				"url", r.Out.URL.String(),
+				"host", r.Out.Host,
+				"remote", r.In.RemoteAddr)
+		},
+		ModifyResponse: func(resp *http.Response) error {
+			logger.Info("response",
+				"method", resp.Request.Method,
+				"url", resp.Request.URL.String(),
+				"status", resp.StatusCode,
+				"size", resp.ContentLength)
+			return nil
+		},
 	}
 
 	server := &http.Server{

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/chainguard-dev/terraform-provider-imagetest
 
-go 1.25.8
+go 1.26.2
 
 require (
 	chainguard.dev/apko v1.2.9

--- a/internal/drivers/aks/driver.go
+++ b/internal/drivers/aks/driver.go
@@ -523,8 +523,8 @@ func (k *driver) createRoleAssignment(ctx context.Context, scope, principalID, r
 		assignmentName,
 		armauthorization.RoleAssignmentCreateParameters{
 			Properties: &armauthorization.RoleAssignmentProperties{
-				PrincipalID:      to.Ptr(principalID),
-				RoleDefinitionID: to.Ptr(roleDefinitionID),
+				PrincipalID:      new(principalID),
+				RoleDefinitionID: new(roleDefinitionID),
 				PrincipalType:    principalType,
 			},
 		},
@@ -654,7 +654,7 @@ func (k *driver) createPodIdentityAssociation(ctx context.Context) error {
 					Issuer:  &oidcIssuerURL,
 					Subject: &credentialSubject,
 					Audiences: []*string{
-						to.Ptr("api://AzureADTokenExchange"),
+						new("api://AzureADTokenExchange"),
 					},
 				},
 			},
@@ -735,11 +735,11 @@ func (k *driver) enableWorkloadIdenity(ctx context.Context) error {
 		cluster.Properties = &armcontainerservice.ManagedClusterProperties{}
 	}
 	cluster.Properties.OidcIssuerProfile = &armcontainerservice.ManagedClusterOIDCIssuerProfile{
-		Enabled: to.Ptr(true),
+		Enabled: new(true),
 	}
 	cluster.Properties.SecurityProfile = &armcontainerservice.ManagedClusterSecurityProfile{
 		WorkloadIdentity: &armcontainerservice.ManagedClusterSecurityProfileWorkloadIdentity{
-			Enabled: to.Ptr(true),
+			Enabled: new(true),
 		},
 	}
 
@@ -827,12 +827,12 @@ func (k *driver) createACR(ctx context.Context, acr *AttachedACR) (*armcontainer
 		acr.ResourceGroup,
 		acr.Name,
 		armcontainerregistry.Registry{
-			Location: to.Ptr(k.location),
+			Location: new(k.location),
 			SKU: &armcontainerregistry.SKU{
 				Name: to.Ptr(armcontainerregistry.SKUNameBasic),
 			},
 			Properties: &armcontainerregistry.RegistryProperties{
-				AdminUserEnabled: to.Ptr(false),
+				AdminUserEnabled: new(false),
 			},
 		},
 		nil,
@@ -970,7 +970,7 @@ func (k *driver) writeKubeConfig(ctx context.Context) error {
 
 func (k *driver) buildTags() map[string]*string {
 	tags := map[string]*string{
-		"imagetest":              to.Ptr("true"),
+		"imagetest":              new("true"),
 		"imagetest:test-name":    &k.name,
 		"imagetest:cluster-name": &k.clusterName,
 	}

--- a/internal/drivers/pod/pod.go
+++ b/internal/drivers/pod/pod.go
@@ -182,13 +182,13 @@ func (o *opts) preflight(ctx context.Context) error {
 		WithName(o.Name).
 		WithSubjects(&rbacv1apply.SubjectApplyConfiguration{
 			Kind:      ptr.To(rbacv1.ServiceAccountKind),
-			Name:      ptr.To(o.Name),
-			Namespace: ptr.To(o.Namespace),
+			Name:      new(o.Name),
+			Namespace: new(o.Namespace),
 		}).
 		WithRoleRef(&rbacv1apply.RoleRefApplyConfiguration{
 			APIGroup: ptr.To(rbacv1.GroupName),
-			Kind:     ptr.To("ClusterRole"),
-			Name:     ptr.To("cluster-admin"),
+			Kind:     new("ClusterRole"),
+			Name:     new("cluster-admin"),
 		})
 	if _, err := o.client.RbacV1().ClusterRoleBindings().Apply(ctx, crba, metav1.ApplyOptions{
 		FieldManager: "imagetest",
@@ -437,7 +437,7 @@ func maybeLog(ctx context.Context, cli kubernetes.Interface, pod *corev1.Pod) st
 	req := cli.CoreV1().Pods(pod.Namespace).GetLogs(pod.Name, &corev1.PodLogOptions{
 		Container: SandboxContainerName,
 		// limit to 1mb of logs
-		LimitBytes: ptr.To(int64(1024 * 1024)),
+		LimitBytes: new(int64(1024 * 1024)),
 	})
 
 	rc, err := req.Stream(ctx)
@@ -477,7 +477,7 @@ func (o *opts) pod() *corev1.Pod {
 		},
 		Spec: corev1.PodSpec{
 			ServiceAccountName:           o.Name,
-			AutomountServiceAccountToken: ptr.To(false),
+			AutomountServiceAccountToken: new(false),
 			SecurityContext:              &corev1.PodSecurityContext{},
 			RestartPolicy:                corev1.RestartPolicyNever,
 			Volumes: []corev1.Volume{


### PR DESCRIPTION
Updates the toolchain to Go 1.26.2. Two changes were needed to keep golangci-lint clean against the new release: switch the entrypoint reverse proxy from the now-deprecated httputil.ReverseProxy.Director to Rewrite, and convert the to.Ptr / ptr.To call sites that modernize flagged into Go 1.26's new(expr) builtin.
