### PR TITLE
o11y: extract w3c trace context so spans have correct parentage

### DIFF
--- a/internal/o11y/tracing.go
+++ b/internal/o11y/tracing.go
@@ -7,9 +7,11 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
+	"go.opentelemetry.io/otel/propagation"
 	sdklog "go.opentelemetry.io/otel/sdk/log"
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"google.golang.org/grpc/metadata"
 )
 
 // Attribute keys used on span attributes and clog context values.
@@ -46,8 +48,8 @@ func Setup(ctx context.Context) error {
 	otel.SetTracerProvider(sdktrace.NewTracerProvider(
 		sdktrace.WithSyncer(traceExp),
 		sdktrace.WithResource(res),
-		sdktrace.WithSampler(sdktrace.AlwaysSample()),
 	))
+	otel.SetTextMapPropagator(propagation.TraceContext{})
 
 	logExp, err := otlploghttp.New(ctx)
 	if err != nil {
@@ -59,4 +61,29 @@ func Setup(ctx context.Context) error {
 	)
 
 	return nil
+}
+
+// ExtractTraceContext extracts W3C trace context from incoming gRPC metadata
+// on ctx, falling back to the TRACEPARENT environment variable.
+func ExtractTraceContext(ctx context.Context) context.Context {
+	if md, ok := metadata.FromIncomingContext(ctx); ok {
+		if tp := md.Get("traceparent"); len(tp) > 0 {
+			// MapCarrier, not HeaderCarrier: gRPC metadata keys are lowercase,
+			// but HeaderCarrier wraps http.Header whose Get() title-cases keys,
+			// silently missing "traceparent" → "Traceparent".
+			carrier := make(propagation.MapCarrier)
+			for k, v := range md {
+				if len(v) > 0 {
+					carrier[k] = v[0]
+				}
+			}
+			return propagation.TraceContext{}.Extract(ctx, carrier)
+		}
+	}
+	if tp := os.Getenv("TRACEPARENT"); tp != "" {
+		return propagation.TraceContext{}.Extract(ctx, propagation.MapCarrier{
+			"traceparent": tp,
+		})
+	}
+	return ctx
 }

--- a/internal/provider/tests_resource.go
+++ b/internal/provider/tests_resource.go
@@ -36,7 +36,6 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
-	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -365,9 +364,7 @@ func (t *TestsResource) do(ctx context.Context, data *TestsResourceModel) (ds di
 	}
 	ctx = clog.WithLogger(ctx, clog.New(logHandler))
 
-	ctx = propagation.TraceContext{}.Extract(ctx, propagation.MapCarrier{
-		"traceparent": os.Getenv("TRACEPARENT"),
-	})
+	ctx = o11y.ExtractTraceContext(ctx)
 
 	ctx = clog.WithValues(ctx,
 		o11y.AttrTestID, id,


### PR DESCRIPTION
previously, all imagetest spans (suite, setup, test, teardown) parented to a single process-level span from the `TRACEPARENT` env var. With this metadata extraction, each `ApplyResourceChange` RPC carries its own span context, so imagetest spans now parent to the specific action that triggered them 