### PR TITLE
Surface k3s logs when readiness wait times out

### DIFF
--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -694,6 +694,26 @@ func (r *Response) ReadFile(ctx context.Context, path string) ([]byte, error) {
 	return data, nil
 }
 
+// Logs returns the combined stdout and stderr captured from the container
+// since it started.
+func (r *Response) Logs(ctx context.Context) (string, error) {
+	rdr, err := r.cli.inner.ContainerLogs(ctx, r.ID, container.LogsOptions{
+		ShowStdout: true,
+		ShowStderr: true,
+		Tail:       "all",
+	})
+	if err != nil {
+		return "", fmt.Errorf("getting container logs: %w", err)
+	}
+	defer rdr.Close()
+
+	var buf bytes.Buffer
+	if _, err := stdcopy.StdCopy(&buf, &buf, rdr); err != nil {
+		return "", fmt.Errorf("reading container logs: %w", err)
+	}
+	return buf.String(), nil
+}
+
 func (d *Client) withDefaultLabels(labels map[string]string) map[string]string {
 	l := map[string]string{
 		"dev.chainguard.imagetest": "true",

--- a/internal/drivers/k3s_in_docker/driver.go
+++ b/internal/drivers/k3s_in_docker/driver.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"text/template"
 	"time"
 
@@ -290,7 +291,16 @@ configs:
 	}
 
 	if err := k.waitReady(ctx); err != nil {
-		return fmt.Errorf("waiting for k3s to be ready: %w", err)
+		logCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
+		defer cancel()
+		logs, logErr := resp.Logs(logCtx)
+		if logErr != nil {
+			logs = fmt.Sprintf("(unavailable: %v)", logErr)
+		}
+		if !strings.HasSuffix(logs, "\n") {
+			logs += "\n"
+		}
+		return fmt.Errorf("waiting for k3s to be ready: %w\n--- k3s container logs ---\n%s--- end k3s container logs ---", err, logs)
 	}
 	trace.SpanFromContext(ctx).AddEvent("k3s.cluster.ready")
 
@@ -364,13 +374,23 @@ func (k *driver) Run(ctx context.Context, ref name.Reference) (*drivers.RunResul
 // bare requirements for scheduling a workload are. We don't want to wait for
 // "kube-system" to be ready, because that typically takes too long, and isn't
 // actually required to start scheduling pods.
+//
+// On timeout, the returned error wraps the most recent error from the API
+// server poll, since "context deadline exceeded" alone says nothing about why
+// the cluster never became ready.
 func (k *driver) waitReady(ctx context.Context) error {
-	return wait.PollUntilContextCancel(ctx, 1*time.Second, true, func(ctx context.Context) (bool, error) {
+	var lastErr error
+	pollErr := wait.PollUntilContextCancel(ctx, 1*time.Second, true, func(ctx context.Context) (bool, error) {
 		_, err := k.kcli.CoreV1().ServiceAccounts("default").Get(ctx, "default", metav1.GetOptions{})
 		if err != nil {
+			lastErr = err
 			clog.DebugContext(ctx, "waiting for default service account", "error", err)
 			return false, nil
 		}
 		return true, nil
 	})
+	if pollErr != nil && lastErr != nil {
+		return fmt.Errorf("%w (last poll error: %v)", pollErr, lastErr)
+	}
+	return pollErr
 }


### PR DESCRIPTION
The k3s_in_docker driver's readiness wait previously failed with just "waiting for k3s to be ready: context deadline exceeded", which surfaces as a Terraform diagnostic with no further information — leaving the user nothing to debug a hang that took 30 minutes to detect. Capture the last poll error from the Kubernetes client and append a tail of the k3s container logs to the returned error, so the diagnostic actually identifies which subsystem (apiserver, controller-manager, kubelet) failed. The log fetch runs on a context detached from the parent so it still completes after the wait's deadline expires.
