### PR TITLE
ec2: randomize subnet AZ instead of pinning to "a"

### DIFF
--- a/internal/drivers/ec2/subnet.go
+++ b/internal/drivers/ec2/subnet.go
@@ -28,6 +28,8 @@ type subnet struct {
 
 var _ resource = (*subnet)(nil)
 
+var azSuffixes = []string{"a", "b", "c"}
+
 func (s *subnet) create(ctx context.Context) (Teardown, error) {
 	log := clog.FromContext(ctx)
 
@@ -77,10 +79,11 @@ func (s *subnet) create(ctx context.Context) (Teardown, error) {
 func (s *subnet) createWithCIDR(ctx context.Context, cidr string) (Teardown, error) {
 	log := clog.FromContext(ctx)
 
+	az := s.region + azSuffixes[rand.IntN(len(azSuffixes))]
 	result, err := s.client.CreateSubnet(ctx, &ec2.CreateSubnetInput{
 		VpcId:            aws.String(s.vpcID),
 		CidrBlock:        aws.String(cidr),
-		AvailabilityZone: aws.String(s.region + "a"),
+		AvailabilityZone: aws.String(az),
 		TagSpecifications: []types.TagSpecification{{
 			ResourceType: types.ResourceTypeSubnet,
 			Tags:         s.tags,
@@ -91,7 +94,7 @@ func (s *subnet) createWithCIDR(ctx context.Context, cidr string) (Teardown, err
 	}
 
 	s.id = *result.Subnet.SubnetId
-	log.Info("created subnet", "id", s.id, "cidr", cidr)
+	log.Info("created subnet", "id", s.id, "cidr", cidr, "az", az)
 
 	_, err = s.client.ModifySubnetAttribute(ctx, &ec2.ModifySubnetAttributeInput{
 		SubnetId:            aws.String(s.id),


### PR DESCRIPTION
Pick an AZ suffix at random from {a,b,c} per subnet creation rather
than always using <region>a. Parallel provider instances now spread
across AZs independently, and the existing InvalidSubnet.Conflict
retry loop will naturally re-roll the AZ on collision.
