### PR TITLE
Strip newlines from proxied URLs in entrypoint access log

### DIFF
--- a/cmd/entrypoint/main.go
+++ b/cmd/entrypoint/main.go
@@ -26,6 +26,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"sync"
 	"syscall"
 	"time"
@@ -675,6 +676,13 @@ func (h *healthStatus) markProbed() {
 	})
 }
 
+// sanitizeLogValue strips newline characters from user-controlled values
+// before they are logged, so a crafted value cannot forge log entries.
+func sanitizeLogValue(s string) string {
+	s = strings.ReplaceAll(s, "\n", "")
+	return strings.ReplaceAll(s, "\r", "")
+}
+
 type proxyServer struct {
 	port    int
 	logPath string
@@ -698,14 +706,14 @@ func (p *proxyServer) Start() error {
 			r.SetURL(target)
 			logger.Info("request",
 				"method", r.Out.Method,
-				"url", r.Out.URL.String(),
+				"url", sanitizeLogValue(r.Out.URL.String()),
 				"host", r.Out.Host,
 				"remote", r.In.RemoteAddr)
 		},
 		ModifyResponse: func(resp *http.Response) error {
 			logger.Info("response",
 				"method", resp.Request.Method,
-				"url", resp.Request.URL.String(),
+				"url", sanitizeLogValue(resp.Request.URL.String()),
 				"status", resp.StatusCode,
 				"size", resp.ContentLength)
 			return nil


### PR DESCRIPTION
CodeQL flags the request URL as user-controlled input flowing into the proxy log (go/log-injection). The JSON slog handler already escapes newlines, but stripping CR/LF explicitly neutralizes log forgery in a way the scanner recognizes and resolves the two open code scanning alerts, while leaving log output unchanged for legitimate URLs.
