### PR TITLE
fix(drivers): bound teardown with a finite, detached deadline (CON-1269)

### DIFF
--- a/internal/drivers/drivers.go
+++ b/internal/drivers/drivers.go
@@ -24,15 +24,20 @@ type Tester interface {
 	Run(context.Context, name.Reference) (*RunResult, error)
 }
 
-// Timeouts holds parsed driver lifecycle timeouts. Zero means no
-// driver-level deadline for that phase.
+// DefaultTeardownTimeout is the backstop deadline for teardown when no explicit
+// teardown timeout is configured.
+const DefaultTeardownTimeout = 15 * time.Minute
+
+// Timeouts holds parsed driver lifecycle timeouts. Zero setup means no
+// driver-level setup deadline; zero teardown means DefaultTeardownTimeout.
 type Timeouts struct {
 	Setup    time.Duration
 	Teardown time.Duration
 }
 
-// ParseTimeouts parses setup and teardown duration strings into a
-// Timeouts value. Empty strings are treated as zero (no deadline).
+// ParseTimeouts parses setup and teardown duration strings into a Timeouts
+// value. Empty strings are treated as zero (setup: no deadline; teardown:
+// default backstop).
 func ParseTimeouts(setup, teardown string) (Timeouts, error) {
 	var t Timeouts
 	if setup != "" {
@@ -61,16 +66,16 @@ func (t Timeouts) SetupContext(ctx context.Context) (context.Context, context.Ca
 	return ctx, func() {}
 }
 
-// TeardownContext returns a context for teardown. If Teardown is set,
-// it creates a fresh context from context.Background() with that
-// deadline — detached from the caller's potentially expired context.
-// If Teardown is zero, it detaches from the parent's cancellation
-// without adding a new deadline.
+// TeardownContext returns a context for teardown: detached from the parent's
+// cancellation and possibly-expired deadline (so cleanup can still run) but
+// always finite, so a stuck teardown can't hang forever. Uses the configured
+// Teardown timeout, else DefaultTeardownTimeout. Parent values are preserved.
 func (t Timeouts) TeardownContext(ctx context.Context) (context.Context, context.CancelFunc) {
-	if t.Teardown > 0 {
-		return context.WithTimeout(context.Background(), t.Teardown)
+	d := t.Teardown
+	if d <= 0 {
+		d = DefaultTeardownTimeout
 	}
-	return context.WithoutCancel(ctx), func() {}
+	return context.WithTimeout(context.WithoutCancel(ctx), d)
 }
 
 type RunResult struct {

--- a/internal/drivers/timeouts_test.go
+++ b/internal/drivers/timeouts_test.go
@@ -1,0 +1,69 @@
+package drivers
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestTeardownContextAlwaysBounded(t *testing.T) {
+	ctx, cancel := Timeouts{}.TeardownContext(t.Context())
+	defer cancel()
+
+	dl, ok := ctx.Deadline()
+	if !ok {
+		t.Fatal("teardown context has no deadline; a stuck teardown could hang forever")
+	}
+	if got := time.Until(dl); got > DefaultTeardownTimeout+time.Minute {
+		t.Errorf("deadline %s exceeds default backstop %s", got, DefaultTeardownTimeout)
+	}
+}
+
+func TestTeardownContextHonorsConfigured(t *testing.T) {
+	ctx, cancel := Timeouts{Teardown: 3 * time.Minute}.TeardownContext(t.Context())
+	defer cancel()
+
+	dl, ok := ctx.Deadline()
+	if !ok {
+		t.Fatal("expected a deadline")
+	}
+	if got := time.Until(dl); got > 3*time.Minute+time.Second || got < 2*time.Minute {
+		t.Errorf("deadline %s, want ~3m", got)
+	}
+}
+
+func TestTeardownContextDetachesFromParentCancellation(t *testing.T) {
+	type ctxKey string
+	const k ctxKey = "marker"
+	parent, parentCancel := context.WithCancel(context.WithValue(t.Context(), k, "v"))
+	parentCancel() // parent already cancelled, as it would be after a test timeout
+
+	ctx, cancel := Timeouts{}.TeardownContext(parent)
+	defer cancel()
+
+	if err := ctx.Err(); err != nil {
+		t.Errorf("teardown context inherited parent cancellation: %v", err)
+	}
+	if ctx.Value(k) != "v" {
+		t.Error("teardown context dropped parent values (logger/span would be lost)")
+	}
+}
+
+func TestTeardownContextDetachesFromExpiredDeadline(t *testing.T) {
+	// A parent whose deadline already passed (the common case: the test phase
+	// timed out) must not poison teardown — it gets a fresh finite deadline.
+	parent, parentCancel := context.WithTimeout(t.Context(), time.Nanosecond)
+	defer parentCancel()
+	time.Sleep(time.Millisecond) // ensure the parent deadline has elapsed
+
+	ctx, cancel := Timeouts{}.TeardownContext(parent)
+	defer cancel()
+
+	if err := ctx.Err(); err != nil {
+		t.Errorf("teardown context inherited the expired parent deadline: %v", err)
+	}
+	dl, ok := ctx.Deadline()
+	if !ok || time.Until(dl) <= 0 {
+		t.Errorf("teardown context has no future deadline (ok=%v)", ok)
+	}
+}


### PR DESCRIPTION
## Why

`Timeouts.TeardownContext` returned an **unbounded** context when no explicit teardown timeout was configured, so a stuck teardown (e.g. a cloud delete that never returns) could hang the provider — and the terraform run driving it — until the CI job is killed ([internal-dev#25942](https://github.com/chainguard-dev/internal-dev/issues/25942), CON-1269).

## What (minimal)

`TeardownContext` now always carries a finite deadline (the configured teardown timeout, else `DefaultTeardownTimeout` = 15m), stays detached from the parent's possibly-expired deadline so cleanup can still run, and preserves the parent's context values (logger/span) — which the old `context.Background()` path dropped.

**Scope:** covers the tests-resource drivers (the `imagetest_tests` / CON-1269 path) that route teardown through `Timeouts.TeardownContext` (eks/docker/k3s/ec2).

_(An earlier draft also switched OTel to async batch export; that's a separate concern from the teardown hang and has been dropped to keep this PR tightly scoped. It can be its own PR if we have evidence the synchronous exporter contributes.)_

## Tests

`timeouts_test.go`: teardown context is always bounded, honors a configured timeout, and detaches from both a cancelled parent and an already-expired parent deadline while preserving values. `go build`, `go vet`, `golangci-lint` (0 issues) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)