### PR TITLE
feat(ec2): collect artifact bundle from the test container

### DIFF
--- a/internal/drivers/ec2/copyartifact_test.go
+++ b/internal/drivers/ec2/copyartifact_test.go
@@ -1,0 +1,121 @@
+package ec2
+
+import (
+	"archive/tar"
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"io"
+	"net/url"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/chainguard-dev/terraform-provider-imagetest/internal/drivers"
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/client"
+)
+
+// TestCopyArtifact exercises copyArtifact against a real Docker daemon. It is
+// the deterministic counterpart to the EC2 acceptance test's artifact path:
+// runContainer uses the same CopyFromContainer + untar + NewRunArtifactResult
+// flow, just over an SSH-tunneled client. Skips when no daemon is reachable.
+func TestCopyArtifact(t *testing.T) {
+	const image = "cgr.dev/chainguard/wolfi-base:latest"
+
+	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
+	if err != nil {
+		t.Skipf("no docker client: %v", err)
+	}
+	defer cli.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	if _, err := cli.Ping(ctx); err != nil {
+		t.Skipf("docker daemon not reachable: %v", err)
+	}
+
+	// Mirror the entrypoint's bundle: an arbitrary blob at ArtifactsPath. The
+	// content is opaque to copyArtifact — it just round-trips the bytes.
+	want := []byte("imagetest-artifact-bundle\x00\x01\x02 contents")
+	wantSum := sha256.Sum256(want)
+	artifactPath := "/test-artifact.tar.gz"
+
+	resp, err := cli.ContainerCreate(ctx,
+		&container.Config{Image: image, Cmd: []string{"true"}},
+		nil, nil, nil, "")
+	if err != nil {
+		t.Skipf("could not create container from %s (image present?): %v", image, err)
+	}
+	t.Cleanup(func() {
+		_ = cli.ContainerRemove(context.Background(), resp.ID, container.RemoveOptions{Force: true})
+	})
+
+	// Inject the file via the same tar framing the Docker API uses.
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	hdr := &tar.Header{Name: "test-artifact.tar.gz", Mode: 0o644, Size: int64(len(want)), Typeflag: tar.TypeReg}
+	if err := tw.WriteHeader(hdr); err != nil {
+		t.Fatalf("write tar header: %v", err)
+	}
+	if _, err := tw.Write(want); err != nil {
+		t.Fatalf("write tar body: %v", err)
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatalf("close tar: %v", err)
+	}
+	if err := cli.CopyToContainer(ctx, resp.ID, "/", &buf, container.CopyToContainerOptions{}); err != nil {
+		t.Fatalf("copy file into container: %v", err)
+	}
+
+	// 1) copyArtifact must unwrap Docker's tar framing and return the raw bytes.
+	rc, err := copyArtifact(ctx, cli, resp.ID, artifactPath)
+	if err != nil {
+		t.Fatalf("copyArtifact: %v", err)
+	}
+	got, err := io.ReadAll(rc)
+	if err != nil {
+		t.Fatalf("read artifact: %v", err)
+	}
+	if err := rc.Close(); err != nil {
+		t.Fatalf("close artifact reader: %v", err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("artifact bytes mismatch:\n got=%q\nwant=%q", got, want)
+	}
+
+	// 2) The full attach path: NewRunArtifactResult must produce a file:// URI
+	// and a checksum matching the content, as surfaced in Terraform state.
+	rc2, err := copyArtifact(ctx, cli, resp.ID, artifactPath)
+	if err != nil {
+		t.Fatalf("copyArtifact (2): %v", err)
+	}
+	res, err := drivers.NewRunArtifactResult(ctx, rc2)
+	_ = rc2.Close()
+	if err != nil {
+		t.Fatalf("NewRunArtifactResult: %v", err)
+	}
+
+	if res.Checksum != hex.EncodeToString(wantSum[:]) {
+		t.Fatalf("checksum mismatch: got %s want %s", res.Checksum, hex.EncodeToString(wantSum[:]))
+	}
+
+	u, err := url.Parse(res.URI)
+	if err != nil || u.Scheme != "file" {
+		t.Fatalf("expected file:// URI, got %q (err=%v)", res.URI, err)
+	}
+	onDisk, err := os.ReadFile(u.Path)
+	if err != nil {
+		t.Fatalf("read artifact file %s: %v", u.Path, err)
+	}
+	if !bytes.Equal(onDisk, want) {
+		t.Fatalf("on-disk artifact mismatch:\n got=%q\nwant=%q", onDisk, want)
+	}
+
+	// copyArtifact must surface a clear error for a missing path.
+	if _, err := copyArtifact(ctx, cli, resp.ID, "/does-not-exist.tar.gz"); err == nil {
+		t.Fatalf("expected error for missing artifact path, got nil")
+	}
+}

--- a/internal/drivers/ec2/docker.go
+++ b/internal/drivers/ec2/docker.go
@@ -1,6 +1,7 @@
 package ec2
 
 import (
+	"archive/tar"
 	"bytes"
 	"context"
 	"encoding/base64"
@@ -224,7 +225,9 @@ func (d *driver) runContainer(ctx context.Context, cli *client.Client, ref name.
 		}
 	}()
 
-	var result *drivers.RunResult
+	// Always non-nil so the artifact bundle can be attached even when the test
+	// fails — that's exactly when the collected logs matter most.
+	result := &drivers.RunResult{}
 	var runErr error
 
 	select {
@@ -235,7 +238,7 @@ func (d *driver) runContainer(ctx context.Context, cli *client.Client, ref name.
 	case status := <-statusCh:
 		switch status.StatusCode {
 		case 0, int64(entrypoint.ProcessPausedCode):
-			result = &drivers.RunResult{}
+			// success, or paused via IMAGETEST_SKIP_TEARDOWN
 		default:
 			runErr = fmt.Errorf("container exited with code %d", status.StatusCode)
 		}
@@ -243,7 +246,6 @@ func (d *driver) runContainer(ctx context.Context, cli *client.Client, ref name.
 		// Health check detected a terminal state
 		if exitCode == int64(entrypoint.ProcessPausedCode) {
 			log.Info("container paused after success (IMAGETEST_SKIP_TEARDOWN)")
-			result = &drivers.RunResult{}
 		} else {
 			runErr = fmt.Errorf("container health check failed with exit code %d", exitCode)
 		}
@@ -255,12 +257,65 @@ func (d *driver) runContainer(ctx context.Context, cli *client.Client, ref name.
 	cancelRun()
 	<-logDone
 
+	// Best-effort: retrieve the artifact bundle the entrypoint wrote (combined
+	// process logs plus anything the test dropped in $IMAGETEST_ARTIFACTS). The
+	// entrypoint bundles it before exit/pause, so it exists on success, on
+	// failure, and while paused. Use a context detached from ctx with its own
+	// deadline so the bundle is still retrievable when the run deadline expired.
+	artifactCtx, cancelArtifact := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
+	defer cancelArtifact()
+	if arc, aerr := copyArtifact(artifactCtx, cli, resp.ID, entrypoint.ArtifactsPath); aerr != nil {
+		clog.WarnContextf(ctx, "failed to retrieve artifact: %v", aerr)
+	} else {
+		a, aerr := drivers.NewRunArtifactResult(artifactCtx, arc)
+		if cerr := arc.Close(); cerr != nil {
+			clog.WarnContextf(ctx, "failed to close artifact reader: %v", cerr)
+		}
+		if aerr != nil {
+			clog.WarnContextf(ctx, "failed to create artifact result: %v", aerr)
+		} else {
+			result.Artifact = a
+		}
+	}
+
 	if runErr != nil && logBuf.Len() > 0 {
 		runErr = fmt.Errorf("%w\n\nContainer %s logs:\n%s", runErr, containerName, logBuf.String())
 	}
 
 	return result, runErr
 }
+
+// copyArtifact retrieves a single regular file from a container, unwrapping the
+// tar stream the Docker API wraps file copies in. It mirrors
+// internal/docker.GetFile, which operates on the wrapper client rather than the
+// raw SDK client used here for the SSH transport.
+func copyArtifact(ctx context.Context, cli *client.Client, cid, path string) (io.ReadCloser, error) {
+	rc, _, err := cli.CopyFromContainer(ctx, cid, path)
+	if err != nil {
+		return nil, err
+	}
+
+	tr := tar.NewReader(rc)
+	if _, err := tr.Next(); err != nil {
+		_ = rc.Close()
+		if err == io.EOF {
+			return nil, fmt.Errorf("no file found in archive for %s", path)
+		}
+		return nil, err
+	}
+
+	return &artifactReader{tr: tr, rc: rc}, nil
+}
+
+// artifactReader exposes the current tar entry as a ReadCloser whose Close
+// closes the underlying CopyFromContainer stream.
+type artifactReader struct {
+	tr *tar.Reader
+	rc io.ReadCloser
+}
+
+func (a *artifactReader) Read(p []byte) (int, error) { return a.tr.Read(p) }
+func (a *artifactReader) Close() error               { return a.rc.Close() }
 
 func (d *driver) mounts(ctx context.Context) []mount.Mount {
 	if len(d.cfg.VolumeMounts) == 0 {

--- a/internal/provider/tests_resource_ec2_test.go
+++ b/internal/provider/tests_resource_ec2_test.go
@@ -30,6 +30,10 @@ var (
 var ec2Tests = map[string][]resource.TestStep{
 	"basic": {{
 		Config: configDriverEC2Basic,
+		Check: resource.ComposeAggregateTestCheckFunc(
+			resource.TestCheckResourceAttrSet("imagetest_tests.basic", "tests.0.artifact.uri"),
+			resource.TestCheckResourceAttrSet("imagetest_tests.basic", "tests.0.artifact.checksum"),
+		),
 	}},
 	"driver-commands-fail": {{
 		Config:      configDriverEC2DriverCommandsFail,


### PR DESCRIPTION
## Summary

The EC2 driver ran tests but never retrieved the entrypoint's artifact bundle (combined `process.log` plus anything the test wrote to `$IMAGETEST_ARTIFACTS`), unlike the `docker_in_docker` and pod-based drivers. As a result, `tests[].artifact.{uri,checksum}` were always **null** for the EC2 driver, and the failure-diagnostic "Test artifact bundle: …" hint never appeared.

This brings the EC2 driver to parity with the other drivers.

## What changed

- **`internal/drivers/ec2/docker.go`** — `runContainer` now copies `entrypoint.ArtifactsPath` out of the test container (best-effort) and attaches it via `drivers.NewRunArtifactResult`, mirroring `docker_in_docker`.
  - `result` is created up front and the copy runs on **every** terminal/paused path, so artifacts are captured **even on test failure** — when the logs matter most.
  - The copy uses a context **detached from the run deadline** (with its own short timeout), so the bundle is still retrievable if the run deadline already expired (the established pattern, cf. `drivers.Timeouts.TeardownContext`).
  - New helper `copyArtifact` unwraps Docker's tar framing against the **raw** SDK client used for the SSH transport. It mirrors `internal/docker.GetFile`, which only operates on the wrapper client type — hence a small dedicated helper rather than reuse.

## Scope

Deliberately minimal and EC2-only — no changes to the shared `GetFile` helper or the pod driver. (The pod driver's `export`/`resume` path is load-bearing for pod termination and is already best-effort; touching it was out of scope.)

## Testing

- **Unit/integration:** new `copyArtifact` test (`internal/drivers/ec2/copyartifact_test.go`) exercises the real `CopyFromContainer` + tar-unwrap + `NewRunArtifactResult` flow against a local Docker daemon; self-skips when Docker/the test image is unavailable.
- **End-to-end:** the `driver-ec2-basic` acceptance test now asserts `tests.0.artifact.{uri,checksum}` are set. Verified against a real EC2 instance — the driver logged `finished copying artifact checksum=… uri=file://…` and the step passed.
- `go build ./...` and `go vet -tags=ec2 ./...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)