### PR TITLE
k3s-in-docker: fail fast when the k3s container exits during readiness wait

### DIFF
--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -526,6 +526,11 @@ type Response struct {
 	cli  *Client
 }
 
+// Inspect returns the current state of the container.
+func (r *Response) Inspect(ctx context.Context) (container.InspectResponse, error) {
+	return r.cli.inner.ContainerInspect(ctx, r.ID)
+}
+
 // PortBinding returns the host port binding for a container port.
 // For SSH connections, it creates a tunnel and returns a cleanup function.
 // For local connections, it returns the local port and cleanup is a no-op.

--- a/internal/drivers/k3s_in_docker/driver.go
+++ b/internal/drivers/k3s_in_docker/driver.go
@@ -290,7 +290,7 @@ configs:
 		}
 	}
 
-	if err := k.waitReady(ctx); err != nil {
+	if err := k.waitReady(ctx, resp); err != nil {
 		logCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
 		defer cancel()
 		logs, logErr := resp.Logs(logCtx)
@@ -375,12 +375,20 @@ func (k *driver) Run(ctx context.Context, ref name.Reference) (*drivers.RunResul
 // "kube-system" to be ready, because that typically takes too long, and isn't
 // actually required to start scheduling pods.
 //
+// If the k3s container exits during the wait (e.g. an internal startup race
+// causing k3s to shut itself down), the poll fails fast instead of waiting for
+// the outer context deadline.
+//
 // On timeout, the returned error wraps the most recent error from the API
 // server poll, since "context deadline exceeded" alone says nothing about why
 // the cluster never became ready.
-func (k *driver) waitReady(ctx context.Context) error {
+func (k *driver) waitReady(ctx context.Context, resp *docker.Response) error {
 	var lastErr error
 	pollErr := wait.PollUntilContextCancel(ctx, 1*time.Second, true, func(ctx context.Context) (bool, error) {
+		if inspect, err := resp.Inspect(ctx); err == nil && inspect.State != nil && !inspect.State.Running {
+			return false, fmt.Errorf("k3s container exited during setup: status=%s exit_code=%d", inspect.State.Status, inspect.State.ExitCode)
+		}
+
 		_, err := k.kcli.CoreV1().ServiceAccounts("default").Get(ctx, "default", metav1.GetOptions{})
 		if err != nil {
 			lastErr = err


### PR DESCRIPTION
When k3s itself dies during startup — e.g. the upstream race in checkForCloudControllerPrivileges where the cloud-controller-manager exits with a 403 on the extension-apiserver-authentication ConfigMap and takes the supervisor down with it — the readiness poll currently keeps hammering the now-dead apiserver port until the outer terraform deadline (30 minutes) fires. Inspect the container state alongside the default-serviceaccount check so we surface the exit immediately, with the existing log-capture wrapper attaching the k3s logs to the error.
