### PR TITLE
feat(ec2): surface setup_commands output on failure

### DIFF
--- a/internal/drivers/ec2/driver.go
+++ b/internal/drivers/ec2/driver.go
@@ -429,12 +429,6 @@ func (d *driver) runSetupCommands(ctx context.Context) error {
 	log.Info("running setup commands", "count", len(d.cfg.SetupCommands))
 	if err := issh.ExecIn(conn, d.cfg.Shell, stdout, stderr, cmds...); err != nil {
 		log.Error("setup commands failed", "stdout", stdout.String(), "stderr", stderr.String())
-		// Include captured stdout/stderr in the returned error so failures
-		// are diagnosable from terraform's stderr alone (i.e. without
-		// `TF_LOG=ERROR` and without SSH-into-the-host). We tail to the
-		// last setupFailureTailLines lines of each stream so the error
-		// message stays bounded for long-running setup_commands while
-		// still surfacing the failing context.
 		return fmt.Errorf(
 			"setup commands failed: %w\n--- stdout (last %d lines) ---\n%s\n--- stderr (last %d lines) ---\n%s",
 			err,

--- a/internal/drivers/ec2/driver.go
+++ b/internal/drivers/ec2/driver.go
@@ -429,11 +429,46 @@ func (d *driver) runSetupCommands(ctx context.Context) error {
 	log.Info("running setup commands", "count", len(d.cfg.SetupCommands))
 	if err := issh.ExecIn(conn, d.cfg.Shell, stdout, stderr, cmds...); err != nil {
 		log.Error("setup commands failed", "stdout", stdout.String(), "stderr", stderr.String())
-		return fmt.Errorf("setup commands failed: %w", err)
+		// Include captured stdout/stderr in the returned error so failures
+		// are diagnosable from terraform's stderr alone (i.e. without
+		// `TF_LOG=ERROR` and without SSH-into-the-host). We tail to the
+		// last setupFailureTailLines lines of each stream so the error
+		// message stays bounded for long-running setup_commands while
+		// still surfacing the failing context.
+		return fmt.Errorf(
+			"setup commands failed: %w\n--- stdout (last %d lines) ---\n%s\n--- stderr (last %d lines) ---\n%s",
+			err,
+			setupFailureTailLines, tailLines(stdout.String(), setupFailureTailLines),
+			setupFailureTailLines, tailLines(stderr.String(), setupFailureTailLines),
+		)
 	}
 
 	log.Info("setup commands complete")
 	return nil
+}
+
+// setupFailureTailLines is the number of trailing lines of stdout/stderr
+// included in the error returned by runSetupCommands. Keeps long-running
+// setup_commands' captured output bounded while still showing the failing
+// context.
+const setupFailureTailLines = 200
+
+// tailLines returns the last n lines of s (newline-separated). If s has
+// at most n lines, it's returned unchanged. The truncation marker reports
+// the original count so consumers know how much was dropped.
+func tailLines(s string, n int) string {
+	if s == "" {
+		return "(empty)"
+	}
+	trimmed := strings.TrimRight(s, "\n")
+	lines := strings.Split(trimmed, "\n")
+	if len(lines) <= n {
+		return trimmed
+	}
+	return fmt.Sprintf("(...truncated to last %d of %d lines...)\n%s",
+		n, len(lines),
+		strings.Join(lines[len(lines)-n:], "\n"),
+	)
 }
 
 // sanitizeAWSTagValue sanitizes a string to be a valid AWS tag value.

--- a/internal/drivers/ec2/driver_test.go
+++ b/internal/drivers/ec2/driver_test.go
@@ -1,9 +1,59 @@
 package ec2
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 )
+
+func TestTailLines(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		n    int
+		want string
+	}{
+		{
+			name: "empty input returns placeholder",
+			in:   "",
+			n:    10,
+			want: "(empty)",
+		},
+		{
+			name: "fewer lines than tail returns full input (trailing newline stripped)",
+			in:   "one\ntwo\nthree\n",
+			n:    10,
+			want: "one\ntwo\nthree",
+		},
+		{
+			name: "exactly n lines returns full input",
+			in:   "one\ntwo\nthree",
+			n:    3,
+			want: "one\ntwo\nthree",
+		},
+		{
+			name: "more lines than n returns last n with truncation marker",
+			in:   "a\nb\nc\nd\ne",
+			n:    2,
+			want: fmt.Sprintf("(...truncated to last %d of %d lines...)\n%s", 2, 5, "d\ne"),
+		},
+		{
+			name: "single line input shorter than n",
+			in:   "only one line",
+			n:    5,
+			want: "only one line",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tailLines(tt.in, tt.n)
+			if got != tt.want {
+				t.Errorf("tailLines() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
 
 func TestSanitizeAWSTagValue(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
## Summary

When a `setup_command` fails over SSH on the EC2 driver, the captured stdout/stderr currently only surfaces via `clog.Error`. That routes through terraform's `tflog`, which is gated on `TF_LOG` and suppressed in most CI environments — so the diagnostic output is effectively invisible unless you're running locally with `TF_LOG=ERROR` set.

This PR includes the **last 200 lines** of each captured stream in the error returned to terraform. terraform prints errors to stderr regardless of `TF_LOG`, so a failed setup_command becomes diagnosable from `terraform apply` output (and hence from GH Actions logs) alone.

## Concrete motivator

In [chainguard-images/images-private PR 228829](https://github.com/chainguard-images/images-private/pull/228829) the `build-the-world` job for `openstack-keystone` fails at `SSH command did not exit cleanly: Process exited with status 2` and there is currently zero visibility into which setup_command actually failed — `grep`ing the GH Actions log for `kolla`/`apt`/anything-from-our-deploy.sh returns zero matches. With this change, the failing line (plus ~200 lines of context around it) would appear in the error block and we could fix the build without needing to SSH into the EC2 host or enable `TF_LOG=ERROR` across the entire workflow.

## Design notes

- Tail size (`setupFailureTailLines = 200`) is a single constant so it's easy to tune.
- The truncation marker reports the original total so consumers know how much was dropped, e.g. `(...truncated to last 200 of 12783 lines...)`.
- The existing `clog.Error` call is preserved — local developers running with `TF_LOG=ERROR` still see the full untruncated output via the structured logger.
- Empty buffers render as `(empty)` so the error message is well-formed even when one stream is silent.

## Test plan

- [x] Unit tests added for `tailLines` covering: empty input, fewer-than-N, exactly-N, more-than-N (truncation), single-line shorter-than-N.
- [x] \`go test ./...\` passes.
- [ ] End-to-end: re-run a failing imagetest_tests.ec2 with this provider build; verify the failing setup_command's surrounding stdout appears in the error block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)