### PR TITLE
fix(ci): run required Test checks on all PRs (drop README-only paths-ignore)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,12 +6,8 @@ name: Tests
 on:
   pull_request:
     branches: ["main"]
-    paths-ignore:
-      - "README.md"
   push:
     branches: ["main"]
-    paths-ignore:
-      - "README.md"
 
 permissions: {}
 


### PR DESCRIPTION
## What

`.github/workflows/test.yml` triggers on `pull_request` and `push` to `main`
behind a `paths-ignore: ["README.md"]` filter. That workflow's **`Build`** and
**`Terraform Provider Acceptance Tests`** jobs are configured as **required
status checks** on `main`.

Because the filter skips the workflow when a PR changes only `README.md`, those
required checks never report on such a PR — so a docs-only change can never
satisfy branch protection and is left unmergeable.

This PR removes the `paths-ignore` filter so the required checks run on every
pull request and push, keeping the required-check set coherent with the
branch's merge requirements.

## Change

- `.github/workflows/test.yml`: drop `paths-ignore: ["README.md"]` from the
  `pull_request` and `push` triggers. No other workflow logic changes.

## Test plan / CI expectations

- `Build` and `Terraform Provider Acceptance Tests` now run on this PR (and on
  all future PRs, including docs-only ones).
- Note for reviewer: the acceptance-test / build jobs depend on provider
  credentials and may report red on a fork-based PR that can't access them —
  that's expected for the fork run and unrelated to this change.

Refs: PSEC-923