### PR TITLE
entrypoint: don't signal failure before on_failure runs

### DIFF
--- a/cmd/entrypoint/main.go
+++ b/cmd/entrypoint/main.go
@@ -114,8 +114,6 @@ func main() {
 			os.Exit(entrypoint.ProcessPausedWithErrorCode)
 		case healthPaused:
 			os.Exit(entrypoint.ProcessPausedCode)
-		case healthFailed:
-			os.Exit(entrypoint.InternalErrorCode)
 		}
 
 		os.Exit(0)
@@ -199,7 +197,6 @@ func (o *opts) Run(ctx context.Context) int {
 	code, err := o.executeProcess(ctx)
 	if err != nil {
 		clog.ErrorContextf(ctx, "wrapped process exited with exit code %d", code)
-		o.healthStatus.update(healthFailed, err.Error(), int64(code))
 	}
 
 	return o.finalize(ctx, code, err)
@@ -601,7 +598,6 @@ const (
 	healthRunning         healthState = "running"
 	healthPaused          healthState = "paused"
 	healthPausedWithError healthState = "paused_with_error"
-	healthFailed          healthState = "failed"
 )
 
 type healthStatus struct {


### PR DESCRIPTION
The entrypoint marked the health socket as healthFailed as soon as the wrapped process exited non-zero, before runOnFailure and bundleArtifacts ran. The sandbox container's readiness probe picked that up within a tick, the parent's pod monitor returned a failure on the resulting Unhealthy event, and the deferred maybeTeardown then forcibly removed the k3s docker container — killing the sandbox pod (and the on_failure hooks running inside it) mid-execution. context.WithoutCancel inside runOnFailure protected against in-process cancellation but not against the container being SIGKILLed out from under it.

Drop the early healthFailed update so the probe stays healthy through on_failure and bundling. Failures now surface to the parent via natural container termination (caught by the pod-status branch in monitor) or, in pause modes, via the healthPausedWithError update finalize emits after the hooks have completed. The healthFailed state and its case in the healthcheck switch are no longer reachable, so they're removed too. As a side benefit, getArtifact now sees a complete bundle on failure instead of racing the writer.
