### PR TITLE
Fix docker.Run race from double-starting exec

### DIFF
--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -580,10 +580,6 @@ func (r *Response) Run(ctx context.Context, cmd harness.Command) error {
 	}
 	defer attach.Close()
 
-	if err := r.cli.inner.ContainerExecStart(ctx, resp.ID, container.ExecStartOptions{}); err != nil {
-		return fmt.Errorf("starting exec: %w", err)
-	}
-
 	var stdall bytes.Buffer
 	stdoutw := io.Writer(&stdall)
 	stderrw := io.Writer(&stdall)


### PR DESCRIPTION
Response.Run called both ContainerExecAttach and ContainerExecStart on the same exec ID. Both POST to /exec/{id}/start — Attach is the hijacked variant that already starts the exec, so the second call races the daemon's bookkeeping and intermittently fails with "Exec command <id> is already running", surfacing as exit 125 in TestHarnessDockerResource subtests. Drop the redundant ContainerExecStart; Attach alone is what the rest of the function already assumes (it reads from attach.Reader).
