### PR TITLE
Fix healthcheck race when the entrypoint is exiting cleanly

### DIFF
--- a/cmd/entrypoint/main.go
+++ b/cmd/entrypoint/main.go
@@ -188,12 +188,16 @@ func (o *opts) Run(ctx context.Context) int {
 		}
 	}
 
-	healthCleanup, err := o.healthStatus.startSocket()
-	if err != nil {
+	// The health socket must stay up until the process exits. Tearing it down
+	// any earlier opens a window where the container still reports Running but
+	// a probe can no longer dial the socket, flipping the container to
+	// unhealthy. Process exit closes the listener, and the socket file lives
+	// in the container's own filesystem, so no explicit cleanup is needed
+	// (startSocket removes any stale file on the next start).
+	if err := o.healthStatus.startSocket(); err != nil {
 		clog.ErrorContextf(ctx, "failed to start health socket: %v", err)
 		return entrypoint.InternalErrorCode
 	}
-	defer healthCleanup()
 
 	code, err := o.executeProcess(ctx)
 	if err != nil {
@@ -576,11 +580,10 @@ func wait(ctx context.Context) error {
 	clog.InfoContext(ctx, "starting wait...")
 
 	health := newHealthStatus()
-	teardown, err := health.startSocket()
-	if err != nil {
+	// Keep the socket alive until process exit, see Run for why.
+	if err := health.startSocket(); err != nil {
 		return fmt.Errorf("failed to start health socket: %w", err)
 	}
-	defer teardown()
 
 	health.update(healthPaused, "paused in wait mode", 0)
 
@@ -633,14 +636,18 @@ func (h *healthStatus) update(state healthState, message string, exitCode int64)
 	h.Time = time.Now()
 }
 
-func (h *healthStatus) startSocket() (func(), error) {
+// startSocket starts the health socket listener. The listener intentionally
+// has no teardown: it must serve probes until the very moment the process
+// exits, since removing the socket while the container is still Running
+// causes probes to fail and mark the container unhealthy.
+func (h *healthStatus) startSocket() error {
 	if err := os.Remove(entrypoint.DefaultHealthCheckSocket); err != nil && !errors.Is(err, os.ErrNotExist) {
-		return nil, fmt.Errorf("failed to remove health socket: %w", err)
+		return fmt.Errorf("failed to remove health socket: %w", err)
 	}
 
 	listener, err := net.Listen("unix", entrypoint.DefaultHealthCheckSocket)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create health socket: %w", err)
+		return fmt.Errorf("failed to create health socket: %w", err)
 	}
 
 	go func() {
@@ -649,24 +656,24 @@ func (h *healthStatus) startSocket() (func(), error) {
 			if err != nil {
 				return
 			}
-			defer conn.Close()
 
 			// Take out a lock, since this is on the same goroutine it blocks, but we
 			// only ever expect this to be called by runtimes during health checks
 			h.mu.RLock()
-			if err := json.NewEncoder(conn).Encode(h); err != nil {
-				return
-			}
+			err = json.NewEncoder(conn).Encode(h)
 			h.mu.RUnlock()
+			_ = conn.Close()
+			if err != nil {
+				// A single broken probe connection must not take down the
+				// health server, keep serving.
+				continue
+			}
 
 			h.markProbed()
 		}
 	}()
 
-	return func() {
-		_ = listener.Close()
-		_ = os.Remove(entrypoint.DefaultHealthCheckSocket)
-	}, nil
+	return nil
 }
 
 func (h *healthStatus) markProbed() {

--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -175,7 +175,7 @@ func (d *Client) Run(ctx context.Context, req *Request) (string, error) {
 	unhealthyCh := make(chan error)
 	if req.HealthCheck != nil {
 		go func() {
-			var negativeExitCodeRetries int
+			var exitRaceRetries int
 			for {
 				time.Sleep(time.Second)
 				select {
@@ -207,16 +207,19 @@ func (d *Client) Run(ctx context.Context, req *Request) (string, error) {
 						// There is a race condition where the container can exit and the health
 						// check can report unhealthy because of it. Negative exit codes indicate
 						// the exec infrastructure failed (command never ran), which typically
-						// happens when the container is exiting. Give it a few iterations to
-						// resolve - if the container exited, we'll see !Running above and the
-						// main wait loop will handle the actual exit.
-						if check.ExitCode < 0 {
-							negativeExitCodeRetries++
-							if negativeExitCodeRetries < 5 {
+						// happens when the container is exiting. Similarly, the entrypoint tears
+						// down its health socket just before exiting, so a probe landing in that
+						// window fails to dial the socket while the container still reports
+						// Running. Give both a few iterations to resolve - if the container
+						// exited, we'll see !Running above and the main wait loop will handle
+						// the actual exit.
+						if check.ExitCode < 0 || strings.Contains(check.Output, "failed to connect to health socket") {
+							exitRaceRetries++
+							if exitRaceRetries < 5 {
 								continue
 							}
 						} else {
-							negativeExitCodeRetries = 0
+							exitRaceRetries = 0
 						}
 
 						// Additional safety: skip known exec infrastructure error messages that


### PR DESCRIPTION
The entrypoint tore down its health socket via defer before main logged and called os.Exit, leaving a window where the container still reports Running but a probe can no longer dial the socket. Under the dind driver's 1s/1-retry healthcheck a single probe in that window flips the container to unhealthy (exit 1000 truncated to 232) and the watchdog fails an otherwise passing test. Keep the socket alive until process exit - the kernel closes the listener and the socket file dies with the container, so the teardown served no purpose.

Since the race is not fully closable from inside the container (a probe in flight at the exact moment of exit can still fail, and the provider also runs against older entrypoint images), extend the docker watchdog's existing exit-race guard to also retry probes that failed to connect to the health socket, mirroring the negative-exit-code handling from #702. A genuinely dead socket still fails after 5 iterations.

Also fix two latent bugs in the accept loop it makes permanent: defer conn.Close() inside the for loop leaked one FD per probe, and an encode error returned while holding the status RLock, deadlocking future status updates and killing the health server on a single broken probe connection.
