### PR TITLE
Add docker_on_host driver

### DIFF
--- a/cmd/entrypoint/kodata/entrypoint-wrapper.sh
+++ b/cmd/entrypoint/kodata/entrypoint-wrapper.sh
@@ -17,7 +17,7 @@ error() {
 usage() {
   error "Usage: $0 <test-script-path>"
   error "Environment variables:"
-  error "  IMAGETEST_DRIVER: Type of test environment (docker_in_docker, k3s_in_docker, eks_with_eksctl, ec2)"
+  error "  IMAGETEST_DRIVER: Type of test environment (docker_in_docker, docker_on_host, k3s_in_docker, eks_with_eksctl, ec2)"
   exit 1
 }
 
@@ -173,6 +173,11 @@ aks)
   ;;
 docker_in_docker)
   init_docker_in_docker "$cmd"
+  ;;
+docker_on_host)
+  # Sandbox shares the host docker daemon via a bind-mounted socket; nothing
+  # to bring up before the test runs.
+  exec "$cmd"
   ;;
 k3s_in_docker)
   init_k3s_in_docker "$cmd"

--- a/docs/resources/tests.md
+++ b/docs/resources/tests.md
@@ -42,6 +42,7 @@ Optional:
 
 - `aks` (Attributes) The AKS driver (see [below for nested schema](#nestedatt--drivers--aks))
 - `docker_in_docker` (Attributes) The docker_in_docker driver (see [below for nested schema](#nestedatt--drivers--docker_in_docker))
+- `docker_on_host` (Attributes) The docker_on_host driver. Runs each test in a sandbox container that shares the host's docker daemon (DooD). Sibling containers the test launches with `docker run` are placed on the host daemon directly, so flags like --cgroupns=host or --privileged take effect against the real host — unlike docker_in_docker, where the inner daemon's nested cgroup namespace breaks workloads such as RKE2. (see [below for nested schema](#nestedatt--drivers--docker_on_host))
 - `ec2` (Attributes) The AWS EC2 driver. (see [below for nested schema](#nestedatt--drivers--ec2))
 - `eks_with_eksctl` (Attributes) The eks_with_eksctl driver (see [below for nested schema](#nestedatt--drivers--eks_with_eksctl))
 - `k3s_in_docker` (Attributes) The k3s_in_docker driver (see [below for nested schema](#nestedatt--drivers--k3s_in_docker))
@@ -136,6 +137,40 @@ Optional:
 
 <a id="nestedatt--drivers--docker_in_docker--timeouts"></a>
 ### Nested Schema for `drivers.docker_in_docker.timeouts`
+
+Optional:
+
+- `setup` (String) Maximum time for driver setup (e.g., cluster creation). If unset, setup is bounded only by the resource-level timeout.
+- `teardown` (String) Maximum time for driver teardown (e.g., cluster deletion). If unset, the driver uses a built-in default.
+
+
+
+<a id="nestedatt--drivers--docker_on_host"></a>
+### Nested Schema for `drivers.docker_on_host`
+
+Optional:
+
+- `extra_envs` (Map of String) Additional environment variables to set in the sandbox.
+- `extra_hosts` (List of String) Additional --add-host entries for the sandbox.
+- `extra_mounts` (Attributes List) Additional host bind mounts beyond the default (/var/run/docker.sock). (see [below for nested schema](#nestedatt--drivers--docker_on_host--extra_mounts))
+- `image` (String) The sandbox image reference. Defaults to cgr.dev/chainguard/docker-dind:latest (the bundled dockerd is unused; the test image's entrypoint overrides it).
+- `timeouts` (Attributes) Timeout configuration for driver lifecycle phases. (see [below for nested schema](#nestedatt--drivers--docker_on_host--timeouts))
+
+<a id="nestedatt--drivers--docker_on_host--extra_mounts"></a>
+### Nested Schema for `drivers.docker_on_host.extra_mounts`
+
+Required:
+
+- `source` (String) Host path to bind mount.
+- `target` (String) Path inside the sandbox container.
+
+Optional:
+
+- `read_only` (Boolean) Mount read-only (default: false).
+
+
+<a id="nestedatt--drivers--docker_on_host--timeouts"></a>
+### Nested Schema for `drivers.docker_on_host.timeouts`
 
 Optional:
 

--- a/internal/docker/content.go
+++ b/internal/docker/content.go
@@ -17,6 +17,7 @@ type Content struct {
 
 	reader io.Reader
 	size   int64
+	mode   int64
 
 	pw *io.PipeWriter
 	pr *io.PipeReader
@@ -42,6 +43,16 @@ func NewContentFromFile(f *os.File, target string) (*Content, error) {
 }
 
 func NewContent(r io.Reader, target string, size int64) *Content {
+	return newContent(r, target, size, 0o644)
+}
+
+// NewExecutableContentFromString returns a Content whose target file is
+// written with mode 0755, suitable for shipping shim scripts onto $PATH.
+func NewExecutableContentFromString(s, target string) *Content {
+	return newContent(strings.NewReader(s), target, int64(len(s)), 0o755)
+}
+
+func newContent(r io.Reader, target string, size, mode int64) *Content {
 	pr, pw := io.Pipe()
 
 	// Normalize the target path
@@ -52,6 +63,7 @@ func NewContent(r io.Reader, target string, size int64) *Content {
 		Dir:    path.Dir(cleanTarget),
 		reader: r,
 		size:   size,
+		mode:   mode,
 		pw:     pw,
 		pr:     pr,
 	}
@@ -89,7 +101,7 @@ func (c *Content) stream() {
 
 	hdr := &tar.Header{
 		Name:     c.Target,
-		Mode:     0o644,
+		Mode:     c.mode,
 		Size:     c.size,
 		Typeflag: tar.TypeReg,
 	}

--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -26,10 +27,12 @@ import (
 	sshhelper "github.com/docker/cli/cli/connhelper/ssh"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
+	dockerfilters "github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/api/types/mount"
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/api/types/registry"
+	"github.com/docker/docker/api/types/volume"
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/pkg/stdcopy"
 	"github.com/docker/go-connections/nat"
@@ -516,6 +519,51 @@ func (d *Client) Remove(ctx context.Context, resp *Response) error {
 	return d.inner.ContainerRemove(ctx, resp.ID, container.RemoveOptions{
 		RemoveVolumes: true,
 	})
+}
+
+// RemoveByLabel force-removes every container, network, and volume on the
+// daemon that matches the given label key=value. Used by drivers that share a
+// host daemon with the test (e.g. docker_on_host) to clean up resources the
+// test launched. Containers are removed first so volume/network refs are
+// released before those resources are deleted.
+func (d *Client) RemoveByLabel(ctx context.Context, key, value string) error {
+	f := dockerfilters.NewArgs(dockerfilters.Arg("label", fmt.Sprintf("%s=%s", key, value)))
+	var errs []error
+
+	cs, err := d.inner.ContainerList(ctx, container.ListOptions{All: true, Filters: f})
+	if err != nil {
+		errs = append(errs, fmt.Errorf("listing containers by label %s=%s: %w", key, value, err))
+	}
+	for _, c := range cs {
+		if err := d.inner.ContainerRemove(ctx, c.ID, container.RemoveOptions{
+			Force:         true,
+			RemoveVolumes: true,
+		}); err != nil {
+			errs = append(errs, fmt.Errorf("removing container %s: %w", c.ID, err))
+		}
+	}
+
+	nws, err := d.inner.NetworkList(ctx, network.ListOptions{Filters: f})
+	if err != nil {
+		errs = append(errs, fmt.Errorf("listing networks by label %s=%s: %w", key, value, err))
+	}
+	for _, nw := range nws {
+		if err := d.inner.NetworkRemove(ctx, nw.ID); err != nil {
+			errs = append(errs, fmt.Errorf("removing network %s: %w", nw.ID, err))
+		}
+	}
+
+	vols, err := d.inner.VolumeList(ctx, volume.ListOptions{Filters: f})
+	if err != nil {
+		errs = append(errs, fmt.Errorf("listing volumes by label %s=%s: %w", key, value, err))
+	}
+	for _, v := range vols.Volumes {
+		if err := d.inner.VolumeRemove(ctx, v.Name, true); err != nil {
+			errs = append(errs, fmt.Errorf("removing volume %s: %w", v.Name, err))
+		}
+	}
+
+	return errors.Join(errs...)
 }
 
 // Response is returned from a Start() request.

--- a/internal/drivers/docker_on_host/doc.go
+++ b/internal/drivers/docker_on_host/doc.go
@@ -1,0 +1,48 @@
+// dockeronhost runs each test in a sandbox container that shares the host's
+// docker daemon ("docker out of docker"). The sandbox bind-mounts only
+// /var/run/docker.sock from the host. Any container the test launches with
+// `docker run` is therefore a sibling of the sandbox on the host daemon, with
+// whatever privileges and namespaces the test requests via flags on its own
+// `docker run` (--privileged, --cgroupns=host, etc.). This is what unblocks
+// workloads such as RKE2 that need direct host cgroup access; in
+// docker_in_docker the inner daemon's cgroup namespace is nested and a
+// sibling's --cgroupns=host still ties to the dind namespace, not the host's.
+//
+// The sandbox itself runs unprivileged and in the default cgroup namespace —
+// it only invokes the docker CLI, so it has no need for cgroup mounts or
+// extra capabilities.
+//
+// Filesystem state shared between the sandbox and its siblings: tests should
+// use named volumes (which the shim auto-labels and the driver reaps on
+// teardown) rather than bind mounts of paths created in the sandbox's
+// filesystem. The host daemon resolves bind sources against the host's
+// filesystem, not the sandbox's, so a `mktemp -d` path created inside the
+// sandbox does not exist on the host and a sibling's `-v` for that path
+// would mount an empty directory.
+//
+// The sandbox image is layered the same way as docker_in_docker:
+//
+//	0: cgr.dev/chainguard/docker-dind (sandbox base, supplies the docker CLI;
+//	   the bundled dockerd is dormant since the test image's entrypoint
+//	   overrides the base's)
+//	1: imagetest-built layer with test content, the entrypoint binary, and envs
+//
+// Because the daemon is shared with the host, sibling containers the test
+// creates outlive the sandbox and must be cleaned up explicitly. The driver
+// installs a `docker` shim at /usr/local/bin/docker (ahead of /usr/bin/docker
+// on $PATH for the default sandbox image) that auto-injects
+// `--label "$IMAGETEST_TEST_LABEL"` into create-like subcommands (run, create,
+// network create, volume create). On Teardown the driver force-removes any
+// container matching that label. Tests using a custom sandbox image must
+// either keep /usr/local/bin earlier on $PATH than /usr/bin or pass the label
+// explicitly on every `docker run`.
+//
+// The /tmp bind mount is load-bearing: any path the test creates inside the
+// sandbox (e.g. via `mktemp -d`) must resolve to the same file when a sibling
+// container bind-mounts it via `docker run -v ...`. Without sharing /tmp with
+// the host, sibling bind mounts would point at empty host directories.
+//
+// Tradeoffs versus docker_in_docker: cross-test pollution is real (image
+// cache, ports, leaked siblings on a shared daemon). Tests that bind fixed
+// host ports will collide; prefer randomized ports.
+package dockeronhost

--- a/internal/drivers/docker_on_host/driver.go
+++ b/internal/drivers/docker_on_host/driver.go
@@ -1,0 +1,264 @@
+package dockeronhost
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"runtime"
+	"time"
+
+	"github.com/chainguard-dev/clog"
+	"github.com/chainguard-dev/terraform-provider-imagetest/internal/bundler"
+	"github.com/chainguard-dev/terraform-provider-imagetest/internal/docker"
+	"github.com/chainguard-dev/terraform-provider-imagetest/internal/drivers"
+	"github.com/chainguard-dev/terraform-provider-imagetest/internal/entrypoint"
+	"github.com/chainguard-dev/terraform-provider-imagetest/internal/harness"
+	"github.com/docker/docker/api/types/mount"
+	"github.com/google/go-containerregistry/pkg/name"
+	ggcrv1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/mutate"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/google/uuid"
+	v1 "github.com/moby/docker-image-spec/specs-go/v1"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// LabelKey is the label key applied to every sandbox container and expected
+// to be applied by tests to any sibling container they spawn, so the driver
+// can clean them all up on teardown.
+const LabelKey = "imagetest.test"
+
+// EnvLabelVar is the env var the driver sets in the sandbox so test scripts
+// can pass `--label "$IMAGETEST_TEST_LABEL"` without hardcoding the value.
+const EnvLabelVar = "IMAGETEST_TEST_LABEL"
+
+// ExtraMount is an additional host bind mount beyond the defaults
+// (/var/run/docker.sock, /sys/fs/cgroup, /tmp).
+type ExtraMount struct {
+	Source   string
+	Target   string
+	ReadOnly bool
+}
+
+type driver struct {
+	ImageRef    name.Reference
+	Envs        map[string]string
+	ExtraHosts  []string
+	ExtraMounts []ExtraMount
+
+	name     string
+	stack    *harness.Stack
+	cli      *docker.Client
+	cliCfg   *docker.DockerConfig
+	ropts    []remote.Option
+	timeouts drivers.Timeouts
+}
+
+func NewDriver(n string, opts ...DriverOpts) (drivers.Tester, error) {
+	d := &driver{
+		ImageRef: name.MustParseReference("cgr.dev/chainguard/docker-dind:latest"),
+		name:     n,
+		stack:    harness.NewStack(),
+		ropts: []remote.Option{
+			remote.WithPlatform(ggcrv1.Platform{
+				OS:           "linux",
+				Architecture: runtime.GOARCH,
+			}),
+		},
+		cliCfg: &docker.DockerConfig{},
+	}
+
+	for _, opt := range opts {
+		if err := opt(d); err != nil {
+			return nil, err
+		}
+	}
+
+	return d, nil
+}
+
+// Setup implements drivers.Tester.
+func (d *driver) Setup(ctx context.Context) error {
+	cli, err := docker.New()
+	if err != nil {
+		return err
+	}
+	d.cli = cli
+	return nil
+}
+
+// Teardown implements drivers.Tester.
+func (d *driver) Teardown(ctx context.Context) error {
+	ctx, cancel := d.timeouts.TeardownContext(ctx)
+	defer cancel()
+	return d.stack.Teardown(ctx)
+}
+
+// Run implements drivers.Tester.
+func (d *driver) Run(ctx context.Context, ref name.Reference) (*drivers.RunResult, error) {
+	span := trace.SpanFromContext(ctx)
+
+	tref, err := bundler.Mutate(ctx, d.ImageRef, ref.Context(), bundler.MutateOpts{
+		RemoteOptions: d.ropts,
+		ImageMutators: []func(ggcrv1.Image) (ggcrv1.Image, error){
+			func(base ggcrv1.Image) (ggcrv1.Image, error) {
+				timg, err := remote.Image(ref, d.ropts...)
+				if err != nil {
+					return nil, fmt.Errorf("failed to load test image: %w", err)
+				}
+
+				layers, err := timg.Layers()
+				if err != nil {
+					return nil, fmt.Errorf("failed to get layers: %w", err)
+				}
+
+				mutated, err := mutate.AppendLayers(base, layers...)
+				if err != nil {
+					return nil, fmt.Errorf("failed to append layers: %w", err)
+				}
+
+				mcfgf, err := mutated.ConfigFile()
+				if err != nil {
+					return nil, fmt.Errorf("failed to get config file: %w", err)
+				}
+
+				tcfgf, err := timg.ConfigFile()
+				if err != nil {
+					return nil, fmt.Errorf("failed to get config file: %w", err)
+				}
+
+				mcfgf.Config.Entrypoint = tcfgf.Config.Entrypoint
+				mcfgf.Config.Cmd = tcfgf.Config.Cmd
+				mcfgf.Config.WorkingDir = tcfgf.Config.WorkingDir
+				mcfgf.Config.Env = append(mcfgf.Config.Env, tcfgf.Config.Env...)
+
+				return mutate.ConfigFile(mutated, mcfgf)
+			},
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to build driver image: %w", err)
+	}
+	span.AddEvent("doh.image.built")
+
+	cliCfg, err := d.cliCfg.Content()
+	if err != nil {
+		return nil, err
+	}
+
+	contents := []*docker.Content{
+		cliCfg,
+		docker.NewExecutableContentFromString(dockerShim, shimPath),
+	}
+
+	r, w := io.Pipe()
+	defer w.Close()
+
+	stw := bytes.NewBuffer(nil)
+	mw := io.MultiWriter(w, stw)
+
+	go func() {
+		defer r.Close()
+		scanner := bufio.NewScanner(r)
+		for scanner.Scan() {
+			clog.InfoContext(ctx, scanner.Text())
+		}
+	}()
+
+	// Use the sandbox container name (which already includes a uuid suffix)
+	// as the run-unique label value, so parallel runs of the same test id
+	// don't tear each other's siblings down.
+	cname := fmt.Sprintf("%s-%s", d.name, uuid.New().String()[:8])
+	runLabel := cname
+
+	extraHosts := []string{"host.docker.internal:host-gateway"}
+	extraHosts = append(extraHosts, d.ExtraHosts...)
+
+	envs := []string{
+		fmt.Sprintf("%s=%s=%s", EnvLabelVar, LabelKey, runLabel),
+	}
+	for k, v := range d.Envs {
+		envs = append(envs, fmt.Sprintf("%s=%s", k, v))
+	}
+
+	mounts := []mount.Mount{
+		// Sibling containers: route to the host daemon.
+		{Type: mount.TypeBind, Source: "/var/run/docker.sock", Target: "/var/run/docker.sock"},
+	}
+	for _, m := range d.ExtraMounts {
+		mounts = append(mounts, mount.Mount{
+			Type:     mount.TypeBind,
+			Source:   m.Source,
+			Target:   m.Target,
+			ReadOnly: m.ReadOnly,
+		})
+	}
+
+	// Register sibling cleanup before the sandbox is started, so siblings
+	// created during a partially-failed Run() are also reaped on Teardown.
+	if err := d.stack.Add(func(ctx context.Context) error {
+		return d.cli.RemoveByLabel(ctx, LabelKey, runLabel)
+	}); err != nil {
+		return nil, err
+	}
+
+	clog.InfoContext(ctx, "running docker-on-host test", "image_ref", tref.String(), "container_name", cname, "label", runLabel)
+	span.AddEvent("doh.container.started")
+	cid, err := d.cli.Run(ctx, &docker.Request{
+		Name:       cname,
+		Ref:        tref,
+		User:       "0:0",
+		Mounts:     mounts,
+		AutoRemove: false,
+		HealthCheck: &v1.HealthcheckConfig{
+			Test:        append([]string{"CMD"}, entrypoint.DefaultHealthCheckCommand...),
+			Interval:    1 * time.Second,
+			Timeout:     5 * time.Second,
+			Retries:     1,
+			StartPeriod: 1 * time.Second,
+		},
+		Env:        envs,
+		ExtraHosts: extraHosts,
+		Contents:   contents,
+		Logger:     mw,
+		Labels: map[string]string{
+			LabelKey: runLabel,
+		},
+	})
+
+	result := &drivers.RunResult{}
+	span.AddEvent("doh.container.completed")
+
+	arc, aerr := docker.GetFile(ctx, d.cli, cid, entrypoint.ArtifactsPath)
+	if aerr != nil {
+		clog.WarnContextf(ctx, "failed to retrieve artifact: %v", aerr)
+	} else {
+		a, aerr := drivers.NewRunArtifactResult(ctx, arc)
+		if aerr != nil {
+			clog.WarnContextf(ctx, "failed to create artifact result: %v", aerr)
+		}
+		result.Artifact = a
+	}
+
+	if err != nil {
+		var rerr *docker.RunError
+		if errors.As(err, &rerr) {
+			if rerr.ExitCode == entrypoint.ProcessPausedCode {
+				return result, nil
+			}
+			return result, fmt.Errorf("docker-on-host test failed: %w\n\n%s", err, stw.String())
+		}
+		return result, fmt.Errorf("docker-on-host test failed: %w\n\n%s", err, stw.String())
+	}
+
+	if err := d.stack.Add(func(ctx context.Context) error {
+		return d.cli.Remove(ctx, &docker.Response{ID: cid})
+	}); err != nil {
+		return result, err
+	}
+
+	return result, nil
+}

--- a/internal/drivers/docker_on_host/opts.go
+++ b/internal/drivers/docker_on_host/opts.go
@@ -1,0 +1,105 @@
+package dockeronhost
+
+import (
+	"maps"
+
+	"github.com/chainguard-dev/terraform-provider-imagetest/internal/docker"
+	"github.com/chainguard-dev/terraform-provider-imagetest/internal/drivers"
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+)
+
+type DriverOpts func(*driver) error
+
+func WithImageRef(rawRef string) DriverOpts {
+	return func(d *driver) error {
+		ref, err := name.ParseReference(rawRef)
+		if err != nil {
+			return err
+		}
+		d.ImageRef = ref
+		return nil
+	}
+}
+
+func WithRemoteOptions(opts ...remote.Option) DriverOpts {
+	return func(d *driver) error {
+		if d.ropts == nil {
+			d.ropts = make([]remote.Option, 0)
+		}
+		d.ropts = append(d.ropts, opts...)
+		return nil
+	}
+}
+
+// WithRegistryAuth invokes the docker-credential-helper to exchange static
+// creds that are mounted in the container. This current implementation will
+// fail if the tests take longer than the tokens ttl.
+func WithRegistryAuth(registry string) DriverOpts {
+	return func(d *driver) error {
+		if d.cliCfg == nil {
+			d.cliCfg = &docker.DockerConfig{
+				Auths: make(map[string]docker.DockerAuthConfig),
+			}
+		}
+
+		if d.cliCfg.Auths == nil {
+			d.cliCfg.Auths = make(map[string]docker.DockerAuthConfig)
+		}
+
+		r, err := name.NewRegistry(registry)
+		if err != nil {
+			return err
+		}
+
+		a, err := authn.DefaultKeychain.Resolve(r)
+		if err != nil {
+			return err
+		}
+
+		acfg, err := a.Authorization()
+		if err != nil {
+			return err
+		}
+
+		d.cliCfg.Auths[registry] = docker.DockerAuthConfig{
+			Username: acfg.Username,
+			Password: acfg.Password,
+			Auth:     acfg.Auth,
+		}
+
+		return nil
+	}
+}
+
+func WithExtraHosts(hosts ...string) DriverOpts {
+	return func(d *driver) error {
+		d.ExtraHosts = append(d.ExtraHosts, hosts...)
+		return nil
+	}
+}
+
+func WithExtraEnvs(envs map[string]string) DriverOpts {
+	return func(d *driver) error {
+		if d.Envs == nil {
+			d.Envs = make(map[string]string)
+		}
+		maps.Copy(d.Envs, envs)
+		return nil
+	}
+}
+
+func WithExtraMounts(mounts ...ExtraMount) DriverOpts {
+	return func(d *driver) error {
+		d.ExtraMounts = append(d.ExtraMounts, mounts...)
+		return nil
+	}
+}
+
+func WithTimeouts(t drivers.Timeouts) DriverOpts {
+	return func(d *driver) error {
+		d.timeouts = t
+		return nil
+	}
+}

--- a/internal/drivers/docker_on_host/shim.go
+++ b/internal/drivers/docker_on_host/shim.go
@@ -1,0 +1,48 @@
+package dockeronhost
+
+// shimPath is where the driver installs a docker shim inside the sandbox.
+// /usr/local/bin precedes /usr/bin on PATH in the standard sandbox image, so
+// invocations of `docker` resolve to the shim and the real binary at
+// /usr/bin/docker is reached only via exec.
+const shimPath = "/usr/local/bin/docker"
+
+// dockerShim wraps the real docker CLI and auto-injects
+// `--label "$IMAGETEST_TEST_LABEL"` into create-like subcommands so the driver
+// can reap siblings on Teardown without tests having to remember the flag.
+//
+// Pass-through (no injection) when:
+//   - $IMAGETEST_TEST_LABEL is empty (lets users opt out by unsetting it),
+//   - the subcommand is not run/create/network create/volume create,
+//   - or the first argument starts with `-` (e.g. `docker --version`,
+//     `docker -H tcp://...`); we don't try to parse global flags.
+const dockerShim = `#!/bin/sh
+set -e
+
+REAL=/usr/bin/docker
+
+if [ -z "${IMAGETEST_TEST_LABEL:-}" ] || [ $# -eq 0 ]; then
+  exec "$REAL" "$@"
+fi
+
+case "$1" in
+  -*)
+    exec "$REAL" "$@"
+    ;;
+  run|create)
+    cmd=$1
+    shift
+    exec "$REAL" "$cmd" --label "$IMAGETEST_TEST_LABEL" "$@"
+    ;;
+  network|volume)
+    if [ "${2:-}" = "create" ]; then
+      cmd=$1
+      shift 2
+      exec "$REAL" "$cmd" create --label "$IMAGETEST_TEST_LABEL" "$@"
+    fi
+    exec "$REAL" "$@"
+    ;;
+  *)
+    exec "$REAL" "$@"
+    ;;
+esac
+`

--- a/internal/drivers/docker_on_host/shim_test.go
+++ b/internal/drivers/docker_on_host/shim_test.go
@@ -1,0 +1,132 @@
+package dockeronhost
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestDockerShim runs the shim through /bin/sh against a stubbed "real
+// docker" that just echoes its argv, so we can directly assert the
+// resulting command line for various input shapes.
+func TestDockerShim(t *testing.T) {
+	tmp := t.TempDir()
+
+	stubReal := filepath.Join(tmp, "real-docker")
+	if err := os.WriteFile(stubReal, []byte("#!/bin/sh\necho \"$@\"\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Point the shim's REAL at our stub instead of /usr/bin/docker.
+	shimSrc := strings.Replace(dockerShim, "REAL=/usr/bin/docker", "REAL="+stubReal, 1)
+	if !strings.Contains(shimSrc, "REAL="+stubReal) {
+		t.Fatal("failed to redirect REAL to stub")
+	}
+	shimFile := filepath.Join(tmp, "docker")
+	if err := os.WriteFile(shimFile, []byte(shimSrc), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	cases := []struct {
+		name  string
+		label string
+		args  []string
+		want  string
+	}{
+		{
+			name:  "empty_label_passes_through",
+			label: "",
+			args:  []string{"run", "image"},
+			want:  "run image",
+		},
+		{
+			name:  "no_args_passes_through",
+			label: "imagetest.test=foo",
+			args:  []string{},
+			want:  "",
+		},
+		{
+			name:  "run_injects_label_first",
+			label: "imagetest.test=foo",
+			args:  []string{"run", "image"},
+			want:  "run --label imagetest.test=foo image",
+		},
+		{
+			name:  "run_preserves_subsequent_flags",
+			label: "imagetest.test=foo",
+			args:  []string{"run", "--rm", "-d", "image", "cmd"},
+			want:  "run --label imagetest.test=foo --rm -d image cmd",
+		},
+		{
+			name:  "create_injects_label",
+			label: "imagetest.test=foo",
+			args:  []string{"create", "image"},
+			want:  "create --label imagetest.test=foo image",
+		},
+		{
+			name:  "network_create_injects_label",
+			label: "imagetest.test=foo",
+			args:  []string{"network", "create", "mynet"},
+			want:  "network create --label imagetest.test=foo mynet",
+		},
+		{
+			name:  "volume_create_injects_label",
+			label: "imagetest.test=foo",
+			args:  []string{"volume", "create", "myvol"},
+			want:  "volume create --label imagetest.test=foo myvol",
+		},
+		{
+			name:  "network_ls_passes_through",
+			label: "imagetest.test=foo",
+			args:  []string{"network", "ls"},
+			want:  "network ls",
+		},
+		{
+			name:  "volume_ls_passes_through",
+			label: "imagetest.test=foo",
+			args:  []string{"volume", "ls"},
+			want:  "volume ls",
+		},
+		{
+			name:  "global_flag_passes_through",
+			label: "imagetest.test=foo",
+			args:  []string{"--version"},
+			want:  "--version",
+		},
+		{
+			name:  "host_flag_passes_through",
+			label: "imagetest.test=foo",
+			args:  []string{"-H", "tcp://x:1234", "ps"},
+			want:  "-H tcp://x:1234 ps",
+		},
+		{
+			name:  "logs_passes_through",
+			label: "imagetest.test=foo",
+			args:  []string{"logs", "abc"},
+			want:  "logs abc",
+		},
+		{
+			name:  "exec_passes_through",
+			label: "imagetest.test=foo",
+			args:  []string{"exec", "-it", "abc", "sh"},
+			want:  "exec -it abc sh",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := exec.Command(shimFile, tc.args...)
+			cmd.Env = append(os.Environ(), "IMAGETEST_TEST_LABEL="+tc.label)
+			out, err := cmd.CombinedOutput()
+			if err != nil {
+				t.Fatalf("shim exec failed: %v\noutput: %s", err, out)
+			}
+			got := strings.TrimRight(string(out), "\n")
+			if got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/provider/drivers.go
+++ b/internal/provider/drivers.go
@@ -16,6 +16,7 @@ import (
 	"github.com/chainguard-dev/terraform-provider-imagetest/internal/drivers"
 	aks "github.com/chainguard-dev/terraform-provider-imagetest/internal/drivers/aks"
 	dockerindocker "github.com/chainguard-dev/terraform-provider-imagetest/internal/drivers/docker_in_docker"
+	dockeronhost "github.com/chainguard-dev/terraform-provider-imagetest/internal/drivers/docker_on_host"
 	mc2 "github.com/chainguard-dev/terraform-provider-imagetest/internal/drivers/ec2"
 	ekswitheksctl "github.com/chainguard-dev/terraform-provider-imagetest/internal/drivers/eks_with_eksctl"
 	k3sindocker "github.com/chainguard-dev/terraform-provider-imagetest/internal/drivers/k3s_in_docker"
@@ -31,6 +32,7 @@ const (
 	DriverAKS            DriverResourceModel = "aks"
 	DriverK3sInDocker    DriverResourceModel = "k3s_in_docker"
 	DriverDockerInDocker DriverResourceModel = "docker_in_docker"
+	DriverDockerOnHost   DriverResourceModel = "docker_on_host"
 	DriverEKSWithEksctl  DriverResourceModel = "eks_with_eksctl"
 	DriverEC2            DriverResourceModel = "ec2"
 )
@@ -39,6 +41,7 @@ type TestsDriversResourceModel struct {
 	AKS            *AKSDriverResourceModel            `tfsdk:"aks"`
 	K3sInDocker    *K3sInDockerDriverResourceModel    `tfsdk:"k3s_in_docker"`
 	DockerInDocker *DockerInDockerDriverResourceModel `tfsdk:"docker_in_docker"`
+	DockerOnHost   *DockerOnHostDriverResourceModel   `tfsdk:"docker_on_host"`
 	EKSWithEksctl  *EKSWithEksctlDriverResourceModel  `tfsdk:"eks_with_eksctl"`
 	EC2            *EC2DriverResourceModel            `tfsdk:"ec2"`
 }
@@ -112,6 +115,20 @@ type DockerInDockerDriverResourceModel struct {
 	Image    types.String                 `tfsdk:"image"`
 	Mirrors  []string                     `tfsdk:"mirrors"`
 	Timeouts *DriverTimeoutsResourceModel `tfsdk:"timeouts"`
+}
+
+type DockerOnHostDriverResourceModel struct {
+	Image       types.String                           `tfsdk:"image"`
+	ExtraMounts []*DockerOnHostExtraMountResourceModel `tfsdk:"extra_mounts"`
+	ExtraEnvs   map[string]string                      `tfsdk:"extra_envs"`
+	ExtraHosts  []string                               `tfsdk:"extra_hosts"`
+	Timeouts    *DriverTimeoutsResourceModel           `tfsdk:"timeouts"`
+}
+
+type DockerOnHostExtraMountResourceModel struct {
+	Source   types.String `tfsdk:"source"`
+	Target   types.String `tfsdk:"target"`
+	ReadOnly types.Bool   `tfsdk:"read_only"`
 }
 
 type EKSWithEksctlDriverResourceModel struct {
@@ -474,6 +491,66 @@ kubectl rollout status deployment/coredns -n kube-system --timeout=60s
 		opts = append(opts, dockerindocker.WithTimeouts(timeouts))
 
 		return dockerindocker.NewDriver(id, opts...)
+
+	case DriverDockerOnHost:
+		cfg := driversCfg.DockerOnHost
+		if cfg == nil {
+			cfg = &DockerOnHostDriverResourceModel{}
+		}
+
+		opts := []dockeronhost.DriverOpts{
+			dockeronhost.WithRemoteOptions(t.ropts...),
+			dockeronhost.WithRegistryAuth(repo.RegistryStr()),
+		}
+
+		for _, extraRepo := range t.extraRepos {
+			opts = append(opts, dockeronhost.WithRegistryAuth(extraRepo.RegistryStr()))
+		}
+
+		if cfg.Image.ValueString() != "" {
+			opts = append(opts, dockeronhost.WithImageRef(cfg.Image.ValueString()))
+		}
+
+		if len(cfg.ExtraEnvs) > 0 {
+			opts = append(opts, dockeronhost.WithExtraEnvs(cfg.ExtraEnvs))
+		}
+
+		if len(cfg.ExtraHosts) > 0 {
+			opts = append(opts, dockeronhost.WithExtraHosts(cfg.ExtraHosts...))
+		}
+
+		if len(cfg.ExtraMounts) > 0 {
+			mounts := make([]dockeronhost.ExtraMount, 0, len(cfg.ExtraMounts))
+			for _, m := range cfg.ExtraMounts {
+				mounts = append(mounts, dockeronhost.ExtraMount{
+					Source:   m.Source.ValueString(),
+					Target:   m.Target.ValueString(),
+					ReadOnly: m.ReadOnly.ValueBool(),
+				})
+			}
+			opts = append(opts, dockeronhost.WithExtraMounts(mounts...))
+		}
+
+		if isLocalRegistry(repo.Registry) {
+			u, err := url.Parse("http://" + repo.RegistryStr())
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse registry url: %w", err)
+			}
+
+			opts = append(opts,
+				dockeronhost.WithExtraHosts(
+					fmt.Sprintf("%s:%s", u.Hostname(), "127.0.0.1"),
+				),
+			)
+		}
+
+		timeouts, err := parseTimeoutsModel(cfg.Timeouts)
+		if err != nil {
+			return nil, fmt.Errorf("docker_on_host: %w", err)
+		}
+		opts = append(opts, dockeronhost.WithTimeouts(timeouts))
+
+		return dockeronhost.NewDriver(id, opts...)
 
 	case DriverEKSWithEksctl:
 		cfg := driversCfg.EKSWithEksctl
@@ -844,6 +921,47 @@ func DriverResourceSchema(ctx context.Context) schema.SingleNestedAttribute {
 						Optional:    true,
 					},
 					"mirrors": schema.ListAttribute{
+						ElementType: types.StringType,
+						Optional:    true,
+					},
+					"timeouts": driverTimeoutsSchema(),
+				},
+			},
+			"docker_on_host": schema.SingleNestedAttribute{
+				Description: "The docker_on_host driver. Runs each test in a sandbox container that shares the host's docker daemon (DooD). Sibling containers the test launches with `docker run` are placed on the host daemon directly, so flags like --cgroupns=host or --privileged take effect against the real host — unlike docker_in_docker, where the inner daemon's nested cgroup namespace breaks workloads such as RKE2.",
+				Optional:    true,
+				Attributes: map[string]schema.Attribute{
+					"image": schema.StringAttribute{
+						Description: "The sandbox image reference. Defaults to cgr.dev/chainguard/docker-dind:latest (the bundled dockerd is unused; the test image's entrypoint overrides it).",
+						Optional:    true,
+					},
+					"extra_mounts": schema.ListNestedAttribute{
+						Description: "Additional host bind mounts beyond the default (/var/run/docker.sock).",
+						Optional:    true,
+						NestedObject: schema.NestedAttributeObject{
+							Attributes: map[string]schema.Attribute{
+								"source": schema.StringAttribute{
+									Description: "Host path to bind mount.",
+									Required:    true,
+								},
+								"target": schema.StringAttribute{
+									Description: "Path inside the sandbox container.",
+									Required:    true,
+								},
+								"read_only": schema.BoolAttribute{
+									Description: "Mount read-only (default: false).",
+									Optional:    true,
+								},
+							},
+						},
+					},
+					"extra_envs": schema.MapAttribute{
+						Description: "Additional environment variables to set in the sandbox.",
+						ElementType: types.StringType,
+						Optional:    true,
+					},
+					"extra_hosts": schema.ListAttribute{
+						Description: "Additional --add-host entries for the sandbox.",
 						ElementType: types.StringType,
 						Optional:    true,
 					},

--- a/internal/provider/testdata/TestAccTestsResource/docker-on-host-basic.sh
+++ b/internal/provider/testdata/TestAccTestsResource/docker-on-host-basic.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+set -eux
+
+echo "Hello from docker-on-host"
+
+# The shim at /usr/local/bin/docker auto-injects --label "$IMAGETEST_TEST_LABEL".
+docker run --rm hello-world

--- a/internal/provider/testdata/TestAccTestsResource/docker-on-host-host-cgroups.sh
+++ b/internal/provider/testdata/TestAccTestsResource/docker-on-host-host-cgroups.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -eux
+
+# The driver runs the sandbox with --cgroupns=host and bind-mounts
+# /sys/fs/cgroup. Spawning a sibling with --cgroupns=host should let it read
+# the host's root cgroup.procs file. This is the operation that fails inside
+# dind ("operation not supported") because dind nests its own cgroup namespace,
+# and is the entire reason the docker_on_host driver exists.
+docker run --rm --cgroupns=host \
+  cgr.dev/chainguard/busybox:latest \
+  sh -c 'cat /sys/fs/cgroup/cgroup.procs > /dev/null'
+
+echo "host-cgroup-read-ok"

--- a/internal/provider/tests_resource_test.go
+++ b/internal/provider/tests_resource_test.go
@@ -281,6 +281,97 @@ resource "imagetest_tests" "foo" {
 					`, "on-failure.sh"),
 			},
 		},
+		"dockeronhost-basic": {
+			{
+				Config: fmt.Sprintf(`
+resource "imagetest_tests" "foo" {
+  name   = "%[1]s"
+  driver = "docker_on_host"
+
+  drivers = {
+    docker_on_host = {}
+  }
+
+  images = {
+    foo = "cgr.dev/chainguard/busybox:latest@sha256:c546e746013d75c1fc9bf01b7a645ce7caa1ec46c45cb618c6e28d7b57bccc85"
+  }
+
+  tests = [
+    {
+      name    = "sample"
+      image   = "cgr.dev/chainguard/busybox:latest"
+      content = [{ source = "${path.module}/testdata/TestAccTestsResource" }]
+      cmd     = "./%[1]s"
+    }
+  ]
+
+  timeout = "5m"
+}
+					`, "docker-on-host-basic.sh"),
+			},
+		},
+		"dockeronhost-on-failure": {
+			{
+				// Verifies both that on_failure hooks fire and that
+				// IMAGETEST_TEST_LABEL is exported into the hook's env.
+				ExpectError: regexp.MustCompile(`on-failure-sentinel-doh-zzz999\s+label=imagetest\.test=`),
+				Config: fmt.Sprintf(`
+resource "imagetest_tests" "foo" {
+  name   = "%[1]s"
+  driver = "docker_on_host"
+
+  drivers = {
+    docker_on_host = {}
+  }
+
+  images = {
+    foo = "cgr.dev/chainguard/busybox:latest@sha256:c546e746013d75c1fc9bf01b7a645ce7caa1ec46c45cb618c6e28d7b57bccc85"
+  }
+
+  tests = [
+    {
+      name       = "sample"
+      image      = "cgr.dev/chainguard/busybox:latest"
+      content    = [{ source = "${path.module}/testdata/TestAccTestsResource" }]
+      cmd        = "./%[1]s"
+      on_failure = ["echo on-failure-sentinel-doh-zzz999 label=$IMAGETEST_TEST_LABEL"]
+    }
+  ]
+
+  timeout = "5m"
+}
+					`, "on-failure.sh"),
+			},
+		},
+		"dockeronhost-host-cgroups": {
+			{
+				Config: fmt.Sprintf(`
+resource "imagetest_tests" "foo" {
+  name   = "%[1]s"
+  driver = "docker_on_host"
+
+  drivers = {
+    docker_on_host = {}
+  }
+
+  images = {
+    foo = "cgr.dev/chainguard/busybox:latest@sha256:c546e746013d75c1fc9bf01b7a645ce7caa1ec46c45cb618c6e28d7b57bccc85"
+  }
+
+  tests = [
+    {
+      name    = "sample"
+      image   = "cgr.dev/chainguard/busybox:latest"
+      content = [{ source = "${path.module}/testdata/TestAccTestsResource" }]
+      cmd     = "./%[1]s"
+    }
+  ]
+
+  timeout = "5m"
+}
+					`, "docker-on-host-host-cgroups.sh"),
+			},
+		},
 		"dockerindocker-artifacts": {
 			{
 				Config: fmt.Sprintf(`


### PR DESCRIPTION
The dind driver cannot run workloads that need direct host cgroup access because the inner daemon's cgroup namespace is nested and `--cgroupns=host` on a sibling still ties to the dind namespace, not the real host's. Today the only workaround is the deprecated oci_exec_test, which forfeits the modern test UX (IMAGES env, /imagetest/libs, on_failure hooks, artifact bundling).

This adds a docker_on_host driver that runs each test in a sandbox container which shares the host's docker daemon ("docker out of docker"). The only thing the sandbox needs from the host is /var/run/docker.sock — siblings inherit whatever privileges and namespaces the test asks for via flags on its own `docker run` (--privileged, --cgroupns=host, etc.), and the host daemon honours those regardless of the sandbox's own setup. The sandbox itself runs unprivileged in the default cgroup namespace; it only invokes the docker CLI. Filesystem state shared between sandbox and siblings should use named volumes (auto-labelled by the shim below, reaped on teardown) rather than bind mounts of sandbox-internal paths, because the host daemon resolves bind sources against the host's filesystem, not the sandbox's.

Sibling lifecycle is managed by label. The driver injects IMAGETEST_TEST_LABEL=imagetest.test=<sandbox-cname> into the sandbox env, installs a `/usr/local/bin/docker` shim that auto-injects `--label "$IMAGETEST_TEST_LABEL"` for run/create/network create/volume create subcommands, and on Teardown force-removes every container, network, and volume matching that label. The cleanup hook is registered before the sandbox is started so resources created during a partially-failed Run() are still reaped. Custom sandbox images need /usr/local/bin earlier on PATH than /usr/bin (the apko default for chainguard images), or tests must pass the label explicitly.

The provider schema gains a `drivers.docker_on_host` block (image, extra_mounts, extra_envs, extra_hosts, timeouts) alongside the existing drivers, the docker package gains a small RemoveByLabel helper plus an executable-mode Content writer used to ship the shim, and the in-sandbox entrypoint-wrapper.sh learns a docker_on_host case. Coverage: a shim unit test (table-driven argv handling for run/create/network create/volume create/passthrough) and three acceptance cases (basic hello-world via the shim, on_failure firing with $IMAGETEST_TEST_LABEL visible to the hook, sibling --cgroupns=host successfully reading host cgroup.procs — the operation that fails inside dind).